### PR TITLE
support EmptyQueryResponse message type

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -652,6 +652,8 @@ func (c *Conn) processContextFreeMsg(t byte, r *msgReader) (err error) {
 		return c.rxErrorResponse(r)
 	case noticeResponse:
 		return nil
+	case emptyQueryResponse:
+		return nil
 	case notificationResponse:
 		c.rxNotificationResponse(r)
 		return nil

--- a/messages.go
+++ b/messages.go
@@ -21,6 +21,7 @@ const (
 	parameterDescription = 't'
 	bindComplete         = '2'
 	notificationResponse = 'A'
+	emptyQueryResponse   = 'I'
 	noData               = 'n'
 	closeComplete        = '3'
 	flush                = 'H'


### PR DESCRIPTION
If the user wants to issue `conn.Execute("--;")` or similar noop to ensure a database connection exists, they would get `Received unknown message type: I`.  Which, according to [the docs](http://www.postgresql.org/docs/9.1/static/protocol-message-formats.html) is a special message type that "substitutes for CommandComplete".   We didn't parse this message type, but it seems trivial enough to add.
