### PR TITLE
select; is valid in 9.4 (the beta anyways)

### DIFF
--- a/conn_pool_test.go
+++ b/conn_pool_test.go
@@ -168,9 +168,10 @@ func TestPoolReleaseWithTransactions(t *testing.T) {
 		t.Fatalf("Unable to acquire connection: %v", err)
 	}
 	mustExec(t, conn, "begin")
-	if _, err = conn.Exec("select"); err == nil {
+	if _, err = conn.Exec("selct"); err == nil {
 		t.Fatal("Did not receive expected error")
 	}
+
 	if conn.TxStatus != 'E' {
 		t.Fatalf("Expected TxStatus to be 'E', instead it was '%c'", conn.TxStatus)
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -294,7 +294,7 @@ func TestExecFailure(t *testing.T) {
 	conn := mustConnect(t, *defaultConnConfig)
 	defer closeConn(t, conn)
 
-	if _, err := conn.Exec("select;"); err == nil {
+	if _, err := conn.Exec("selct;"); err == nil {
 		t.Fatal("Expected SQL syntax error")
 	}
 


### PR DESCRIPTION
A couple tests expect select; to cause a error.

9.3:   ERROR:  syntax error at or near ";"
9.4:
postgres= select;
(1 row)
