### PR TITLE
reduce unecessary memory allocation

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -99,7 +99,7 @@ func Connect(config ConnConfig) (c *Conn, err error) {
 	if c.config.Logger != nil {
 		c.logger = c.config.Logger
 	} else {
-		c.logger = &discardLogger{}
+		c.logger = dlogger
 	}
 
 	if c.config.User == "" {
@@ -190,8 +190,10 @@ func Connect(config ConnConfig) (c *Conn, err error) {
 			}
 		case readyForQuery:
 			c.rxReadyForQuery(r)
-			c.logger = &connLogger{logger: c.logger, pid: c.Pid}
-			c.logger.Info("Connection established")
+			if c.logger != dlogger {
+				c.logger = &connLogger{logger: c.logger, pid: c.Pid}
+				c.logger.Info("Connection established")
+			}
 
 			err = c.loadPgTypes()
 			if err != nil {
@@ -640,14 +642,16 @@ func (c *Conn) Exec(sql string, arguments ...interface{}) (commandTag CommandTag
 	startTime := time.Now()
 	c.lastActivityTime = startTime
 
-	defer func() {
-		if err == nil {
-			endTime := time.Now()
-			c.logger.Info("Exec", "sql", sql, "args", logQueryArgs(arguments), "time", endTime.Sub(startTime), "commandTag", commandTag)
-		} else {
-			c.logger.Error("Exec", "sql", sql, "args", logQueryArgs(arguments), "error", err)
-		}
-	}()
+	if c.logger != dlogger {
+		defer func() {
+			if err == nil {
+				endTime := time.Now()
+				c.logger.Info("Exec", "sql", sql, "args", logQueryArgs(arguments), "time", endTime.Sub(startTime), "commandTag", commandTag)
+			} else {
+				c.logger.Error("Exec", "sql", sql, "args", logQueryArgs(arguments), "error", err)
+			}
+		}()
+	}
 
 	if err = c.sendQuery(sql, arguments...); err != nil {
 		return

--- a/logger.go
+++ b/logger.go
@@ -19,6 +19,9 @@ type Logger interface {
 
 type discardLogger struct{}
 
+// default discardLogger instance
+var dlogger = &discardLogger{}
+
 func (l *discardLogger) Debug(msg string, ctx ...interface{}) {}
 func (l *discardLogger) Info(msg string, ctx ...interface{})  {}
 func (l *discardLogger) Warn(msg string, ctx ...interface{})  {}

--- a/query.go
+++ b/query.go
@@ -68,6 +68,10 @@ func (rows *Rows) close() {
 
 	rows.closed = true
 
+	if rows.logger == dlogger {
+		return
+	}
+
 	if rows.err == nil {
 		endTime := time.Now()
 		rows.logger.Info("Query", "sql", rows.sql, "args", logQueryArgs(rows.args), "time", endTime.Sub(rows.startTime), "rowCount", rows.rowCount)


### PR DESCRIPTION
Avoid calls to logQueryArgs when logger is a discardLogger
