### PR TITLE
combine two small reads into one

### DIFF
--- a/msg_reader.go
+++ b/msg_reader.go
@@ -36,11 +36,10 @@ func (r *msgReader) rxMsg() (t byte, err error) {
 		io.CopyN(ioutil.Discard, r.reader, int64(r.msgBytesRemaining))
 	}
 
-	t, err = r.reader.ReadByte()
-	b := r.buf[0:4]
+	b := r.buf[0:5]
 	_, err = io.ReadFull(r.reader, b)
-	r.msgBytesRemaining = int32(binary.BigEndian.Uint32(b)) - 4
-	return t, err
+	r.msgBytesRemaining = int32(binary.BigEndian.Uint32(b[1:])) - 4
+	return b[0], err
 }
 
 func (r *msgReader) readByte() byte {


### PR DESCRIPTION
There's no need to read 1 byte and then immediately read 4 more, rather
than just reading 5 bytes to begin with. Also, with this change rxMsg is
no longer swallowing an error from ReadByte.

On a related note... How much performance profiling and tuning have you done on this package? I recently built [que-go](https://github.com/bgentry/que-go) using pgx, and during my early benchmarks of it, it doesn't actually appear to be faster than the Ruby version ([que](https://github.com/chanks/que)). The profiling I've done so far suggests that the vast majority of the time in Go is spent in `syscall.Syscall`. Here's one of those CPU profiles:

![](http://cl.ly/451i3j120c1x/data)

I certainly can't say that this is the fault of pgx, but I'm curious how much perf work you've done.

Thanks!