### PR TITLE
Fix decoding of ARRAY[]::text[]

### DIFF
--- a/values.go
+++ b/values.go
@@ -1102,15 +1102,16 @@ func encodeTimestamp(w *WriteBuf, value interface{}) error {
 
 func decode1dArrayHeader(vr *ValueReader) (length int32, err error) {
 	numDims := vr.ReadInt32()
-	if numDims == 0 {
-		return 0, nil
-	}
-	if numDims != 1 {
+	if numDims > 1 {
 		return 0, ProtocolError(fmt.Sprintf("Expected array to have 0 or 1 dimension, but it had %v", numDims))
 	}
 
 	vr.ReadInt32() // 0 if no nulls / 1 if there is one or more nulls -- but we don't care
 	vr.ReadInt32() // element oid
+
+	if numDims == 0 {
+		return 0, nil
+	}
 
 	length = vr.ReadInt32()
 


### PR DESCRIPTION
The original version could not decode ARRAY[]::text[]. When an empty array was detected, decode1dArrayHeader was not reading enough values off the socket, and subsequent values were incorrectly read.