### PR TITLE
Unit test demonstrating infinite loop

### DIFF
--- a/values_test.go
+++ b/values_test.go
@@ -223,6 +223,37 @@ func TestArrayDecoding(t *testing.T) {
 	}
 }
 
+type buggyScanner struct {}
+
+func (*buggyScanner) Scan(r *pgx.ValueReader) error {
+	r.ReadInt32()
+	return nil
+}
+
+func TestBuggyScanner(t *testing.T) {
+	t.Parallel()
+
+	conn := mustConnect(t, *defaultConnConfig)
+	defer closeConn(t, conn)
+
+	rows, err := conn.Query("select 'tevvvvvzvzst', array[]::text[] union select 'ko', array[]::text[]")
+	if err != nil {
+		t.Errorf(`error retrieving rows with array: %v`, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var s string
+		var b buggyScanner
+		err = rows.Scan(&s, &b)
+		if err != nil {
+			t.Errorf(`error reading array: %v`, err)
+		}
+	}
+
+	ensureConnValid(t, conn)
+}
+
 func TestEmptyArrayDecoding(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Hi, I have just created a unit test demonstrating an infinite loop during cleanup in a defered function. The CPU will just sit at 100% use. I know this is a special case, but it's would be nice if a buggy Scanner doesn't make cleanup functions like rows.Close run indefinitely. Sadly, I'm not sure how to fix/improve this.

It would be awesome if you could do something about this :-)