### PR TITLE
add Decoder interface (like Scanner)

### DIFF
--- a/query.go
+++ b/query.go
@@ -280,6 +280,11 @@ func (rows *Rows) Scan(dest ...interface{}) (err error) {
 			if err != nil {
 				rows.Fatal(err)
 			}
+		case Decoder:
+			err = d.Decode(vr)
+			if err != nil {
+				rows.Fatal(err)
+			}
 		default:
 			rows.Fatal(fmt.Errorf("Scan cannot decode into %T", d))
 		}

--- a/values.go
+++ b/values.go
@@ -90,6 +90,16 @@ type Scanner interface {
 	Scan(r *ValueReader) error
 }
 
+// Decoder is an interface used to decode values from the PostgreSQL server.
+type Decoder interface {
+	// Decode MUST check r.Type().DataType (to check by OID) or
+	// r.Type().DataTypeName (to check by name) to ensure that it is scanning an
+	// expected column type. It also MUST check r.Type().FormatCode before
+	// decoding. It should not assume that it was called on a data type or format
+	// that it understands.
+	Decode(r *ValueReader) error
+}
+
 // Encoder is an interface used to encode values for transmission to the
 // PostgreSQL server.
 type Encoder interface {


### PR DESCRIPTION
this change allows a type to implement a Decode(r *ValueReader) method
instead of a Scan(r *ValueReader) method, in case that type already has
a Scan(v interface{}) method designed to be used by the built-in sql
package.

perhaps the Scanner interface could be deprecated in future, to avoid
possible confusion with the interface of the same name in the built-in
sql package?