### PR TITLE
Support nil driver.Value

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -301,7 +301,11 @@ func (r *Rows) Next(dest []driver.Value) error {
 func valueToInterface(argsV []driver.Value) []interface{} {
 	args := make([]interface{}, 0, len(argsV))
 	for _, v := range argsV {
-		args = append(args, v.(interface{}))
+		if v != nil {
+			args = append(args, v.(interface{}))
+		} else {
+			args = append(args, nil)
+		}
 	}
 	return args
 }


### PR DESCRIPTION
If the driver.Valuer ever returns nil for a custom type, `valueToInterface` will return a panic: `interface conversion: interface is nil, not interface {}`. This patch adds support for nil values.