### PR TITLE
Support decoding of TimestampOid in stdlib driver

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -73,6 +73,7 @@ func init() {
 	databaseSqlOids[pgx.Float8Oid] = true
 	databaseSqlOids[pgx.DateOid] = true
 	databaseSqlOids[pgx.TimestampTzOid] = true
+	databaseSqlOids[pgx.TimestampOid] = true
 }
 
 type Driver struct {

--- a/values.go
+++ b/values.go
@@ -1089,6 +1089,7 @@ func decodeTimestamp(vr *ValueReader) time.Time {
 
 	if vr.Len() != 8 {
 		vr.Fatal(ProtocolError(fmt.Sprintf("Received an invalid size for an timestamp: %d", vr.Len())))
+		return zeroTime
 	}
 
 	microsecSinceY2K := vr.ReadInt64()


### PR DESCRIPTION
Seems safe as it's pretty much equivalent to TimestampTzOid