### PR TITLE
Add support for encoding to UUID from string types

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -776,7 +776,7 @@ func (c *Conn) sendPreparedQuery(ps *PreparedStatement, arguments ...interface{}
 				err = encodeFloat4(wbuf, arguments[i])
 			case Float8Oid:
 				err = encodeFloat8(wbuf, arguments[i])
-			case TextOid, VarcharOid:
+			case TextOid, VarcharOid, UuidOid:
 				err = encodeText(wbuf, arguments[i])
 			case DateOid:
 				err = encodeDate(wbuf, arguments[i])

--- a/values.go
+++ b/values.go
@@ -39,6 +39,7 @@ const (
 	TimestampArrayOid   = 1115
 	TimestampTzOid      = 1184
 	TimestampTzArrayOid = 1185
+	UuidOid             = 2950
 	JsonbOid            = 3802
 )
 

--- a/values_test.go
+++ b/values_test.go
@@ -199,6 +199,23 @@ func mustParseCIDR(t *testing.T, s string) net.IPNet {
 	return *ipnet
 }
 
+func TestUuidTranscode(t *testing.T) {
+	t.Parallel()
+
+	conn := mustConnect(t, *defaultConnConfig)
+	defer closeConn(t, conn)
+
+	input := "01086ee0-4963-4e35-9116-30c173a8d0bd"
+	var output string
+	err := conn.QueryRow("select $1::uuid", &input).Scan(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if input != output {
+		t.Errorf("uuid: Did not transcode successfully: %s is not %s", input, output)
+	}
+}
+
 func TestInetCidrTranscode(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Decoding works out of the box as the default is to try decode to string.
However encoding requires handling as a string like type.