### PR TITLE
Track Listen/Unlisten and clear subscriptions on conn release

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -109,6 +109,7 @@ func (p *ConnPool) Release(conn *Conn) {
 	if conn.TxStatus != 'I' {
 		conn.Exec("rollback")
 	}
+	conn.Unlisten("")
 
 	p.cond.L.Lock()
 	if conn.IsAlive() {


### PR DESCRIPTION
This avoid releasing connections back into the pool that have active listen subscriptions.