### PR TITLE
Added uint32 and uint64 decoders

### DIFF
--- a/values.go
+++ b/values.go
@@ -687,25 +687,35 @@ func Decode(vr *ValueReader, d interface{}) error {
 	case *int32:
 		*v = decodeInt4(vr)
 	case *uint32:
+		var valInt int32
 		switch vr.Type().DataType {
 		case Int2Oid:
-			*v = uint32(decodeInt2(vr))
+			valInt = int32(decodeInt2(vr))
 		case Int4Oid:
-			*v = uint32(decodeInt4(vr))
+			valInt = decodeInt4(vr)
 		default:
 			return fmt.Errorf("Can't convert OID %v to uint32", vr.Type().DataType)
 		}
+		if valInt < 0 {
+			return fmt.Errorf("%d is less than zero for uint32", valInt)
+		}
+		*v = uint32(valInt)
 	case *uint64:
+		var valInt int64
 		switch vr.Type().DataType {
 		case Int2Oid:
-			*v = uint64(decodeInt2(vr))
+			valInt = int64(decodeInt2(vr))
 		case Int4Oid:
-			*v = uint64(decodeInt4(vr))
+			valInt = int64(decodeInt4(vr))
 		case Int8Oid:
-			*v = uint64(decodeInt8(vr))
+			valInt = decodeInt8(vr)
 		default:
 			return fmt.Errorf("Can't convert OID %v to uint64", vr.Type().DataType)
 		}
+		if valInt < 0 {
+			return fmt.Errorf("%d is less than zero for uint32", valInt)
+		}
+		*v = uint64(valInt)
 	case *Oid:
 		*v = decodeOid(vr)
 	case *string:

--- a/values.go
+++ b/values.go
@@ -686,6 +686,26 @@ func Decode(vr *ValueReader, d interface{}) error {
 		*v = decodeInt2(vr)
 	case *int32:
 		*v = decodeInt4(vr)
+	case *uint32:
+		switch vr.Type().DataType {
+		case Int2Oid:
+			*v = uint32(decodeInt2(vr))
+		case Int4Oid:
+			*v = uint32(decodeInt4(vr))
+		default:
+			return fmt.Errorf("Can't convert OID %v to uint32", vr.Type().DataType)
+		}
+	case *uint64:
+		switch vr.Type().DataType {
+		case Int2Oid:
+			*v = uint64(decodeInt2(vr))
+		case Int4Oid:
+			*v = uint64(decodeInt4(vr))
+		case Int8Oid:
+			*v = uint64(decodeInt8(vr))
+		default:
+			return fmt.Errorf("Can't convert OID %v to uint64", vr.Type().DataType)
+		}
 	case *Oid:
 		*v = decodeOid(vr)
 	case *string:
@@ -1009,6 +1029,7 @@ func encodeUInt64(w *WriteBuf, oid Oid, value uint64) error {
 			return fmt.Errorf("%d is larger than max int32 %d", value, math.MaxInt32)
 		}
 	case Int8Oid:
+
 		if value <= math.MaxInt64 {
 			w.WriteInt32(8)
 			w.WriteInt64(int64(value))

--- a/values.go
+++ b/values.go
@@ -713,7 +713,7 @@ func Decode(vr *ValueReader, d interface{}) error {
 			return fmt.Errorf("Can't convert OID %v to uint64", vr.Type().DataType)
 		}
 		if valInt < 0 {
-			return fmt.Errorf("%d is less than zero for uint32", valInt)
+			return fmt.Errorf("%d is less than zero for uint64", valInt)
 		}
 		*v = uint64(valInt)
 	case *Oid:


### PR DESCRIPTION
There are `uint32` and `uint64` encoders, but no decoder.
While there's no distinct `uint`-like type in the Postgres, this decoder would do the 'best-effort' conversion and work right for the majority of cases (except negative values ofc, but I guess it's safe to assume that the user knows what he's doing if he plays with `uint`).