### PR TITLE
Lazy load the inet constants

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -26,6 +26,9 @@ type ConnPool struct {
 	closed               bool
 	preparedStatements   map[string]*PreparedStatement
 	acquireTimeout       time.Duration
+	pgTypes              map[Oid]PgType
+	pgsql_af_inet        *byte
+	pgsql_af_inet6       *byte
 }
 
 type ConnPoolStat struct {
@@ -244,10 +247,14 @@ func (p *ConnPool) Stat() (s ConnPoolStat) {
 }
 
 func (p *ConnPool) createConnection() (*Conn, error) {
-	c, err := Connect(p.config)
+	c, err := connect(p.config, p.pgTypes, p.pgsql_af_inet, p.pgsql_af_inet6)
 	if err != nil {
 		return nil, err
 	}
+
+	p.pgTypes = c.PgTypes
+	p.pgsql_af_inet = c.pgsql_af_inet
+	p.pgsql_af_inet6 = c.pgsql_af_inet6
 
 	if p.afterConnect != nil {
 		err = p.afterConnect(c)

--- a/values.go
+++ b/values.go
@@ -1576,10 +1576,10 @@ func encodeIPNet(w *WriteBuf, oid Oid, value net.IPNet) error {
 	switch len(value.IP) {
 	case net.IPv4len:
 		size = 8
-		family = w.conn.pgsql_af_inet
+		family = *w.conn.pgsql_af_inet
 	case net.IPv6len:
 		size = 20
-		family = w.conn.pgsql_af_inet6
+		family = *w.conn.pgsql_af_inet6
 	default:
 		return fmt.Errorf("Unexpected IP length: %v", len(value.IP))
 	}


### PR DESCRIPTION
This is a small change to the connection routine to lazy load the inet
constants to optimize the connection time slightly.