### PR TITLE
Preparex

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -585,7 +585,7 @@ func configSSL(sslmode string, cc *ConnConfig) error {
 // for bound parameters. These placeholders are referenced positional as $1, $2, etc.
 //
 // Prepare is idempotent; i.e. it is safe to call Prepare multiple times with the same
-// name and sql arguments. This allows a code path to Prepare and Query/Exec without
+// name and sql arguments. This allows a code path to Prepare and Query/Exec/Preparex without
 // concern for if the statement has already been prepared.
 func (c *Conn) Prepare(name, sql string) (ps *PreparedStatement, err error) {
 	if name != "" {
@@ -671,7 +671,7 @@ func (c *Conn) Prepare(name, sql string) (ps *PreparedStatement, err error) {
 // It defers from Prepare as it allows additional options (such as parameter OIDs) to be passed via struct
 //
 // Preparex is idempotent; i.e. it is safe to call Preparex multiple times with the same
-// name and sql arguments. This allows a code path to Preparex and Query/Exec without
+// name and sql arguments. This allows a code path to Preparex and Query/Exec/Prepare without
 // concern for if the statement has already been prepared.
 func (c *Conn) Preparex(name, sql string, opts PreparexOptions) (ps *PreparedStatement, err error) {
 	if name != "" {

--- a/conn_pool.go
+++ b/conn_pool.go
@@ -329,7 +329,7 @@ func (p *ConnPool) Begin() (*Tx, error) {
 //
 // Prepare is idempotent; i.e. it is safe to call Prepare multiple times with
 // the same name and sql arguments. This allows a code path to Prepare and
-// Query/Exec without concern for if the statement has already been prepared.
+// Query/Exec/Preparex without concern for if the statement has already been prepared.
 func (p *ConnPool) Prepare(name, sql string) (*PreparedStatement, error) {
 	p.cond.L.Lock()
 	defer p.cond.L.Unlock()
@@ -370,7 +370,7 @@ func (p *ConnPool) Prepare(name, sql string) (*PreparedStatement, error) {
 // It defers from Prepare as it allows additional options (such as parameter OIDs) to be passed via struct
 //
 // Preparex is idempotent; i.e. it is safe to call Preparex multiple times with the same
-// name and sql arguments. This allows a code path to Preparex and Query/Exec without
+// name and sql arguments. This allows a code path to Preparex and Query/Exec/Prepare without
 // concern for if the statement has already been prepared.
 func (p *ConnPool) Preparex(name, sql string, opts PreparexOptions) (*PreparedStatement, error) {
 	p.cond.L.Lock()

--- a/tx.go
+++ b/tx.go
@@ -127,6 +127,24 @@ func (tx *Tx) Exec(sql string, arguments ...interface{}) (commandTag CommandTag,
 	return tx.conn.Exec(sql, arguments...)
 }
 
+// Prepare delegates to the underlying *Conn
+func (tx *Tx) Prepare(name, sql string) (*PreparedStatement, error) {
+	if tx.status != TxStatusInProgress {
+		return nil, ErrTxClosed
+	}
+
+	return tx.conn.Prepare(name, sql)
+}
+
+// Prepare delegates to the underlying *Conn
+func (tx *Tx) Preparex(name, sql string, opts PreparexOptions) (*PreparedStatement, error) {
+	if tx.status != TxStatusInProgress {
+		return nil, ErrTxClosed
+	}
+
+	return tx.conn.Preparex(name, sql, opts)
+}
+
 // Query delegates to the underlying *Conn
 func (tx *Tx) Query(sql string, args ...interface{}) (*Rows, error) {
 	if tx.status != TxStatusInProgress {

--- a/tx.go
+++ b/tx.go
@@ -136,7 +136,7 @@ func (tx *Tx) Prepare(name, sql string) (*PreparedStatement, error) {
 	return tx.conn.Prepare(name, sql)
 }
 
-// Prepare delegates to the underlying *Conn
+// Preparex delegates to the underlying *Conn
 func (tx *Tx) Preparex(name, sql string, opts PreparexOptions) (*PreparedStatement, error) {
 	if tx.status != TxStatusInProgress {
 		return nil, ErrTxClosed


### PR DESCRIPTION
In reference to https://github.com/jackc/pgx/issues/144

Adds the `Preparex` function to both `Conn` and `ConnPool`. Adds the `PreparexOptions` struct to support `Preparex`

Sample usage:
```
pgxPool, _ := pgx.NewConnPool(pgx.ConnPoolConfig{
		ConnConfig: pgx.ConnConfig{
			Host:     "my_postgres_host",
			Port:     5432,
			User:     "pg_user",
			Password: "super_secure",
			Database: "tester",
		},
		MaxConnections: 1,
})

prepOpts := pgx.PreparexOptions{
	ParameterOids: []pgx.Oid{
		pgx.TimestampOid,
		pgx.Int8Oid,
		pgx.TimestampOid,
		pgx.Int8Oid,
	},
}

pgxConn, _ := pgxPool.Acquire()

pgxConn.Preparex("tester", `UPDATE my_table AS t 
SET expiration=c.c_3 
FROM(VALUES ($1,$2),($3,$4)) AS c(c_3,c_4) 
WHERE t.id=c.c_4 RETURNING *`, prepOpts)

timeOne, _ := time.Parse(time.RFC3339Nano, "2016-05-10T22:22:20.6666Z")
timeTwo, _ := time.Parse(time.RFC3339Nano, "2016-04-28T10:10:11.4444Z")

pgxConn.Exec("tester", timeOne, 253, timeTwo, 254)
```


Using the standard `Prepare` with the above query will fail with `ERROR: operator does not exist: bigint = text (SQLSTATE 42883)`, as `Query` and `Exec` will.

I would still propose  `Queryx` and `Execx` functions to make accessing the `Preparex` functionality more straightforward. 