### PR TITLE
Add Prepare to Tx

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -127,6 +127,15 @@ func (tx *Tx) Exec(sql string, arguments ...interface{}) (commandTag CommandTag,
 	return tx.conn.Exec(sql, arguments...)
 }
 
+// Prepare delegates to the underlying *Conn
+func (tx *Tx) Prepare(name, sql string) (*PreparedStatement, error) {
+	if tx.status != TxStatusInProgress {
+		return nil, ErrTxClosed
+	}
+
+	return tx.conn.Prepare(name, sql)
+}
+
 // Query delegates to the underlying *Conn
 func (tx *Tx) Query(sql string, args ...interface{}) (*Rows, error) {
 	if tx.status != TxStatusInProgress {


### PR DESCRIPTION
Even though prepared statements are bound to a connections session and are not isolated by transaction, we need this functionality as there is no way to access the transactions underlying connection.


EDIT:

Just realized there IS a way to access the underlying `Conn` in a `Tx`, my fault. Leaving this here as I think it would be a nice convenience function.