### PR TITLE
Copy sql query from prepared statement to rows.

### DIFF
--- a/query.go
+++ b/query.go
@@ -449,7 +449,7 @@ func (c *Conn) Query(sql string, args ...interface{}) (*Rows, error) {
 			return rows, rows.err
 		}
 	}
-
+	rows.sql = ps.SQL
 	rows.fields = ps.FieldDescriptions
 	err := c.sendPreparedQuery(ps, args...)
 	if err != nil {


### PR DESCRIPTION
This enables proper logging of sql query when using stdlib. As `sql` argument is an empty string, `rows.sql` is empty as well. Therefore in `rows.close()` empty string is logged as a sql query. This problem is  fixed by coping sql query from the prepared statement. 