### PR TITLE
Introduced interface for the returning value of QueryRow func(s) that allows to mock DB connection

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -308,7 +308,7 @@ func (p *ConnPool) Query(sql string, args ...interface{}) (*Rows, error) {
 // QueryRow acquires a connection and delegates the call to that connection. The
 // connection is released automatically after Scan is called on the returned
 // *Row.
-func (p *ConnPool) QueryRow(sql string, args ...interface{}) *Row {
+func (p *ConnPool) QueryRow(sql string, args ...interface{}) Scannable {
 	rows, _ := p.Query(sql, args...)
 	return (*Row)(rows)
 }

--- a/conn_pool.go
+++ b/conn_pool.go
@@ -307,8 +307,8 @@ func (p *ConnPool) Query(sql string, args ...interface{}) (*Rows, error) {
 
 // QueryRow acquires a connection and delegates the call to that connection. The
 // connection is released automatically after Scan is called on the returned
-// *Row.
-func (p *ConnPool) QueryRow(sql string, args ...interface{}) Scannable {
+// *Row wich implements Scanable interface.
+func (p *ConnPool) QueryRow(sql string, args ...interface{}) Scanable {
 	rows, _ := p.Query(sql, args...)
 	return (*Row)(rows)
 }

--- a/query.go
+++ b/query.go
@@ -7,9 +7,9 @@ import (
 	"time"
 )
 
-// Scannable interface provides ability to mock DB connection for testing code
+// Scanable interface provides ability to mock DB connection for testing code
 // without establishing real DB connection.
-type Scannable interface {
+type Scanable interface {
 	Scan(...interface{}) error
 }
 
@@ -482,8 +482,8 @@ func (c *Conn) getRows(sql string, args []interface{}) *Rows {
 
 // QueryRow is a convenience wrapper over Query. Any error that occurs while
 // querying is deferred until calling Scan on the returned *Row which implements
-// Scannable interface. That *Row will error with ErrNoRows if no rows are returned.
-func (c *Conn) QueryRow(sql string, args ...interface{}) Scannable {
+// Scanable interface. That *Row will error with ErrNoRows if no rows are returned.
+func (c *Conn) QueryRow(sql string, args ...interface{}) Scanable {
 	rows, _ := c.Query(sql, args...)
 	return (*Row)(rows)
 }

--- a/query.go
+++ b/query.go
@@ -7,6 +7,12 @@ import (
 	"time"
 )
 
+// Scannable interface provides ability to mock DB connection for testing code
+// without establishing real DB connection.
+type Scannable interface {
+	Scan(...interface{}) error
+}
+
 // Row is a convenience wrapper over Rows that is returned by QueryRow.
 type Row Rows
 
@@ -475,9 +481,9 @@ func (c *Conn) getRows(sql string, args []interface{}) *Rows {
 }
 
 // QueryRow is a convenience wrapper over Query. Any error that occurs while
-// querying is deferred until calling Scan on the returned *Row. That *Row will
-// error with ErrNoRows if no rows are returned.
-func (c *Conn) QueryRow(sql string, args ...interface{}) *Row {
+// querying is deferred until calling Scan on the returned *Row which implements
+// Scannable interface. That *Row will error with ErrNoRows if no rows are returned.
+func (c *Conn) QueryRow(sql string, args ...interface{}) Scannable {
 	rows, _ := c.Query(sql, args...)
 	return (*Row)(rows)
 }

--- a/stress_test.go
+++ b/stress_test.go
@@ -18,7 +18,7 @@ type queryer interface {
 	Query(sql string, args ...interface{}) (*pgx.Rows, error)
 }
 type queryRower interface {
-	QueryRow(sql string, args ...interface{}) *pgx.Row
+	QueryRow(sql string, args ...interface{}) pgx.Scanable
 }
 
 func TestStressConnPool(t *testing.T) {

--- a/tx.go
+++ b/tx.go
@@ -153,7 +153,7 @@ func (tx *Tx) Query(sql string, args ...interface{}) (*Rows, error) {
 }
 
 // QueryRow delegates to the underlying *Conn
-func (tx *Tx) QueryRow(sql string, args ...interface{}) *Row {
+func (tx *Tx) QueryRow(sql string, args ...interface{}) Scanable {
 	rows, _ := tx.Query(sql, args...)
 	return (*Row)(rows)
 }


### PR DESCRIPTION
Introduced Scanable interface for using as returning value instead of *Row. It allows testing code without establishing real database connection:

```

type someScanner struct {
    args []interface{}
}

func (ss *someScanner) Scan(dest ...interface{}) error {
    // do something with dest here
    return nil
}

type anotherScanner struct {
    args []interface{}
}

func (as *anotherScanner) Scan(dest ...interface{}) error {
    // do something with dest here
    return nil
}

type defaultScanner struct {
    args []interface{}
}

func (ds *defaultScanner) Scan(dest ...interface{}) error {
    // do something with dest here
    return nil
}

type mockConn struct {}

func (mc *mockConn) QueryRow(query string, args ...interface{}) pgx.Scanable {
    switch query {
    case someQuery:
        return &someScanner{args}
    case anotherQuery:
        return &anotherScanner{args}
    default:
        return &defaultScanner{args}
    }
}

```

Let's imagine some func that depends on db connection and has to be tested:

```
func myfunc(conn pgx.Conn) []byte {
    var res []byte
    conn.QueryRow(
        someQuery,
        someArg1,
        someArg2,
    ).Scan(&res)
    return res
}
```

So, now we can use mock in our tests:

```
func TestSomething(t *testing.T) {
    conn := &mockConn{}
    res := myfunc(conn)
    // check result here
}
```
