### PR TITLE
Switches Oid from int32 to uint32

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -53,6 +53,10 @@ func (s *startupMessage) Bytes() (buf []byte) {
 	return buf
 }
 
+// Oid (Object Identifier Type) is, according to https://www.postgresql.org/docs/current/static/datatype-oid.html,
+// used internally by PostgreSQL as a primary key for various system tables. It is currently implemented
+// as an unsigned four-byte integer. Its definition can be found in src/include/postgres_ext.h
+// in the PostgreSQL sources.
 type Oid uint32
 
 type FieldDescription struct {

--- a/messages.go
+++ b/messages.go
@@ -138,6 +138,12 @@ func (wb *WriteBuf) WriteInt32(n int32) {
 	wb.buf = append(wb.buf, b...)
 }
 
+func (wb *WriteBuf) WriteUint32(n uint32) {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, n)
+	wb.buf = append(wb.buf, b...)
+}
+
 func (wb *WriteBuf) WriteInt64(n int64) {
 	b := make([]byte, 8)
 	binary.BigEndian.PutUint64(b, uint64(n))

--- a/messages.go
+++ b/messages.go
@@ -53,7 +53,7 @@ func (s *startupMessage) Bytes() (buf []byte) {
 	return buf
 }
 
-type Oid int32
+type Oid uint32
 
 type FieldDescription struct {
 	Name            string

--- a/msg_reader.go
+++ b/msg_reader.go
@@ -137,6 +137,34 @@ func (r *msgReader) readInt32() int32 {
 	return n
 }
 
+func (r *msgReader) readUint32() uint32 {
+	if r.err != nil {
+		return 0
+	}
+
+	r.msgBytesRemaining -= 4
+	if r.msgBytesRemaining < 0 {
+		r.fatal(errors.New("read past end of message"))
+		return 0
+	}
+
+	b, err := r.reader.Peek(4)
+	if err != nil {
+		r.fatal(err)
+		return 0
+	}
+
+	n := uint32(binary.BigEndian.Uint32(b))
+
+	r.reader.Discard(4)
+
+	if r.shouldLog(LogLevelTrace) {
+		r.log(LogLevelTrace, "msgReader.readUint32", "value", n, "msgBytesRemaining", r.msgBytesRemaining)
+	}
+
+	return n
+}
+
 func (r *msgReader) readInt64() int64 {
 	if r.err != nil {
 		return 0

--- a/value_reader.go
+++ b/value_reader.go
@@ -74,6 +74,20 @@ func (r *ValueReader) ReadInt32() int32 {
 	return r.mr.readInt32()
 }
 
+func (r *ValueReader) ReadUint32() uint32 {
+	if r.err != nil {
+		return 0
+	}
+
+	r.valueBytesRemaining -= 4
+	if r.valueBytesRemaining < 0 {
+		r.Fatal(errors.New("read past end of value"))
+		return 0
+	}
+
+	return r.mr.readUint32()
+}
+
 func (r *ValueReader) ReadInt64() int64 {
 	if r.err != nil {
 		return 0
@@ -89,7 +103,7 @@ func (r *ValueReader) ReadInt64() int64 {
 }
 
 func (r *ValueReader) ReadOid() Oid {
-	return Oid(r.ReadInt32())
+	return Oid(r.ReadUint32())
 }
 
 // ReadString reads count bytes and returns as string

--- a/values.go
+++ b/values.go
@@ -1299,19 +1299,19 @@ func decodeInt4(vr *ValueReader) int32 {
 func decodeOid(vr *ValueReader) Oid {
 	if vr.Len() == -1 {
 		vr.Fatal(ProtocolError("Cannot decode null into Oid"))
-		return 0
+		return Oid(0)
 	}
 
 	if vr.Type().DataType != OidOid {
 		vr.Fatal(ProtocolError(fmt.Sprintf("Cannot decode oid %v into pgx.Oid", vr.Type().DataType)))
-		return 0
+		return Oid(0)
 	}
 
 	// Oid needs to decode text format because it is used in loadPgTypes
 	switch vr.Type().FormatCode {
 	case TextFormatCode:
 		s := vr.ReadString(vr.Len())
-		n, err := strconv.ParseInt(s, 10, 32)
+		n, err := strconv.ParseUint(s, 10, 32)
 		if err != nil {
 			vr.Fatal(ProtocolError(fmt.Sprintf("Received invalid Oid: %v", s)))
 		}
@@ -1319,7 +1319,7 @@ func decodeOid(vr *ValueReader) Oid {
 	case BinaryFormatCode:
 		if vr.Len() != 4 {
 			vr.Fatal(ProtocolError(fmt.Sprintf("Received an invalid size for an Oid: %d", vr.Len())))
-			return 0
+			return Oid(0)
 		}
 		return Oid(vr.ReadInt32())
 	default:
@@ -1334,7 +1334,7 @@ func encodeOid(w *WriteBuf, oid Oid, value Oid) error {
 	}
 
 	w.WriteInt32(4)
-	w.WriteInt32(int32(value))
+	w.WriteUint32(uint32(value))
 
 	return nil
 }

--- a/values_test.go
+++ b/values_test.go
@@ -551,6 +551,39 @@ func TestInetCidrTranscodeWithJustIP(t *testing.T) {
 	}
 }
 
+func TestOid(t *testing.T) {
+	t.Parallel()
+
+	conn := mustConnect(t, *defaultConnConfig)
+	defer closeConn(t, conn)
+
+	tests := []struct {
+		sql   string
+		value pgx.Oid
+	}{
+		{"select $1::oid", 0},
+		{"select $1::oid", 1},
+		{"select $1::oid", 4294967295},
+	}
+
+	for i, tt := range tests {
+		expected := tt.value
+		var actual pgx.Oid
+
+		err := conn.QueryRow(tt.sql, expected).Scan(&actual)
+		if err != nil {
+			t.Errorf("%d. Unexpected failure: %v (sql -> %v, value -> %v)", i, err, tt.sql, expected)
+			continue
+		}
+
+		if actual != expected {
+			t.Errorf("%d. Expected %v, got %v (sql -> %v)", i, expected, actual, tt.sql)
+		}
+
+		ensureConnValid(t, conn)
+	}
+}
+
 func TestNullX(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
According to https://www.postgresql.org/docs/9.5/static/datatype-oid.html, "The oid type is currently implemented as an unsigned four-byte integer."

In src/include/postgres_ext.h,

```
typedef unsigned int Oid;
```

And in a psql sesson:

```
# create table t (o oid);
CREATE TABLE
# insert into t (o) values (1);
INSERT 0 1
# insert into t (o) values (4294967295);
INSERT 0 1
# insert into t (o) values (4294967296);
ERROR:  22003: OID out of range
```

In the current implementation, when we try this:

```
  var minOid pgx.Oid
  var maxOid pgx.Oid
  err := conn.QueryRow("select 1::oid, 4294967295::oid").Scan(&minOid, &maxOid)
```

maxOid comes out as -1 instead of 4294967295. This patch fixes that.