### PR TITLE
Add Cid/NullCid Type

### DIFF
--- a/values.go
+++ b/values.go
@@ -342,7 +342,7 @@ func (n NullInt32) Encode(w *WriteBuf, oid Oid) error {
 //
 // it is the data type of the xmin and xmax hidden system columns.
 //
-// It is currently implemented as an unsigned for byte integer.
+// It is currently implemented as an unsigned four byte integer.
 // Its definition can be found in src/include/postgres_ext.h as TransactionId
 // in the PostgreSQL sources.
 type Xid uint32
@@ -394,7 +394,7 @@ func (n NullXid) Encode(w *WriteBuf, oid Oid) error {
 //
 // it is the data type of the cmin and cmax hidden system columns.
 //
-// It is currently implemented as an unsigned for byte integer.
+// It is currently implemented as an unsigned four byte integer.
 // Its definition can be found in src/include/c.h as CommandId
 // in the PostgreSQL sources.
 type Cid uint32

--- a/values_test.go
+++ b/values_test.go
@@ -595,6 +595,7 @@ func TestNullX(t *testing.T) {
 		i16 pgx.NullInt16
 		i32 pgx.NullInt32
 		xid pgx.NullXid
+		cid pgx.NullCid
 		i64 pgx.NullInt64
 		f32 pgx.NullFloat32
 		f64 pgx.NullFloat64
@@ -619,6 +620,9 @@ func TestNullX(t *testing.T) {
 		{"select $1::xid", []interface{}{pgx.NullXid{Xid: 1, Valid: true}}, []interface{}{&actual.xid}, allTypes{xid: pgx.NullXid{Xid: 1, Valid: true}}},
 		{"select $1::xid", []interface{}{pgx.NullXid{Xid: 1, Valid: false}}, []interface{}{&actual.xid}, allTypes{xid: pgx.NullXid{Xid: 0, Valid: false}}},
 		{"select $1::xid", []interface{}{pgx.NullXid{Xid: 4294967295, Valid: true}}, []interface{}{&actual.xid}, allTypes{xid: pgx.NullXid{Xid: 4294967295, Valid: true}}},
+		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 1, Valid: true}}},
+		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: false}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 0, Valid: false}}},
+		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 4294967295, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 4294967295, Valid: true}}},
 		{"select $1::int8", []interface{}{pgx.NullInt64{Int64: 1, Valid: true}}, []interface{}{&actual.i64}, allTypes{i64: pgx.NullInt64{Int64: 1, Valid: true}}},
 		{"select $1::int8", []interface{}{pgx.NullInt64{Int64: 1, Valid: false}}, []interface{}{&actual.i64}, allTypes{i64: pgx.NullInt64{Int64: 0, Valid: false}}},
 		{"select $1::float4", []interface{}{pgx.NullFloat32{Float32: 1.23, Valid: true}}, []interface{}{&actual.f32}, allTypes{f32: pgx.NullFloat32{Float32: 1.23, Valid: true}}},


### PR DESCRIPTION
When one does

```SQL
select cmin, cmax, * from some_table;
```

The cmin and cmax system columns are of type cid.

cid is currently implemented as an unsigned four byte integer. Its definition can be found in src/include/c.h as CommandId in the PostgreSQL sources.
