### PR TITLE
Add Tid/NullTid Type

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -136,6 +136,12 @@ func (wb *WriteBuf) WriteInt16(n int16) {
 	wb.buf = append(wb.buf, b...)
 }
 
+func (wb *WriteBuf) WriteUint16(n uint16) {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, n)
+	wb.buf = append(wb.buf, b...)
+}
+
 func (wb *WriteBuf) WriteInt32(n int32) {
 	b := make([]byte, 4)
 	binary.BigEndian.PutUint32(b, uint32(n))

--- a/msg_reader.go
+++ b/msg_reader.go
@@ -137,6 +137,34 @@ func (r *msgReader) readInt32() int32 {
 	return n
 }
 
+func (r *msgReader) readUint16() uint16 {
+	if r.err != nil {
+		return 0
+	}
+
+	r.msgBytesRemaining -= 2
+	if r.msgBytesRemaining < 0 {
+		r.fatal(errors.New("read past end of message"))
+		return 0
+	}
+
+	b, err := r.reader.Peek(2)
+	if err != nil {
+		r.fatal(err)
+		return 0
+	}
+
+	n := uint16(binary.BigEndian.Uint16(b))
+
+	r.reader.Discard(2)
+
+	if r.shouldLog(LogLevelTrace) {
+		r.log(LogLevelTrace, "msgReader.readUint16", "value", n, "msgBytesRemaining", r.msgBytesRemaining)
+	}
+
+	return n
+}
+
 func (r *msgReader) readUint32() uint32 {
 	if r.err != nil {
 		return 0

--- a/value_reader.go
+++ b/value_reader.go
@@ -60,6 +60,20 @@ func (r *ValueReader) ReadInt16() int16 {
 	return r.mr.readInt16()
 }
 
+func (r *ValueReader) ReadUint16() uint16 {
+	if r.err != nil {
+		return 0
+	}
+
+	r.valueBytesRemaining -= 2
+	if r.valueBytesRemaining < 0 {
+		r.Fatal(errors.New("read past end of value"))
+		return 0
+	}
+
+	return r.mr.readUint16()
+}
+
 func (r *ValueReader) ReadInt32() int32 {
 	if r.err != nil {
 		return 0

--- a/values.go
+++ b/values.go
@@ -22,6 +22,7 @@ const (
 	Int4Oid             = 23
 	TextOid             = 25
 	OidOid              = 26
+	TidOid              = 27
 	XidOid              = 28
 	CidOid              = 29
 	JsonOid             = 114
@@ -95,6 +96,7 @@ func init() {
 		"int4":         BinaryFormatCode,
 		"int8":         BinaryFormatCode,
 		"oid":          BinaryFormatCode,
+		"tid":          BinaryFormatCode,
 		"xid":          BinaryFormatCode,
 		"cid":          BinaryFormatCode,
 		"record":       BinaryFormatCode,

--- a/values_test.go
+++ b/values_test.go
@@ -596,6 +596,7 @@ func TestNullX(t *testing.T) {
 		i32 pgx.NullInt32
 		xid pgx.NullXid
 		cid pgx.NullCid
+		tid pgx.NullTid
 		i64 pgx.NullInt64
 		f32 pgx.NullFloat32
 		f64 pgx.NullFloat64
@@ -623,6 +624,9 @@ func TestNullX(t *testing.T) {
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 1, Valid: true}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: false}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 0, Valid: false}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 4294967295, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 4294967295, Valid: true}}},
+		{"select $1::tid", []interface{}{pgx.NullTid{Tid: pgx.Tid{BlockNumber: 1, OffsetNumber: 1}, Valid: true}}, []interface{}{&actual.tid}, allTypes{tid: pgx.NullTid{Tid: pgx.Tid{BlockNumber: 1, OffsetNumber: 1}, Valid: true}}},
+		{"select $1::tid", []interface{}{pgx.NullTid{Tid: pgx.Tid{BlockNumber: 1, OffsetNumber: 1}, Valid: false}}, []interface{}{&actual.tid}, allTypes{tid: pgx.NullTid{Tid: pgx.Tid{BlockNumber: 0, OffsetNumber: 0}, Valid: false}}},
+		{"select $1::tid", []interface{}{pgx.NullTid{Tid: pgx.Tid{BlockNumber: 4294967295, OffsetNumber: 65535}, Valid: true}}, []interface{}{&actual.tid}, allTypes{tid: pgx.NullTid{Tid: pgx.Tid{BlockNumber: 4294967295, OffsetNumber: 65535}, Valid: true}}},
 		{"select $1::int8", []interface{}{pgx.NullInt64{Int64: 1, Valid: true}}, []interface{}{&actual.i64}, allTypes{i64: pgx.NullInt64{Int64: 1, Valid: true}}},
 		{"select $1::int8", []interface{}{pgx.NullInt64{Int64: 1, Valid: false}}, []interface{}{&actual.i64}, allTypes{i64: pgx.NullInt64{Int64: 0, Valid: false}}},
 		{"select $1::float4", []interface{}{pgx.NullFloat32{Float32: 1.23, Valid: true}}, []interface{}{&actual.f32}, allTypes{f32: pgx.NullFloat32{Float32: 1.23, Valid: true}}},


### PR DESCRIPTION
When one does

```SQL
select ctid, * from some_table;
┌───────┬───┐
│ ctid  │ x │
├───────┼───┤
│ (0,1) │ 1 │
└───────┴───┘
(1 row)
```

The ctid system column is of type tid (Tuple Identifier).

tid is currently implemented as a pair of numbers: an unsigned four byte integer and an unsigned two byte integer. Its conversion functions can be found in src/backend/utils/adt/tid.c in the PostgreSQL sources.
