### PR TITLE
Add NullOid Type

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -53,12 +53,6 @@ func (s *startupMessage) Bytes() (buf []byte) {
 	return buf
 }
 
-// Oid (Object Identifier Type) is, according to https://www.postgresql.org/docs/current/static/datatype-oid.html,
-// used internally by PostgreSQL as a primary key for various system tables. It is currently implemented
-// as an unsigned four-byte integer. Its definition can be found in src/include/postgres_ext.h
-// in the PostgreSQL sources.
-type Oid uint32
-
 type FieldDescription struct {
 	Name            string
 	Table           Oid


### PR DESCRIPTION
This PR adds support for null oids, the same way all other types currently have a null version.

The oid type is used a lot in system tables, so it's conceivable an end user could craft a select statement that would have null oids: perhaps from being on the nulls-allowed side of a left join, for instance.

This PR moves the definition of the Oid type from messages.go and into values.go, where the other types are defined.

And because the Oid type now has a NullOid type to go with it, this PR removes the standalone TestOid test in values_test.go. It now tests Oid/NullOid by leveraging the existing TestNullX test already in values_test.go.

Also, three documentation typos my previous PRs introduced into values.go get fixed by this PR.