### PR TITLE
Adds Name/NullName types

### DIFF
--- a/values.go
+++ b/values.go
@@ -287,7 +287,7 @@ func (n Name) LengthOK() bool {
 // If Valid is false then the value is NULL.
 type NullName struct {
 	Name  Name
-	Valid bool // Valid is true if Char is not NULL
+	Valid bool // Valid is true if Name is not NULL
 }
 
 func (n *NullName) Scan(vr *ValueReader) error {

--- a/values_test.go
+++ b/values_test.go
@@ -551,28 +551,6 @@ func TestInetCidrTranscodeWithJustIP(t *testing.T) {
 	}
 }
 
-func TestNameLengthOK(t *testing.T) {
-	tests := []struct {
-		input    pgx.Name
-		expected bool
-	}{
-		{"", true},
-		{"1234", true},
-		{"123456789012345678901234567890123456789012345678901234567890123", true},
-		{"1234567890123456789012345678901234567890123456789012345678901234", false},
-	}
-
-	var actual bool
-
-	for i, tt := range tests {
-		actual = tt.input.LengthOK()
-
-		if actual != tt.expected {
-			t.Errorf("%d. Expected %v, got %v (name -> %v)", i, tt.expected, actual, tt.input)
-		}
-	}
-}
-
 func TestNullX(t *testing.T) {
 	t.Parallel()
 
@@ -621,9 +599,6 @@ func TestNullX(t *testing.T) {
 		{"select $1::\"char\"", []interface{}{pgx.NullChar{Char: 255, Valid: true}}, []interface{}{&actual.c}, allTypes{c: pgx.NullChar{Char: 255, Valid: true}}},
 		{"select $1::name", []interface{}{pgx.NullString{String: "foo", Valid: true}}, []interface{}{&actual.s}, allTypes{s: pgx.NullString{String: "foo", Valid: true}}},
 		{"select $1::name", []interface{}{pgx.NullString{String: "foo", Valid: false}}, []interface{}{&actual.s}, allTypes{s: pgx.NullString{String: "", Valid: false}}},
-		// bytes past NameDataLen-1 (63 bytes) get silently truncated by PostgreSQL
-		{"select $1::name", []interface{}{pgx.NullString{String: "1234567890123456789012345678901234567890123456789012345678901234", Valid: true}},
-			[]interface{}{&actual.s}, allTypes{s: pgx.NullString{String: "123456789012345678901234567890123456789012345678901234567890123", Valid: true}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 1, Valid: true}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: false}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 0, Valid: false}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 4294967295, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 4294967295, Valid: true}}},

--- a/values_test.go
+++ b/values_test.go
@@ -551,6 +551,28 @@ func TestInetCidrTranscodeWithJustIP(t *testing.T) {
 	}
 }
 
+func TestNameLengthOK(t *testing.T) {
+	tests := []struct {
+		input    pgx.Name
+		expected bool
+	}{
+		{"", true},
+		{"1234", true},
+		{"123456789012345678901234567890123456789012345678901234567890123", true},
+		{"1234567890123456789012345678901234567890123456789012345678901234", false},
+	}
+
+	var actual bool
+
+	for i, tt := range tests {
+		actual = tt.input.LengthOK()
+
+		if actual != tt.expected {
+			t.Errorf("%d. Expected %v, got %v (name -> %v)", i, tt.expected, actual, tt.input)
+		}
+	}
+}
+
 func TestNullX(t *testing.T) {
 	t.Parallel()
 
@@ -562,6 +584,7 @@ func TestNullX(t *testing.T) {
 		i16 pgx.NullInt16
 		i32 pgx.NullInt32
 		c   pgx.NullChar
+		n   pgx.NullName
 		oid pgx.NullOid
 		xid pgx.NullXid
 		cid pgx.NullCid
@@ -596,6 +619,11 @@ func TestNullX(t *testing.T) {
 		{"select $1::\"char\"", []interface{}{pgx.NullChar{Char: 1, Valid: true}}, []interface{}{&actual.c}, allTypes{c: pgx.NullChar{Char: 1, Valid: true}}},
 		{"select $1::\"char\"", []interface{}{pgx.NullChar{Char: 1, Valid: false}}, []interface{}{&actual.c}, allTypes{c: pgx.NullChar{Char: 0, Valid: false}}},
 		{"select $1::\"char\"", []interface{}{pgx.NullChar{Char: 255, Valid: true}}, []interface{}{&actual.c}, allTypes{c: pgx.NullChar{Char: 255, Valid: true}}},
+		{"select $1::name", []interface{}{pgx.NullString{String: "foo", Valid: true}}, []interface{}{&actual.s}, allTypes{s: pgx.NullString{String: "foo", Valid: true}}},
+		{"select $1::name", []interface{}{pgx.NullString{String: "foo", Valid: false}}, []interface{}{&actual.s}, allTypes{s: pgx.NullString{String: "", Valid: false}}},
+		// bytes past NameDataLen-1 (63 bytes) get silently truncated by PostgreSQL
+		{"select $1::name", []interface{}{pgx.NullString{String: "1234567890123456789012345678901234567890123456789012345678901234", Valid: true}},
+			[]interface{}{&actual.s}, allTypes{s: pgx.NullString{String: "123456789012345678901234567890123456789012345678901234567890123", Valid: true}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 1, Valid: true}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: false}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 0, Valid: false}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 4294967295, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 4294967295, Valid: true}}},


### PR DESCRIPTION
The name type is used a lot in the system tables, such as the `relname` column of `pg_class`.

Under the hood, it's pretty much just a C-string that can be 63 bytes long, not counting the '\0' terminator.

This PR also accompanies the pgx.Name type with a little convenience method that says whether a name is short enough. PostgreSQL will silently truncate longer names, so the convenience method can be used by those who want to know beforehand.