### PR TITLE
Fix test failure when DB and client are not in the same time zone

### DIFF
--- a/values_test.go
+++ b/values_test.go
@@ -1095,11 +1095,11 @@ func TestRowDecode(t *testing.T) {
 		expected []interface{}
 	}{
 		{
-			"select row(1, 'cat', '2015-01-01 08:12:42'::timestamptz)",
+			"select row(1, 'cat', '2015-01-01 08:12:42-00'::timestamptz)",
 			[]interface{}{
 				int32(1),
 				"cat",
-				time.Date(2015, 1, 1, 8, 12, 42, 0, time.Local),
+				time.Date(2015, 1, 1, 8, 12, 42, 0, time.UTC).Local(),
 			},
 		},
 	}


### PR DESCRIPTION
To reproduce the test failure, create a database where the Postgres server's local time is not your machine's local time. I made mine inside a Docker container where it was UTC while my machine was in EDT.

This patch explicitly sets the time zone to UTC in the database and in the test expectation, then compares the two times in the client-local time zone.