### PR TITLE
Simplify QueryExecTimeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 
 conn_config_test.go
+tags

--- a/conn.go
+++ b/conn.go
@@ -37,6 +37,7 @@ type ConnConfig struct {
 	LogLevel          int
 	Dial              DialFunc
 	RuntimeParams     map[string]string // Run-time parameters to set on connection as session default values (e.g. search_path or application_name)
+	QueryExecTimeout  time.Duration     // Max query/statement execution time
 }
 
 // Conn is a PostgreSQL connection handle. It is not safe for concurrent usage.
@@ -164,6 +165,10 @@ func connect(config ConnConfig, pgTypes map[Oid]PgType, pgsqlAfInet *byte, pgsql
 	if pgsqlAfInet6 != nil {
 		c.pgsqlAfInet6 = new(byte)
 		*c.pgsqlAfInet6 = *pgsqlAfInet6
+	}
+
+	if config.QueryExecTimeout < 0 {
+		return nil, errors.New("QueryExecTimeout must be equal to or greater than 0")
 	}
 
 	if c.config.LogLevel != 0 {
@@ -392,6 +397,26 @@ func (c *Conn) Close() (err error) {
 		c.log(LogLevelInfo, "Closed connection")
 	}
 	return err
+}
+
+// Starts a Query/Statement exec timeout if config.QueryExecTimeout is set.
+//
+// The timer should be stopped manually in the caller method to avoid false
+// timeout error to occur.
+//
+// FYI: Exec() and Query() may return different error messages:
+//   - conn.Exec():  "conn is dead"
+//   - conn.Query(): "FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"
+func (c *Conn) startQueryExecTimeoutTimer() (timer *time.Timer) {
+	if c.config.QueryExecTimeout > 0 {
+		timer = time.AfterFunc(c.config.QueryExecTimeout, func() {
+			if c.shouldLog(LogLevelInfo) {
+				c.log(LogLevelInfo, "Timeout: QueryExecTimeout")
+			}
+			c.die(errors.New("Timeout: QueryExecTimeout"))
+		})
+	}
+	return timer
 }
 
 // ParseURI parses a database URI into ConnConfig
@@ -960,6 +985,16 @@ func (c *Conn) Exec(sql string, arguments ...interface{}) (commandTag CommandTag
 
 	startTime := time.Now()
 	c.lastActivityTime = startTime
+
+	// Set statement execution deadline
+	if timeoutTimer := c.startQueryExecTimeoutTimer(); timeoutTimer != nil {
+		defer func() {
+			if timeoutTimer.Stop() || err == nil {
+				return
+			}
+			err = ProtocolError("Timeout: QueryExecTimeout. Orig error: " + err.Error())
+		}()
+	}
 
 	defer func() {
 		if err == nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1484,5 +1485,71 @@ func TestSetLogLevel(t *testing.T) {
 
 	if len(logger.logs) == 0 {
 		t.Fatal("Expected logger to be called, but it wasn't")
+	}
+}
+
+func TestQueryExecTimeoutSanity(t *testing.T) {
+	t.Parallel()
+
+	config := *defaultConnConfig
+	config.Logger = &testLogger{}
+
+	// case 1: default 0 value
+	conn, err := pgx.Connect(config)
+	if err != nil {
+		t.Fatalf("Expected Connect with default config.QueryExecTimeout not to fail, instead it failed with '%v'", err)
+	}
+	conn.Close()
+
+	// case 2: negative value
+	config.QueryExecTimeout = -1 * time.Second
+	_, err = pgx.Connect(config)
+	if err == nil {
+		t.Fatal("ExpectedConnect with negative config.QueryExecTimeout  to fail, instead it did not")
+	}
+
+	// case 3: positive value
+	config.QueryExecTimeout = 1 * time.Second
+	conn, err = pgx.Connect(config)
+	if err != nil {
+		t.Fatalf("Expected Connect with positive config.QueryExecTimeout not to fail, instead it failed with '%v'", err)
+	}
+	conn.Close()
+}
+
+func TestExecWithQueryExecTimeoutSet(t *testing.T) {
+	t.Parallel()
+
+	config := *defaultConnConfig
+	config.Logger = &testLogger{}
+
+	// case 1: too small timeout to run a statement
+	config.QueryExecTimeout = 500 * time.Millisecond
+	conn1 := mustConnect(t, config)
+	defer closeConn(t, conn1)
+
+	_, err := conn1.Exec("SELECT pg_sleep(2)")
+	if err == nil {
+		t.Fatal("Expected Exec to fail with 'use of closed network connection', instead it did not")
+	}
+
+	matched, _ := regexp.MatchString("Timeout: QueryExecTimeout. .* use of closed network connection", err.Error())
+	if !matched {
+		t.Fatalf("Expected Exec() to fail with timeout, instead it failed with '%v'", err)
+	}
+
+	// It should close the timed out connection
+	if conn1.IsAlive() {
+		t.Fatal("Expected conn1.IsAlive to be false, instead it was true")
+	}
+
+	// case 2: big enough timeout that allows statement to finish.
+	config.QueryExecTimeout = 10 * time.Second
+	conn2 := mustConnect(t, config)
+	defer closeConn(t, conn2)
+
+	_, err = conn2.Exec("SELECT pg_sleep(2)")
+	if err != nil {
+		t.Fatalf("Expected Exec not to fail, instead it failed with '%v'", err)
 	}
 }

--- a/query_test.go
+++ b/query_test.go
@@ -3,6 +3,7 @@ package pgx_test
 import (
 	"bytes"
 	"database/sql"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -1349,4 +1350,52 @@ func TestConnQueryDatabaseSQLNullX(t *testing.T) {
 	}
 
 	ensureConnValid(t, conn)
+}
+
+func TestConnQueryWithQueryExecTimeoutSet(t *testing.T) {
+	t.Parallel()
+
+	config := *defaultConnConfig
+	config.Logger = &testLogger{}
+
+	// case 1: too small timeout to run a query
+	config.QueryExecTimeout = 500 * time.Millisecond
+	conn1 := mustConnect(t, config)
+	defer closeConn(t, conn1)
+
+	rows, err := conn1.Query("SELECT pg_sleep(2)")
+	if err != nil {
+		t.Fatalf("Expected Query() not to fail, instead it failed with '%v'", err)
+	}
+
+	hasNext := rows.Next()
+	if hasNext {
+		t.Fatal("Expected rows.Next() to return false, instead it did not")
+	}
+	if rows.Err() == nil {
+		t.Fatal("Expected Query() to fail with 'use of closed network connection', instead it did not")
+	}
+
+	matched, _ := regexp.MatchString("Timeout: QueryExecTimeout. .* use of closed network connection", rows.Err().Error())
+	if !matched {
+		t.Fatalf("Expected Query() to fail with timeout, instead it failed with '%v'", rows.Err())
+	}
+
+	// case 2: big enough timeout that allows query to finish.
+	config.QueryExecTimeout = 10 * time.Second
+	conn2 := mustConnect(t, config)
+	defer closeConn(t, conn2)
+
+	rows, err = conn2.Query("SELECT pg_sleep(2)")
+	if err != nil {
+		t.Fatalf("Expected Query() not to fail, instead it failed with '%v'", err)
+	}
+
+	hasNext = rows.Next()
+	if !hasNext {
+		t.Fatal("Expected rows.Next() to return true, instead it did not")
+	}
+	if rows.Err() != nil {
+		t.Fatalf("Expected rows.Next() not to fail, instead it failed with '%v'", rows.Err())
+	}
 }


### PR DESCRIPTION
When postgres accepts connections but does not respond to a request, QueryExecTimeout causes client to hang.
Simplify QueryExecTimeout to not make an extra request to postgres but just close current connection
