### PR TITLE
Add AclItem/NullAclItem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ env:
     - PGVERSION=9.2
     - PGVERSION=9.1
 
+# The tricky test user, below, has to actually exist so that it can be used in a test
+# of aclitem formatting. It turns out aclitems cannot contain non-existing users/roles.
 before_script:
   - mv conn_config_test.go.travis conn_config_test.go
   - psql -U postgres -c 'create database pgx_test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
   - psql -U postgres -c "create user pgx_ssl SUPERUSER PASSWORD 'secret'"
   - psql -U postgres -c "create user pgx_md5 SUPERUSER PASSWORD 'secret'"
   - psql -U postgres -c "create user pgx_pw  SUPERUSER PASSWORD 'secret'"
+  - psql -U postgres -c "create user \" tricky, ' } \"\" \\ test user \" superuser password 'secret'"
 
 install:
   - go get -u github.com/shopspring/decimal

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To setup the normal test environment, first install these dependencies:
 Then run the following SQL:
 
     create user pgx_md5 password 'secret';
+    create user " tricky, ' } "" \ test user " superuser password 'secret';
     create database pgx_test;
 
 Connect to database pgx_test and run:

--- a/values.go
+++ b/values.go
@@ -265,7 +265,18 @@ func (n NullString) Encode(w *WriteBuf, oid Oid) error {
 	return encodeString(w, oid, n.String)
 }
 
-// AclItem is used for PostgreSQL's aclitem data type.
+// AclItem is used for PostgreSQL's aclitem data type. A sample aclitem
+// might look like this:
+//
+//	postgres=arwdDxt/postgres
+//
+// Note, however, that because the user/role name part of an aclitem is
+// an identifier, it follows all the usual formatting rules for SQL
+// identifiers: if it contains spaces and other special characters,
+// it should appear in double-quotes:
+//
+//	postgres=arwdDxt/"role with spaces"
+//
 type AclItem string
 
 // NullAclItem represents a pgx.AclItem that may be null. NullAclItem implements the

--- a/values_test.go
+++ b/values_test.go
@@ -562,6 +562,7 @@ func TestNullX(t *testing.T) {
 		i16 pgx.NullInt16
 		i32 pgx.NullInt32
 		c   pgx.NullChar
+		a   pgx.NullAclItem
 		n   pgx.NullName
 		oid pgx.NullOid
 		xid pgx.NullXid
@@ -599,6 +600,8 @@ func TestNullX(t *testing.T) {
 		{"select $1::\"char\"", []interface{}{pgx.NullChar{Char: 255, Valid: true}}, []interface{}{&actual.c}, allTypes{c: pgx.NullChar{Char: 255, Valid: true}}},
 		{"select $1::name", []interface{}{pgx.NullName{Name: "foo", Valid: true}}, []interface{}{&actual.n}, allTypes{n: pgx.NullName{Name: "foo", Valid: true}}},
 		{"select $1::name", []interface{}{pgx.NullName{Name: "foo", Valid: false}}, []interface{}{&actual.n}, allTypes{n: pgx.NullName{Name: "", Valid: false}}},
+		{"select $1::aclitem", []interface{}{pgx.NullAclItem{AclItem: "postgres=arwdDxt/postgres", Valid: true}}, []interface{}{&actual.a}, allTypes{a: pgx.NullAclItem{AclItem: "postgres=arwdDxt/postgres", Valid: true}}},
+		{"select $1::aclitem", []interface{}{pgx.NullAclItem{AclItem: "postgres=arwdDxt/postgres", Valid: false}}, []interface{}{&actual.a}, allTypes{a: pgx.NullAclItem{AclItem: "", Valid: false}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 1, Valid: true}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: false}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 0, Valid: false}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 4294967295, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 4294967295, Valid: true}}},

--- a/values_test.go
+++ b/values_test.go
@@ -600,6 +600,7 @@ func TestNullX(t *testing.T) {
 		{"select $1::\"char\"", []interface{}{pgx.NullChar{Char: 255, Valid: true}}, []interface{}{&actual.c}, allTypes{c: pgx.NullChar{Char: 255, Valid: true}}},
 		{"select $1::name", []interface{}{pgx.NullName{Name: "foo", Valid: true}}, []interface{}{&actual.n}, allTypes{n: pgx.NullName{Name: "foo", Valid: true}}},
 		{"select $1::name", []interface{}{pgx.NullName{Name: "foo", Valid: false}}, []interface{}{&actual.n}, allTypes{n: pgx.NullName{Name: "", Valid: false}}},
+		{"select $1::aclitem", []interface{}{pgx.NullAclItem{AclItem: `postgres=arwdDxt/" tricky, ' } "" \ test user "`, Valid: true}}, []interface{}{&actual.a}, allTypes{a: pgx.NullAclItem{AclItem: `postgres=arwdDxt/" tricky, ' } "" \ test user "`, Valid: true}}},
 		{"select $1::aclitem", []interface{}{pgx.NullAclItem{AclItem: "postgres=arwdDxt/postgres", Valid: true}}, []interface{}{&actual.a}, allTypes{a: pgx.NullAclItem{AclItem: "postgres=arwdDxt/postgres", Valid: true}}},
 		{"select $1::aclitem", []interface{}{pgx.NullAclItem{AclItem: "postgres=arwdDxt/postgres", Valid: false}}, []interface{}{&actual.a}, allTypes{a: pgx.NullAclItem{AclItem: "", Valid: false}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 1, Valid: true}}},

--- a/values_test.go
+++ b/values_test.go
@@ -600,9 +600,10 @@ func TestNullX(t *testing.T) {
 		{"select $1::\"char\"", []interface{}{pgx.NullChar{Char: 255, Valid: true}}, []interface{}{&actual.c}, allTypes{c: pgx.NullChar{Char: 255, Valid: true}}},
 		{"select $1::name", []interface{}{pgx.NullName{Name: "foo", Valid: true}}, []interface{}{&actual.n}, allTypes{n: pgx.NullName{Name: "foo", Valid: true}}},
 		{"select $1::name", []interface{}{pgx.NullName{Name: "foo", Valid: false}}, []interface{}{&actual.n}, allTypes{n: pgx.NullName{Name: "", Valid: false}}},
-		{"select $1::aclitem", []interface{}{pgx.NullAclItem{AclItem: `postgres=arwdDxt/" tricky, ' } "" \ test user "`, Valid: true}}, []interface{}{&actual.a}, allTypes{a: pgx.NullAclItem{AclItem: `postgres=arwdDxt/" tricky, ' } "" \ test user "`, Valid: true}}},
 		{"select $1::aclitem", []interface{}{pgx.NullAclItem{AclItem: "postgres=arwdDxt/postgres", Valid: true}}, []interface{}{&actual.a}, allTypes{a: pgx.NullAclItem{AclItem: "postgres=arwdDxt/postgres", Valid: true}}},
 		{"select $1::aclitem", []interface{}{pgx.NullAclItem{AclItem: "postgres=arwdDxt/postgres", Valid: false}}, []interface{}{&actual.a}, allTypes{a: pgx.NullAclItem{AclItem: "", Valid: false}}},
+		// A tricky (and valid) aclitem can still be used, especially with Go's useful backticks
+		{"select $1::aclitem", []interface{}{pgx.NullAclItem{AclItem: `postgres=arwdDxt/" tricky, ' } "" \ test user "`, Valid: true}}, []interface{}{&actual.a}, allTypes{a: pgx.NullAclItem{AclItem: `postgres=arwdDxt/" tricky, ' } "" \ test user "`, Valid: true}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 1, Valid: true}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 1, Valid: false}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 0, Valid: false}}},
 		{"select $1::cid", []interface{}{pgx.NullCid{Cid: 4294967295, Valid: true}}, []interface{}{&actual.cid}, allTypes{cid: pgx.NullCid{Cid: 4294967295, Valid: true}}},


### PR DESCRIPTION
The aclitem datatype is another PostgreSQL-specific data type used in the system catalogs. This one is kind of tricky for a few reasons: 1) it only goes over the wire in text format, not binary; 2) an aclitem is valid if the user/role after the slash in the aclitem actually exists in PostgreSQL; 3) the user/role part of an aclitem is a SQL identifier, with all the crazy formatting rules that go with that: within double quotes, pretty much anything goes.

The pg_class system table's relacl column actually uses the aclitem[] type (not aclitem), which also goes over the wire in text format only, so if this PR gets accepted, the next thing I'd like to figure out is how to get aclitem[] working too.
