### PR TITLE
support for uuid[]

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -920,7 +920,7 @@ func (c *Conn) sendPreparedQuery(ps *PreparedStatement, arguments ...interface{}
 			wbuf.WriteInt16(TextFormatCode)
 		default:
 			switch oid {
-			case BoolOid, ByteaOid, Int2Oid, Int4Oid, Int8Oid, Float4Oid, Float8Oid, TimestampTzOid, TimestampTzArrayOid, TimestampOid, TimestampArrayOid, DateOid, BoolArrayOid, ByteaArrayOid, Int2ArrayOid, Int4ArrayOid, Int8ArrayOid, Float4ArrayOid, Float8ArrayOid, TextArrayOid, VarcharArrayOid, OidOid, InetOid, CidrOid, InetArrayOid, CidrArrayOid, RecordOid, JsonOid, JsonbOid:
+			case BoolOid, ByteaOid, Int2Oid, Int4Oid, Int8Oid, Float4Oid, Float8Oid, TimestampTzOid, TimestampTzArrayOid, TimestampOid, TimestampArrayOid, DateOid, BoolArrayOid, ByteaArrayOid, Int2ArrayOid, Int4ArrayOid, Int8ArrayOid, Float4ArrayOid, Float8ArrayOid, TextArrayOid, VarcharArrayOid, OidOid, InetOid, CidrOid, InetArrayOid, CidrArrayOid, RecordOid, JsonOid, JsonbOid, UuidOid, UuidArrayOid:
 				wbuf.WriteInt16(BinaryFormatCode)
 			default:
 				wbuf.WriteInt16(TextFormatCode)

--- a/value_reader.go
+++ b/value_reader.go
@@ -2,6 +2,7 @@ package pgx
 
 import (
 	"errors"
+	"fmt"
 )
 
 // ValueReader is used by the Scanner interface to decode values.
@@ -133,6 +134,26 @@ func (r *ValueReader) ReadString(count int32) string {
 	}
 
 	return r.mr.readString(count)
+}
+
+// ReadUuid reads count bytes and returns the formatted uuid
+func (r *ValueReader) ReadUuid(count int32) string {
+	if r.err != nil {
+		return ""
+	}
+	if count != 16 {
+		r.Fatal(errors.New("unexpected UUID length"))
+		return ""
+	}
+
+	r.valueBytesRemaining -= count
+	if r.valueBytesRemaining < 0 {
+		r.Fatal(errors.New("read past end of value"))
+		return ""
+	}
+
+	v := r.mr.readBytes(count)
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", v[:4], v[4:6], v[6:8], v[8:10], v[10:])
 }
 
 // ReadBytes reads count bytes and returns as []byte


### PR DESCRIPTION
#Add support for UUID arrays. It works, but the change is rather pervasive.

Unfortunately # 1: This switches UUIDs over to the binary protocol, with UUIDs encoded over the wire as 16 bytes, not as text, so we need to add the suitable en/decoding.

Unfortunately # 2: , since a uuid in Go is just a string we can't switch on the type of what we decode to, since that's a `[]string` or a `*string`, so we need to check the OID of the column everywhere we deal decode into a string.

I guess we could add a case for a `[16]byte`, so we can skip the en/decoding step, if the user prefers that format.

Maybe you have an idea to solve this in a nicer way, @jackc?