### PR TITLE
Alternative `uuid[]`

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -920,7 +920,7 @@ func (c *Conn) sendPreparedQuery(ps *PreparedStatement, arguments ...interface{}
 			wbuf.WriteInt16(TextFormatCode)
 		default:
 			switch oid {
-			case BoolOid, ByteaOid, Int2Oid, Int4Oid, Int8Oid, Float4Oid, Float8Oid, TimestampTzOid, TimestampTzArrayOid, TimestampOid, TimestampArrayOid, DateOid, BoolArrayOid, ByteaArrayOid, Int2ArrayOid, Int4ArrayOid, Int8ArrayOid, Float4ArrayOid, Float8ArrayOid, TextArrayOid, VarcharArrayOid, OidOid, InetOid, CidrOid, InetArrayOid, CidrArrayOid, RecordOid, JsonOid, JsonbOid:
+			case BoolOid, ByteaOid, Int2Oid, Int4Oid, Int8Oid, Float4Oid, Float8Oid, TimestampTzOid, TimestampTzArrayOid, TimestampOid, TimestampArrayOid, DateOid, BoolArrayOid, ByteaArrayOid, Int2ArrayOid, Int4ArrayOid, Int8ArrayOid, Float4ArrayOid, Float8ArrayOid, TextArrayOid, VarcharArrayOid, OidOid, InetOid, CidrOid, InetArrayOid, CidrArrayOid, RecordOid, JsonOid, JsonbOid, UuidOid, UuidArrayOid:
 				wbuf.WriteInt16(BinaryFormatCode)
 			default:
 				wbuf.WriteInt16(TextFormatCode)

--- a/conn.go
+++ b/conn.go
@@ -920,7 +920,7 @@ func (c *Conn) sendPreparedQuery(ps *PreparedStatement, arguments ...interface{}
 			wbuf.WriteInt16(TextFormatCode)
 		default:
 			switch oid {
-			case BoolOid, ByteaOid, Int2Oid, Int4Oid, Int8Oid, Float4Oid, Float8Oid, TimestampTzOid, TimestampTzArrayOid, TimestampOid, TimestampArrayOid, DateOid, BoolArrayOid, ByteaArrayOid, Int2ArrayOid, Int4ArrayOid, Int8ArrayOid, Float4ArrayOid, Float8ArrayOid, TextArrayOid, VarcharArrayOid, OidOid, InetOid, CidrOid, InetArrayOid, CidrArrayOid, RecordOid, JsonOid, JsonbOid, UuidOid, UuidArrayOid:
+			case BoolOid, ByteaOid, Int2Oid, Int4Oid, Int8Oid, Float4Oid, Float8Oid, TimestampTzOid, TimestampTzArrayOid, TimestampOid, TimestampArrayOid, DateOid, BoolArrayOid, ByteaArrayOid, Int2ArrayOid, Int4ArrayOid, Int8ArrayOid, Float4ArrayOid, Float8ArrayOid, TextArrayOid, VarcharArrayOid, OidOid, InetOid, CidrOid, InetArrayOid, CidrArrayOid, RecordOid, JsonOid, JsonbOid, UuidArrayOid:
 				wbuf.WriteInt16(BinaryFormatCode)
 			default:
 				wbuf.WriteInt16(TextFormatCode)

--- a/value_reader.go
+++ b/value_reader.go
@@ -2,6 +2,7 @@ package pgx
 
 import (
 	"errors"
+	"fmt"
 )
 
 // ValueReader is used by the Scanner interface to decode values.
@@ -133,6 +134,26 @@ func (r *ValueReader) ReadString(count int32) string {
 	}
 
 	return r.mr.readString(count)
+}
+
+// ReadUuid reads count bytes and returns the formatted uuid
+func (r *ValueReader) ReadUuid(count int32) string {
+	if r.err != nil {
+		return ""
+	}
+	if count != 16 {
+		r.Fatal(errors.New("unexpected UUID length"))
+		return ""
+	}
+
+	r.valueBytesRemaining -= count
+	if r.valueBytesRemaining < 0 {
+		r.Fatal(errors.New("read past end of value"))
+		return ""
+	}
+
+	v := r.mr.readBytes(count)
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", v[:4], v[4:6], v[6:8], v[8:10], v[10:])
 }
 
 // ReadBytes reads count bytes and returns as []byte

--- a/values.go
+++ b/values.go
@@ -989,16 +989,18 @@ func (u *UUIDs) Scan(vr *ValueReader) error {
 		return nil
 	}
 
-	a := make([]string, int(numElems))
-	for i := 0; i < len(a); i++ {
-		elSize := vr.ReadInt32()
-		if elSize == -1 {
-			vr.Fatal(ProtocolError("Cannot decode null element"))
-			return nil
+	if numElems > 0 {
+		a := make([]string, int(numElems))
+		for i := 0; i < len(a); i++ {
+			elSize := vr.ReadInt32()
+			if elSize == -1 {
+				vr.Fatal(ProtocolError("Cannot decode null element"))
+				return nil
+			}
+			a[i] = vr.ReadUuid(elSize)
 		}
-		a[i] = vr.ReadUuid(elSize)
+		*u = a
 	}
-	*u = a
 	return vr.Err()
 }
 

--- a/values_test.go
+++ b/values_test.go
@@ -773,9 +773,9 @@ func TestArrayDecoding(t *testing.T) {
 			},
 		},
 		{
-			"select $1::uuid[]", []string{"01086ee0-4963-4e35-9116-30c173a8d0bd", "01086ee0-4963-4e35-9116-aaaaaaaaaaaa"}, &[]string{},
+			"select $1::uuid[]", pgx.UUIDs{"01086ee0-4963-4e35-9116-30c173a8d0bd", "01086ee0-4963-4e35-9116-aaaaaaaaaaaa"}, &pgx.UUIDs{},
 			func(t *testing.T, query, scan interface{}) {
-				if !reflect.DeepEqual(query, *(scan.(*[]string))) {
+				if !reflect.DeepEqual(query, *(scan.(*pgx.UUIDs))) {
 					t.Fatalf("failed to encode uuid[]")
 				}
 			},


### PR DESCRIPTION
This is an alternative to #233. You do need to use `pgx.UUIDs(yourStringSlice)` when querying or scanning, but the change is smaller overall. Single UUIDs are still simple strings.