### PR TITLE
allow a firstelem at 0 - int2vector

### DIFF
--- a/values.go
+++ b/values.go
@@ -2406,8 +2406,8 @@ func decode1dArrayHeader(vr *ValueReader) (length int32, err error) {
 	length = vr.ReadInt32()
 
 	idxFirstElem := vr.ReadInt32()
-	if idxFirstElem != 1 {
-		return 0, ProtocolError(fmt.Sprintf("Expected array's first element to start a index 1, but it is %d", idxFirstElem))
+	if idxFirstElem < 0 || idxFirstElem > 1 {
+		return 0, ProtocolError(fmt.Sprintf("Expected array's first element to start at index 0 or 1, but it is %d", idxFirstElem))
 	}
 
 	return length, nil


### PR DESCRIPTION
I'm reading [pg_catalog.pg_index](https://www.postgresql.org/docs/9.6/static/catalog-pg-index.html) for a [project](https://github.com/alicebob/schemaspy). It has a `int2vector` column which pgx doesn't seem to support. 
Query:
```
SELECT indexrelid, indrelid, indisunique, indisprimary, indkey::int4[]
FROM pg_catalog.pg_index
```
pgx error:
```
	int_test.go:20: can't scan into dest[4]: Expected array's first element to start a index 0 or 1, but it is 0
```

This patch seems to fix it nicely, but I see no way to add a proper test case, since I don't know how to generate a new `int2vector` type :(
