### PR TITLE
fix(stdlib): lock openFromConnPoolCount while using

### DIFF
--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"github.com/jackc/pgx"
 	"github.com/jackc/pgx/stdlib"
+	"sync"
 	"testing"
 )
 
@@ -161,6 +162,43 @@ func TestOpenFromConnPool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("db.QueryRow unexpectedly failed: %v", err)
 	}
+}
+
+func TestOpenFromConnPoolRace(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	connConfig := pgx.ConnConfig{
+		Host:     "127.0.0.1",
+		User:     "pgx_md5",
+		Password: "secret",
+		Database: "pgx_test",
+	}
+
+	config := pgx.ConnPoolConfig{ConnConfig: connConfig}
+	pool, err := pgx.NewConnPool(config)
+	if err != nil {
+		t.Fatalf("Unable to create connection pool: %v", err)
+	}
+	defer pool.Close()
+
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			db, err := stdlib.OpenFromConnPool(pool)
+			if err != nil {
+				t.Fatalf("Unable to create connection pool: %v", err)
+			}
+			defer closeDB(t, db)
+
+			// Can get pgx.ConnPool from driver
+			driver := db.Driver().(*stdlib.Driver)
+			if driver.Pool == nil {
+				t.Fatal("Expected driver opened through OpenFromConnPool to have Pool, but it did not")
+			}
+		}()
+	}
+
+	wg.Wait()
 }
 
 func TestStmtExec(t *testing.T) {


### PR DESCRIPTION
Locks the `openFromConnPoolCount` counter while formatting the driver name and incrementing to avoid a data race of multiple goroutines modifying the counter and registering the same name. `sql.Register` panics if a driver name has already been registered.

Without the lock, the new test are caught by the race detector with messages similar to the following:

```
==================
WARNING: DATA RACE
Read at 0x00000158fb20 by goroutine 17:
  runtime.convT2E()
      /opt/local/lib/go/src/runtime/iface.go:191 +0x0
  github.com/jackc/pgx/stdlib.OpenFromConnPool()
      /Users/terin/Development/pgx/src/github.com/jackc/pgx/stdlib/sql.go:118 +0xb9
  github.com/jackc/pgx/stdlib_test.TestOpenFromConnPoolRace.func1()
      /Users/terin/Development/pgx/src/github.com/jackc/pgx/stdlib/sql_test.go:187 +0x7d

Previous write at 0x00000158fb20 by goroutine 16:
  github.com/jackc/pgx/stdlib.OpenFromConnPool()
      /Users/terin/Development/pgx/src/github.com/jackc/pgx/stdlib/sql.go:119 +0x17f
  github.com/jackc/pgx/stdlib_test.TestOpenFromConnPoolRace.func1()
      /Users/terin/Development/pgx/src/github.com/jackc/pgx/stdlib/sql_test.go:187 +0x7d

Goroutine 17 (running) created at:
  github.com/jackc/pgx/stdlib_test.TestOpenFromConnPoolRace()
      /Users/terin/Development/pgx/src/github.com/jackc/pgx/stdlib/sql_test.go:198 +0x303
  testing.tRunner()
      /opt/local/lib/go/src/testing/testing.go:657 +0x107

Goroutine 16 (running) created at:
  github.com/jackc/pgx/stdlib_test.TestOpenFromConnPoolRace()
      /Users/terin/Development/pgx/src/github.com/jackc/pgx/stdlib/sql_test.go:198 +0x303
  testing.tRunner()
      /opt/local/lib/go/src/testing/testing.go:657 +0x107
==================
panic: sql: Register called twice for driver pgx-2

goroutine 24 [running]:
database/sql.Register(0xc4200fa140, 0x5, 0x1553e20, 0xc420100008)
	/opt/local/lib/go/src/database/sql/sql.go:50 +0x211
github.com/jackc/pgx/stdlib.OpenFromConnPool(0xc4200ab2c0, 0x13ffac8, 0xc4200f4550, 0xc420076b38)
	/Users/terin/Development/pgx/src/github.com/jackc/pgx/stdlib/sql.go:120 +0x1bd
github.com/jackc/pgx/stdlib_test.TestOpenFromConnPoolRace.func1(0xc4200f4550, 0xc4200ab2c0, 0xc420080c30)
	/Users/terin/Development/pgx/src/github.com/jackc/pgx/stdlib/sql_test.go:187 +0x7e
created by github.com/jackc/pgx/stdlib_test.TestOpenFromConnPoolRace
	/Users/terin/Development/pgx/src/github.com/jackc/pgx/stdlib/sql_test.go:198 +0x304
FAIL	github.com/jackc/pgx/stdlib	0.046s
```