### PR TITLE
Optimize HStore Encode method

### DIFF
--- a/values.go
+++ b/values.go
@@ -893,7 +893,11 @@ func (h Hstore) Encode(w *WriteBuf, oid Oid) error {
 		ks = strings.Replace(ks, `"`, `\"`, -1)
 		vs := strings.Replace(v, `\`, `\\`, -1)
 		vs = strings.Replace(vs, `"`, `\"`, -1)
-		buf.WriteString(fmt.Sprintf(`"%s"=>"%s"`, ks, vs))
+		buf.WriteString(`"`)
+		buf.WriteString(ks)
+		buf.WriteString(`"=>"`)
+		buf.WriteString(vs)
+		buf.WriteString(`"`)
 		if i < len(h) {
 			buf.WriteString(", ")
 		}


### PR DESCRIPTION
While looking for a memory leak in my application i accidently found that hstore encoding is doing a redundant fmt.Sprintf. That line of code together with the WriteString is accounting for 25% of the memory consumption inside this function in the old situation. Unrolling the WriteString makes it better: 

```
// old at top
// 5000000	       338 ns/op	 160 B/op	       4 allocs/op
// 10000000	       124 ns/op         112 B/op	       1 allocs/op
func BenchmarkAlloc(b *testing.B) {
	a:= "key"
	c:="value"
	for i :=0; i< b.N;i++ {
		var b bytes.Buffer
		b.WriteString(`"`)
		b.WriteString(a)
		b.WriteString(`"=>"`)
		b.WriteString(c)
		b.WriteString(`"`)
		//b.WriteString(fmt.Sprintf(`"%s"=>"%s"`,a,c))
	}
	b.ReportAllocs()
}
```

The difference is even bigger if longer strings are used.