### PR TITLE
Add godoc.org badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![](https://godoc.org/github.com/jackc/pgx?status.svg)](https://godoc.org/github.com/jackc/pgx)
+
 # Pgx
 
 Pgx is a pure Go database connection library designed specifically for


### PR DESCRIPTION
A trivial doc patch to add a [godoc|reference] badge to README.md, like all the cool kids have.