### PR TITLE
Add missing `pgx.Identifier` to `CopyFrom` example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -225,7 +225,7 @@ implement CopyFromSource to avoid buffering the entire data set in memory.
     }
 
     copyCount, err := conn.CopyFrom(
-        "people",
+        pgx.Identifier{"people"},
         []string{"first_name", "last_name", "age"},
         pgx.CopyFromRows(rows),
     )


### PR DESCRIPTION
Noticed a the column name needed be wrapped in type `pgx.Identifier` which was missing in the example documentation.

Excellent work with the `CopyFrom` feature, by the way.