### PR TITLE
Add missing period in documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
 // Package pgx is a PostgreSQL database driver.
 /*
-pgx provides lower level access to PostgreSQL than the standard database/sql
+pgx provides lower level access to PostgreSQL than the standard database/sql.
 It remains as similar to the database/sql interface as possible while
 providing better speed and access to PostgreSQL specific features. Import
 github.com/jack/pgx/stdlib to use pgx as a database/sql compatible driver.


### PR DESCRIPTION
On GoDoc, the first and second lines of this comment appear on the same line highlighting the need for a period. Extremely minor change otherwise.