### PR TITLE
Fix some invalid one round trip execs failing to return non-nil error

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1458,6 +1458,10 @@ func (c *Conn) execEx(ctx context.Context, sql string, options *QueryExOptions, 
 			return "", err
 		}
 	} else if options != nil && len(options.ParameterOIDs) > 0 {
+		if err := c.ensureConnectionReadyForQuery(); err != nil {
+			return "", err
+		}
+
 		buf, err := c.buildOneRoundTripExec(c.wbuf, sql, options, arguments)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Prior to this commit, execEx() would write the one round trip exec to
the connection before first calling ensureConnectionReadyForQuery, which
ultimately caused any errors to be suppressed if the exec followed a
valid query, because the receive message processing would finish
successfully as soon as it received the ReadyForQuery that actually
belonged to the preceding query. So, the exec would never actually
receive the error message that it caused, leaving it to be incorrectly
received by the first subsequent query sent.