### PR TITLE
Return ErrClosedPool when Acquire() with closed pool

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -43,6 +43,9 @@ type ConnPoolStat struct {
 // ErrAcquireTimeout occurs when an attempt to acquire a connection times out.
 var ErrAcquireTimeout = errors.New("timeout acquiring connection from pool")
 
+// ErrClosedPool occurs when an attempt to acquire a connection times out.
+var ErrClosedPool = errors.New("cannot acquire from closed pool")
+
 // NewConnPool creates a new ConnPool. config.ConnConfig is passed through to
 // Connect directly.
 func NewConnPool(config ConnPoolConfig) (p *ConnPool, err error) {
@@ -108,7 +111,7 @@ func (p *ConnPool) deadlinePassed(deadline *time.Time) bool {
 // acquire performs acquision assuming pool is already locked
 func (p *ConnPool) acquire(deadline *time.Time) (*Conn, error) {
 	if p.closed {
-		return nil, errors.New("cannot acquire from closed pool")
+		return nil, ErrClosedPool
 	}
 
 	// A connection is available

--- a/conn_pool_test.go
+++ b/conn_pool_test.go
@@ -315,6 +315,23 @@ func TestPoolWithoutAcquireTimeoutSet(t *testing.T) {
 	}
 }
 
+func TestPoolErrClosedPool(t *testing.T) {
+	t.Parallel()
+
+	pool := createConnPool(t, 1)
+	// Intentionaly close the pool now so we can test ErrClosedPool
+	pool.Close()
+
+	c, err := pool.Acquire()
+	if c != nil {
+		t.Fatalf("Expected acquired connection to be nil, instead it was '%v'", c)
+	}
+
+	if err == nil || err != pgx.ErrClosedPool {
+		t.Fatalf("Expected error to be pgx.ErrClosedPool, instead it was '%v'", err)
+	}
+}
+
 func TestPoolReleaseWithTransactions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
*Note:* I didnt couldnt get local tests to run . Got a err `query.go:11:2: use of internal package not allowed` 


What: 
  * Use a named Err for when we attempt Acquire with a closed pool

Why: 
 * I can test err = pgx.ErrClosedPool in my consuming code 😀 