### PR TITLE
Skip certificate verification for sslmode "require"

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -711,7 +711,9 @@ func configSSL(sslmode string, cc *ConnConfig) error {
 		cc.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 		cc.UseFallbackTLS = true
 		cc.FallbackTLSConfig = nil
-	case "require", "verify-ca", "verify-full":
+	case "require":
+		cc.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	case "verify-ca", "verify-full":
 		cc.TLSConfig = &tls.Config{
 			ServerName: cc.Host,
 		}


### PR DESCRIPTION
Fixes #282.

This more appropriately aligns the behaviour of the library with
that advertised by the postgres documentation.

According to the table on the official documentation page
https://www.postgresql.org/docs/current/static/libpq-ssl.html,
the "require" mode should be used when:

"I want my data to be encrypted, and I accept the overhead. I trust that the network will make sure I always connect to the server I want."

This maps reasonably well to a TLS config that skips certificate verification.