### PR TITLE
Prefix types in namespaces other than pg_catalog or public

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -384,9 +384,13 @@ func (c *Conn) connect(config ConnConfig, network, address string, tlsConfig *tl
 func (c *Conn) initConnInfo() error {
 	nameOIDs := make(map[string]pgtype.OID, 256)
 
-	rows, err := c.Query(`select t.oid, t.typname
+	rows, err := c.Query(`select t.oid,
+	case when nsp.nspname in ('pg_catalog', 'public') then t.typname
+		else nsp.nspname||'.'||t.typname
+	end
 from pg_type t
 left join pg_type base_type on t.typelem=base_type.oid
+left join pg_namespace nsp on t.typnamespace=nsp.oid
 where (
 	  t.typtype in('b', 'p', 'r', 'e')
 	  and (base_type.oid is null or base_type.typtype in('b', 'p', 'r'))

--- a/pgmock/pgmock.go
+++ b/pgmock/pgmock.go
@@ -204,7 +204,17 @@ func AcceptUnauthenticatedConnRequestSteps() []Step {
 func PgxInitSteps() []Step {
 	steps := []Step{
 		ExpectMessage(&pgproto3.Parse{
-			Query: "select t.oid, t.typname\nfrom pg_type t\nleft join pg_type base_type on t.typelem=base_type.oid\nwhere (\n\t  t.typtype in('b', 'p', 'r', 'e')\n\t  and (base_type.oid is null or base_type.typtype in('b', 'p', 'r'))\n\t)",
+			Query: `select t.oid,
+	case when nsp.nspname in ('pg_catalog', 'public') then t.typname
+		else nsp.nspname||'.'||t.typname
+	end
+from pg_type t
+left join pg_type base_type on t.typelem=base_type.oid
+left join pg_namespace nsp on t.typnamespace=nsp.oid
+where (
+	  t.typtype in('b', 'p', 'r', 'e')
+	  and (base_type.oid is null or base_type.typtype in('b', 'p', 'r'))
+	)`,
 		}),
 		ExpectMessage(&pgproto3.Describe{
 			ObjectType: 'S',


### PR DESCRIPTION
It's possible to define a type (e.g., an enum) with the same name in two
different schemas. When initializing data types after connecting, types defined
within schemas other than pg_catalog or public should be qualified with their
schema name to disambiguate them and ensure all types with the same base name
get added to the map of OID to type.

Prior to this commit, the last type scanned would "win", and all others with the
same name would be missing from the ConnInfo type maps, which would subsequently
cause any PREPARE involving columns of those missing types to return the error
"unknown oid".

I tried writing the following test for this, but the test db user doesn't currently have permission to create schemas, etc. Any ideas on how to test this easily?

```go
func TestConnInitConnInfoConflictingTypeNames(t *testing.T) {
	conn := mustConnect(t, *defaultConnConfig)
	defer closeConn(t, conn)

	// create two types with the same name in different schemas
	mustExec(t, conn, `create schema foo;
create schema bar;
create type foo.some_type as enum ('a');
create type bar.some_type as enum ('b');`)
	closeConn(t, conn)
	ensureConnValid(t, conn)

	// open a new connection and check that both types are in ConnInfo
	conn = mustConnect(t, *defaultConnConfig)
	defer closeConn(t, conn)
	defer conn.Exec(`drop schema foo, bar cascade;`)

	connInfo := conn.ConnInfo
	if _, ok := connInfo.DataTypeForName("some_type"); ok {
		t.Fatal("Excepted unqualified some_type to be missing")
	}
	fooDt, ok := connInfo.DataTypeForName("foo.some_type")
	if !ok {
		t.Fatal("Excepted foo.some_type name to be present")
	}
	barDt, ok := connInfo.DataTypeForName("bar.some_type")
	if !ok {
		t.Fatal("Excepted bar.some_type name to be present")
	}
	if fooDt.OID == barDt.OID {
		t.Fatal("Excepted foo.some_type OID to be distinct from bar.some_type OID")
	}
	if _, ok := connInfo.DataTypeForOID(fooDt.OID); !ok {
		t.Fatal("Excepted foo.some_type OID to be present")
	}
	if _, ok := connInfo.DataTypeForOID(barDt.OID); !ok {
		t.Fatal("Excepted bar.some_type OID to be present")
	}

	ensureConnValid(t, conn)
}
```