### PR TITLE
Changed CreateReplicationSlot to return the consistent_point and snapshot_name

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -435,7 +435,13 @@ func (rc *ReplicationConn) StartReplication(slotName string, startLsn uint64, ti
 }
 
 // Create the replication slot, using the given name and output plugin.
-func (rc *ReplicationConn) CreateReplicationSlot(slotName, outputPlugin string) (consistentPoint string, snapshotName string, err error) {
+func (rc *ReplicationConn) CreateReplicationSlot(slotName, outputPlugin string) (err error) {
+	_, err = rc.c.Exec(fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL %s", slotName, outputPlugin))
+	return
+}
+
+// Create the replication slot, using the given name and output plugin, and return the consistent_point and snapshot_name values.
+func (rc *ReplicationConn) CreateReplicationSlotEx(slotName, outputPlugin string) (consistentPoint string, snapshotName string, err error) {
 	var dummy string
 	var rows *Rows
 	rows, err = rc.sendReplicationModeQuery(fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL %s", slotName, outputPlugin))

--- a/replication.go
+++ b/replication.go
@@ -435,8 +435,14 @@ func (rc *ReplicationConn) StartReplication(slotName string, startLsn uint64, ti
 }
 
 // Create the replication slot, using the given name and output plugin.
-func (rc *ReplicationConn) CreateReplicationSlot(slotName, outputPlugin string) (err error) {
-	_, err = rc.c.Exec(fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL %s", slotName, outputPlugin))
+func (rc *ReplicationConn) CreateReplicationSlot(slotName, outputPlugin string) (consistentPoint string, snapshotName string, err error) {
+	var dummy string
+	var rows *Rows
+	rows, err = rc.sendReplicationModeQuery(fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL %s", slotName, outputPlugin))
+	defer rows.Close()
+	for rows.Next() {
+		rows.Scan(&dummy, &consistentPoint, &snapshotName, &dummy)
+	}
 	return
 }
 

--- a/replication_test.go
+++ b/replication_test.go
@@ -56,7 +56,7 @@ func TestSimpleReplicationConnection(t *testing.T) {
 	replicationConn := mustReplicationConnect(t, *replicationConnConfig)
 	defer closeReplicationConn(t, replicationConn)
 
-	err = replicationConn.CreateReplicationSlot("pgx_test", "test_decoding")
+	_, _, err = replicationConn.CreateReplicationSlot("pgx_test", "test_decoding")
 	if err != nil {
 		t.Fatalf("replication slot create failed: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestReplicationConn_DropReplicationSlot(t *testing.T) {
 	replicationConn := mustReplicationConnect(t, *replicationConnConfig)
 	defer closeReplicationConn(t, replicationConn)
 
-	err := replicationConn.CreateReplicationSlot("pgx_slot_test", "test_decoding")
+	_, _, err := replicationConn.CreateReplicationSlot("pgx_slot_test", "test_decoding")
 	if err != nil {
 		t.Logf("replication slot create failed: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestReplicationConn_DropReplicationSlot(t *testing.T) {
 	}
 
 	// We re-create to ensure the drop worked.
-	err = replicationConn.CreateReplicationSlot("pgx_slot_test", "test_decoding")
+	_, _, err = replicationConn.CreateReplicationSlot("pgx_slot_test", "test_decoding")
 	if err != nil {
 		t.Logf("replication slot create failed: %v", err)
 	}

--- a/replication_test.go
+++ b/replication_test.go
@@ -56,9 +56,17 @@ func TestSimpleReplicationConnection(t *testing.T) {
 	replicationConn := mustReplicationConnect(t, *replicationConnConfig)
 	defer closeReplicationConn(t, replicationConn)
 
-	_, _, err = replicationConn.CreateReplicationSlot("pgx_test", "test_decoding")
+	var cp string
+	var snapshot_name string
+	cp, snapshot_name, err = replicationConn.CreateReplicationSlotEx("pgx_test", "test_decoding")
 	if err != nil {
 		t.Fatalf("replication slot create failed: %v", err)
+	}
+	if cp == "" {
+		t.Logf("consistent_point is empty")
+	}
+	if snapshot_name == "" {
+		t.Logf("snapshot_name is empty")
 	}
 
 	// Do a simple change so we can get some wal data
@@ -178,19 +186,34 @@ func TestReplicationConn_DropReplicationSlot(t *testing.T) {
 	replicationConn := mustReplicationConnect(t, *replicationConnConfig)
 	defer closeReplicationConn(t, replicationConn)
 
-	_, _, err := replicationConn.CreateReplicationSlot("pgx_slot_test", "test_decoding")
+	var cp string
+	var snapshot_name string
+	cp, snapshot_name, err := replicationConn.CreateReplicationSlotEx("pgx_slot_test", "test_decoding")
 	if err != nil {
 		t.Logf("replication slot create failed: %v", err)
 	}
+	if cp == "" {
+		t.Logf("consistent_point is empty")
+	}
+	if snapshot_name == "" {
+		t.Logf("snapshot_name is empty")
+	}
+
 	err = replicationConn.DropReplicationSlot("pgx_slot_test")
 	if err != nil {
 		t.Fatalf("Failed to drop replication slot: %v", err)
 	}
 
 	// We re-create to ensure the drop worked.
-	_, _, err = replicationConn.CreateReplicationSlot("pgx_slot_test", "test_decoding")
+	cp, snapshot_name, err = replicationConn.CreateReplicationSlotEx("pgx_slot_test", "test_decoding")
 	if err != nil {
 		t.Logf("replication slot create failed: %v", err)
+	}
+	if cp == "" {
+		t.Logf("consistent_point is empty")
+	}
+	if snapshot_name == "" {
+		t.Logf("snapshot_name is empty")
 	}
 
 	// And finally we drop to ensure we don't leave dirty state


### PR DESCRIPTION
When using logical replication, the snapshot name is needed to be able to do a full dump of the existing database when first setting up a replicated system.