### PR TITLE
Fix QueryRow() left over messages

### DIFF
--- a/query.go
+++ b/query.go
@@ -34,6 +34,8 @@ func (r *Row) Scan(dest ...interface{}) (err error) {
 	}
 
 	rows.Scan(dest...)
+	for rows.Next() {
+	}
 	rows.Close()
 	return rows.Err()
 }


### PR DESCRIPTION
Bug previously hidden be the use of ensureConnectionReadyForQuery.

QueryRow scan now properly read all messages including the last CommandComplete before closing.