### PR TITLE
Adds `go get github.com/pkg/errors` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ skip tests for connection types that are not configured.
 
 To setup the normal test environment, first install these dependencies:
 
+    go get github.com/pkg/errors
     go get github.com/jackc/fake
     go get github.com/shopspring/decimal
     go get gopkg.in/inconshreveable/log15.v2


### PR DESCRIPTION
Following the test setup instructions and then running `go test` results in

```
internal/sanitize/sanitize.go:11:2: cannot find package "github.com/pkg/errors"
```

This patch adds an instruction to the README.md for the user to `go get github.com/pkg/errors`.