### PR TITLE
Use logrus.FieldLogger instead of *logrus.Logger

### DIFF
--- a/log/logrusadapter/adapter.go
+++ b/log/logrusadapter/adapter.go
@@ -8,10 +8,10 @@ import (
 )
 
 type Logger struct {
-	l *logrus.Logger
+	l logrus.FieldLogger
 }
 
-func NewLogger(l *logrus.Logger) *Logger {
+func NewLogger(l logrus.FieldLogger) *Logger {
 	return &Logger{l: l}
 }
 


### PR DESCRIPTION
This allows supplying a logrus logger that already has fields configured