### PR TITLE
ConnPool begin should not retry if ctx is done

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -519,7 +519,7 @@ func (p *ConnPool) BeginEx(ctx context.Context, txOptions *TxOptions) (*Tx, erro
 			// again on a new connection would fix, so just return the error. But
 			// if the connection is dead try to acquire a new connection and try
 			// again.
-			if alive {
+			if alive || ctx.Err() != nil {
 				return nil, err
 			}
 			continue

--- a/conn_pool_test.go
+++ b/conn_pool_test.go
@@ -1066,3 +1066,18 @@ func TestConnPoolBeginBatch(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestConnPoolBeginEx(t *testing.T) {
+	t.Parallel()
+
+	pool := createConnPool(t, 2)
+	defer pool.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tx, err := pool.BeginEx(ctx, nil)
+	if err == nil || tx != nil {
+		t.Fatal("Should not be able to create a tx")
+	}
+}


### PR DESCRIPTION
bug fix, connpool.BeginEx deadlock if ctx is done