### PR TITLE
support query without prepared statements

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -74,6 +74,17 @@ type ConnConfig struct {
 	Dial              DialFunc
 	RuntimeParams     map[string]string // Run-time parameters to set on connection as session default values (e.g. search_path or application_name)
 	OnNotice          NoticeHandler     // Callback function called when a notice response is received.
+
+	// PreferSimpleProtocol disables implicit prepared statement usage. By default
+	// pgx automatically uses the unnamed prepared statement for Query and
+	// QueryRow. It also uses a prepared statement when Exec has arguments. This
+	// can improve performance due to being able to use the binary format. It also
+	// does not rely on client side parameter sanitization. However, it does incur
+	// two round-trips per query and may be incompatible proxies such as
+	// PGBouncer. Setting PreferSimpleProtocol causes the simple protocol to be
+	// used by default. The same functionality can be controlled on a per query
+	// basis by setting QueryExOptions.SimpleProtocol.
+	PreferSimpleProtocol bool
 }
 
 func (cc *ConnConfig) networkAddress() (network, address string) {
@@ -1566,7 +1577,7 @@ func (c *Conn) execEx(ctx context.Context, sql string, options *QueryExOptions, 
 		err = c.termContext(err)
 	}()
 
-	if options != nil && options.SimpleProtocol {
+	if (options == nil && c.config.PreferSimpleProtocol) || (options != nil && options.SimpleProtocol) {
 		err = c.sanitizeAndSendSimpleQuery(sql, arguments...)
 		if err != nil {
 			return "", err

--- a/conn.go
+++ b/conn.go
@@ -469,10 +469,12 @@ where t.typtype = 'b'
 	}
 
 	for name, oid := range nameOIDs {
+		v := &pgtype.EnumArray{}
 		c.ConnInfo.RegisterDataType(pgtype.DataType{
-			&pgtype.EnumArray{},
-			name,
-			oid,
+			Value:      v,
+			Name:       name,
+			OID:        oid,
+			FormatCode: pgtype.DetermineFormatCode(v),
 		})
 	}
 
@@ -942,11 +944,7 @@ func (c *Conn) prepareEx(name, sql string, opts *PrepareExOptions) (ps *Prepared
 			for i := range ps.FieldDescriptions {
 				if dt, ok := c.ConnInfo.DataTypeForOID(ps.FieldDescriptions[i].DataType); ok {
 					ps.FieldDescriptions[i].DataTypeName = dt.Name
-					if _, ok := dt.Value.(pgtype.BinaryDecoder); ok {
-						ps.FieldDescriptions[i].FormatCode = BinaryFormatCode
-					} else {
-						ps.FieldDescriptions[i].FormatCode = TextFormatCode
-					}
+					ps.FieldDescriptions[i].FormatCode = dt.FormatCode
 				} else {
 					return nil, errors.Errorf("unknown oid: %d", ps.FieldDescriptions[i].DataType)
 				}

--- a/conn_test.go
+++ b/conn_test.go
@@ -255,6 +255,31 @@ func TestConnectWithConnectionRefused(t *testing.T) {
 	}
 }
 
+func TestConnectWithPreferSimpleProtocol(t *testing.T) {
+	t.Parallel()
+
+	connConfig := *defaultConnConfig
+	connConfig.PreferSimpleProtocol = true
+
+	conn := mustConnect(t, connConfig)
+	defer closeConn(t, conn)
+
+	// If simple protocol is used we should be able to correctly scan the result
+	// into a pgtype.Text as the integer will have been encoded in text.
+
+	var s pgtype.Text
+	err := conn.QueryRow("select $1::int4", 42).Scan(&s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Get() != "42" {
+		t.Fatalf(`expected "42", got %v`, s)
+	}
+
+	ensureConnValid(t, conn)
+}
+
 func TestConnectCustomDialer(t *testing.T) {
 	t.Parallel()
 
@@ -1988,9 +2013,9 @@ func TestConnInitConnInfo(t *testing.T) {
 	// spot check that the standard postgres type names aren't qualified
 	nameOIDs := map[string]pgtype.OID{
 		"_int8": pgtype.Int8ArrayOID,
-		"int8": pgtype.Int8OID,
-		"json": pgtype.JSONOID,
-		"text": pgtype.TextOID,
+		"int8":  pgtype.Int8OID,
+		"json":  pgtype.JSONOID,
+		"text":  pgtype.TextOID,
 	}
 	for name, oid := range nameOIDs {
 		dtByName, ok := conn.ConnInfo.DataTypeForName(name)

--- a/query.go
+++ b/query.go
@@ -393,7 +393,7 @@ func (c *Conn) QueryEx(ctx context.Context, sql string, options *QueryExOptions,
 		return rows, rows.err
 	}
 
-	if options != nil && options.SimpleProtocol {
+	if (options == nil && c.config.PreferSimpleProtocol) || (options != nil && options.SimpleProtocol) {
 		err = c.sanitizeAndSendSimpleQuery(sql, args...)
 		if err != nil {
 			rows.fatal(err)

--- a/query.go
+++ b/query.go
@@ -134,7 +134,7 @@ func (rows *Rows) Next() bool {
 			for i := range rows.fields {
 				if dt, ok := rows.conn.ConnInfo.DataTypeForOID(rows.fields[i].DataType); ok {
 					rows.fields[i].DataTypeName = dt.Name
-					rows.fields[i].FormatCode = TextFormatCode
+					rows.fields[i].FormatCode = dt.FormatCode
 				} else {
 					rows.fatal(errors.Errorf("unknown oid: %d", rows.fields[i].DataType))
 					return false
@@ -367,6 +367,9 @@ type QueryExOptions struct {
 }
 
 func (c *Conn) QueryEx(ctx context.Context, sql string, options *QueryExOptions, args ...interface{}) (rows *Rows, err error) {
+	var (
+		fieldDescriptions []FieldDescription
+	)
 	c.lastActivityTime = time.Now()
 	rows = c.getRows(sql, args)
 
@@ -376,12 +379,12 @@ func (c *Conn) QueryEx(ctx context.Context, sql string, options *QueryExOptions,
 		return rows, err
 	}
 
-	if err := c.ensureConnectionReadyForQuery(); err != nil {
+	if err = c.ensureConnectionReadyForQuery(); err != nil {
 		rows.fatal(err)
 		return rows, err
 	}
 
-	if err := c.lock(); err != nil {
+	if err = c.lock(); err != nil {
 		rows.fatal(err)
 		return rows, err
 	}
@@ -394,12 +397,18 @@ func (c *Conn) QueryEx(ctx context.Context, sql string, options *QueryExOptions,
 	}
 
 	if (options == nil && c.config.PreferSimpleProtocol) || (options != nil && options.SimpleProtocol) {
-		err = c.sanitizeAndSendSimpleQuery(sql, args...)
-		if err != nil {
+		if err = c.sanitizeAndSendSimpleQuery(sql, args...); err != nil {
 			rows.fatal(err)
 			return rows, err
 		}
 
+		if fieldDescriptions, err = c.readFieldDescriptions(QueryExOptions{}); err != nil {
+			rows.fatal(err)
+			return rows, err
+		}
+
+		rows.sql = sql
+		rows.fields = fieldDescriptions
 		return rows, nil
 	}
 
@@ -421,25 +430,9 @@ func (c *Conn) QueryEx(ctx context.Context, sql string, options *QueryExOptions,
 		}
 		c.pendingReadyForQueryCount++
 
-		fieldDescriptions, err := c.readUntilRowDescription()
-		if err != nil {
+		if fieldDescriptions, err = c.readFieldDescriptions(*options); err != nil {
 			rows.fatal(err)
 			return rows, err
-		}
-
-		if len(options.ResultFormatCodes) == 0 {
-			for i := range fieldDescriptions {
-				fieldDescriptions[i].FormatCode = TextFormatCode
-			}
-		} else if len(options.ResultFormatCodes) == 1 {
-			fc := options.ResultFormatCodes[0]
-			for i := range fieldDescriptions {
-				fieldDescriptions[i].FormatCode = fc
-			}
-		} else {
-			for i := range options.ResultFormatCodes {
-				fieldDescriptions[i].FormatCode = options.ResultFormatCodes[i]
-			}
 		}
 
 		rows.sql = sql
@@ -449,7 +442,6 @@ func (c *Conn) QueryEx(ctx context.Context, sql string, options *QueryExOptions,
 
 	ps, ok := c.preparedStatements[sql]
 	if !ok {
-		var err error
 		ps, err = c.prepareEx("", sql, nil)
 		if err != nil {
 			rows.fatal(err)
@@ -542,4 +534,28 @@ func (c *Conn) sanitizeAndSendSimpleQuery(sql string, args ...interface{}) (err 
 func (c *Conn) QueryRowEx(ctx context.Context, sql string, options *QueryExOptions, args ...interface{}) *Row {
 	rows, _ := c.QueryEx(ctx, sql, options, args...)
 	return (*Row)(rows)
+}
+
+func (c *Conn) readFieldDescriptions(options QueryExOptions) (fieldDescriptions []FieldDescription, err error) {
+	if fieldDescriptions, err = c.readUntilRowDescription(); err != nil {
+		return fieldDescriptions, err
+	}
+
+	switch len(options.ResultFormatCodes) {
+	case 0:
+		for i := range fieldDescriptions {
+			fieldDescriptions[i].FormatCode = TextFormatCode
+		}
+	case 1:
+		fc := options.ResultFormatCodes[0]
+		for i := range fieldDescriptions {
+			fieldDescriptions[i].FormatCode = fc
+		}
+	default:
+		for i := range options.ResultFormatCodes {
+			fieldDescriptions[i].FormatCode = options.ResultFormatCodes[i]
+		}
+	}
+
+	return fieldDescriptions, err
 }

--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -85,10 +85,6 @@ import (
 	"github.com/jackc/pgx/pgtype"
 )
 
-// oids that map to intrinsic database/sql types. These will be allowed to be
-// binary, anything else will be forced to text format
-var databaseSqlOIDs map[pgtype.OID]bool
-
 var pgxDriver *Driver
 
 type ctxKey int
@@ -97,27 +93,30 @@ var ctxKeyFakeTx ctxKey = 0
 
 var ErrNotPgx = errors.New("not pgx *sql.DB")
 
+// oids that map to intrinsic database/sql types. These will be allowed to be
+// binary, anything else will be forced to text format
+var allowedBinaryOID = []pgtype.OID{
+	pgtype.BoolOID,
+	pgtype.ByteaOID,
+	pgtype.CIDOID,
+	pgtype.DateOID,
+	pgtype.Float4OID,
+	pgtype.Float8OID,
+	pgtype.Int2OID,
+	pgtype.Int4OID,
+	pgtype.Int8OID,
+	pgtype.OIDOID,
+	pgtype.TimestampOID,
+	pgtype.TimestamptzOID,
+	pgtype.XIDOID,
+}
+
 func init() {
 	pgxDriver = &Driver{
 		configs:     make(map[int64]*DriverConfig),
 		fakeTxConns: make(map[*pgx.Conn]*sql.Tx),
 	}
 	sql.Register("pgx", pgxDriver)
-
-	databaseSqlOIDs = make(map[pgtype.OID]bool)
-	databaseSqlOIDs[pgtype.BoolOID] = true
-	databaseSqlOIDs[pgtype.ByteaOID] = true
-	databaseSqlOIDs[pgtype.CIDOID] = true
-	databaseSqlOIDs[pgtype.DateOID] = true
-	databaseSqlOIDs[pgtype.Float4OID] = true
-	databaseSqlOIDs[pgtype.Float8OID] = true
-	databaseSqlOIDs[pgtype.Int2OID] = true
-	databaseSqlOIDs[pgtype.Int4OID] = true
-	databaseSqlOIDs[pgtype.Int8OID] = true
-	databaseSqlOIDs[pgtype.OIDOID] = true
-	databaseSqlOIDs[pgtype.TimestampOID] = true
-	databaseSqlOIDs[pgtype.TimestamptzOID] = true
-	databaseSqlOIDs[pgtype.XIDOID] = true
 }
 
 type Driver struct {
@@ -130,8 +129,11 @@ type Driver struct {
 }
 
 func (d *Driver) Open(name string) (driver.Conn, error) {
-	var connConfig pgx.ConnConfig
-	var afterConnect func(*pgx.Conn) error
+	var (
+		afterConnect func(*pgx.Conn) error
+		connConfig   pgx.ConnConfig
+	)
+
 	if len(name) >= 9 && name[0] == 0 {
 		idBuf := []byte(name)[1:9]
 		id := int64(binary.BigEndian.Uint64(idBuf))
@@ -150,6 +152,8 @@ func (d *Driver) Open(name string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	conn.ConnInfo = restrictBinary(conn.ConnInfo)
 
 	if afterConnect != nil {
 		err = afterConnect(conn)
@@ -232,8 +236,6 @@ func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 		return nil, err
 	}
 
-	restrictBinaryToDatabaseSqlTypes(ps)
-
 	return &Stmt{ps: ps, conn: c}, nil
 }
 
@@ -299,33 +301,28 @@ func (c *Conn) ExecContext(ctx context.Context, query string, argsV []driver.Nam
 }
 
 func (c *Conn) Query(query string, argsV []driver.Value) (driver.Rows, error) {
-	if !c.conn.IsAlive() {
-		return nil, driver.ErrBadConn
-	}
-
-	ps, err := c.conn.Prepare("", query)
-	if err != nil {
-		return nil, err
-	}
-
-	restrictBinaryToDatabaseSqlTypes(ps)
-
-	return c.queryPrepared("", argsV)
+	return c.query(context.Background(), query, valueToInterface(argsV))
 }
 
 func (c *Conn) QueryContext(ctx context.Context, query string, argsV []driver.NamedValue) (driver.Rows, error) {
+	return c.query(ctx, query, namedValueToInterface(argsV))
+}
+
+func (c *Conn) query(ctx context.Context, query string, args []interface{}) (driver.Rows, error) {
+	var (
+		err  error
+		rows *pgx.Rows
+	)
+
 	if !c.conn.IsAlive() {
 		return nil, driver.ErrBadConn
 	}
 
-	ps, err := c.conn.PrepareEx(ctx, "", query, nil)
-	if err != nil {
+	if rows, err = c.conn.QueryEx(ctx, query, nil, args...); err != nil {
 		return nil, err
 	}
 
-	restrictBinaryToDatabaseSqlTypes(ps)
-
-	return c.queryPreparedContext(ctx, "", argsV)
+	return &Rows{rows: rows}, nil
 }
 
 func (c *Conn) queryPrepared(name string, argsV []driver.Value) (driver.Rows, error) {
@@ -369,13 +366,26 @@ func (c *Conn) Ping(ctx context.Context) error {
 // Anything that isn't a database/sql compatible type needs to be forced to
 // text format so that pgx.Rows.Values doesn't decode it into a native type
 // (e.g. []int32)
-func restrictBinaryToDatabaseSqlTypes(ps *pgx.PreparedStatement) {
-	for i, _ := range ps.FieldDescriptions {
-		intrinsic, _ := databaseSqlOIDs[ps.FieldDescriptions[i].DataType]
-		if !intrinsic {
-			ps.FieldDescriptions[i].FormatCode = pgx.TextFormatCode
+func restrictBinary(in *pgtype.ConnInfo) (out *pgtype.ConnInfo) {
+	out = in.DeepCopy()
+	for oid, dt := range out.DataTypes() {
+		if textOID(oid) {
+			dt.FormatCode = pgx.TextFormatCode
+			out.RegisterDataType(dt)
 		}
 	}
+
+	return out
+}
+
+func textOID(oid pgtype.OID) bool {
+	for _, roid := range allowedBinaryOID {
+		if roid == oid {
+			return false
+		}
+	}
+
+	return true
 }
 
 type Stmt struct {


### PR DESCRIPTION
allows querying without prepared statements from stdlib driver.

minimal PR. work extracted from #359 