### PR TITLE
Postgres 9.2 is not supported since September 2017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - PGVERSION=9.5
     - PGVERSION=9.4
     - PGVERSION=9.3
-    - PGVERSION=9.2
 
 before_script:
   - ./travis/before_script.bash


### PR DESCRIPTION
Postgres 9.2 has reached the end of its life, so don't skip testing compatibility for it.

See: https://www.postgresql.org/support/versioning/