### PR TITLE
Make TLS parsing compatible with lib/pq...

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -703,43 +703,15 @@ func ParseURI(uri string) (ConnConfig, error) {
 		cp.Dial = d.Dial
 	}
 
-	err = configTLS(url.Query().Get("sslmode"), &cp)
+	tlsArgs := configTLSArgs{
+		sslCert:     url.Query().Get("sslcert"),
+		sslKey:      url.Query().Get("sslkey"),
+		sslMode:     url.Query().Get("sslmode"),
+		sslRootCert: url.Query().Get("sslrootcert"),
+	}
+	err = configTLS(tlsArgs, &cp)
 	if err != nil {
 		return cp, err
-	}
-
-	// Extract optional TLS parameters and reconstruct a coherent tls.Config based
-	// on the DSN input.  Reuse the same keywords found in github.com/lib/pq.
-	if cp.TLSConfig != nil {
-		{
-			caCertPool := x509.NewCertPool()
-
-			caPath := url.Query().Get("sslrootcert")
-			caCert, err := ioutil.ReadFile(caPath)
-			if err != nil {
-				return cp, errors.Wrapf(err, "unable to read CA file %q", caPath)
-			}
-
-			if !caCertPool.AppendCertsFromPEM(caCert) {
-				return cp, errors.Wrap(err, "unable to add CA to cert pool")
-			}
-
-			cp.TLSConfig.RootCAs = caCertPool
-			cp.TLSConfig.ClientCAs = caCertPool
-		}
-
-		sslcert := url.Query().Get("sslcert")
-		sslkey := url.Query().Get("sslkey")
-		if (sslcert != "" && sslkey == "") || (sslcert == "" && sslkey != "") {
-			return cp, fmt.Errorf(`both "sslcert" and "sslkey" are required`)
-		}
-
-		cert, err := tls.LoadX509KeyPair(sslcert, sslkey)
-		if err != nil {
-			return cp, errors.Wrap(err, "unable to read cert")
-		}
-
-		cp.TLSConfig.Certificates = []tls.Certificate{cert}
 	}
 
 	ignoreKeys := map[string]struct{}{
@@ -783,7 +755,7 @@ func ParseDSN(s string) (ConnConfig, error) {
 
 	m := dsnRegexp.FindAllStringSubmatch(s, -1)
 
-	var sslmode string
+	tlsArgs := configTLSArgs{}
 
 	cp.RuntimeParams = make(map[string]string)
 
@@ -804,7 +776,13 @@ func ParseDSN(s string) (ConnConfig, error) {
 		case "dbname":
 			cp.Database = b[2]
 		case "sslmode":
-			sslmode = b[2]
+			tlsArgs.sslMode = b[2]
+		case "sslrootcert":
+			tlsArgs.sslRootCert = b[2]
+		case "sslcert":
+			tlsArgs.sslCert = b[2]
+		case "sslkey":
+			tlsArgs.sslKey = b[2]
 		case "connect_timeout":
 			timeout, err := strconv.ParseInt(b[2], 10, 64)
 			if err != nil {
@@ -818,7 +796,7 @@ func ParseDSN(s string) (ConnConfig, error) {
 		}
 	}
 
-	err := configTLS(sslmode, &cp)
+	err := configTLS(tlsArgs, &cp)
 	if err != nil {
 		return cp, err
 	}
@@ -898,7 +876,7 @@ func ParseEnvLibpq() (ConnConfig, error) {
 
 	sslmode := os.Getenv("PGSSLMODE")
 
-	err := configTLS(sslmode, &cc)
+	err := configTLS(configTLSArgs{sslMode: sslmode}, &cc)
 	if err != nil {
 		return cc, err
 	}
@@ -913,14 +891,27 @@ func ParseEnvLibpq() (ConnConfig, error) {
 	return cc, nil
 }
 
-func configTLS(sslmode string, cc *ConnConfig) error {
+type configTLSArgs struct {
+	sslMode     string
+	sslRootCert string
+	sslCert     string
+	sslKey      string
+}
+
+// configTLS uses lib/pq's TLS parameters to reconstruct a coherent tls.Config.
+// Inputs are parsed out and provided by ParseDSN() or ParseURI().
+func configTLS(args configTLSArgs, cc *ConnConfig) error {
 	// Match libpq default behavior
-	if sslmode == "" {
-		sslmode = "prefer"
+	if args.sslMode == "" {
+		args.sslMode = "prefer"
 	}
 
-	switch sslmode {
+	switch args.sslMode {
 	case "disable":
+		cc.UseFallbackTLS = false
+		cc.TLSConfig = nil
+		cc.FallbackTLSConfig = nil
+		return nil
 	case "allow":
 		cc.UseFallbackTLS = true
 		cc.FallbackTLSConfig = &tls.Config{InsecureSkipVerify: true}
@@ -937,6 +928,37 @@ func configTLS(sslmode string, cc *ConnConfig) error {
 	default:
 		return errors.New("sslmode is invalid")
 	}
+
+	{
+		caCertPool := x509.NewCertPool()
+
+		caPath := args.sslRootCert
+		caCert, err := ioutil.ReadFile(caPath)
+		if err != nil {
+			return errors.Wrapf(err, "unable to read CA file %q", caPath)
+		}
+
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return errors.Wrap(err, "unable to add CA to cert pool")
+		}
+
+		cc.TLSConfig.RootCAs = caCertPool
+		cc.TLSConfig.ClientCAs = caCertPool
+	}
+
+	sslcert := args.sslCert
+	sslkey := args.sslKey
+
+	if (sslcert != "" && sslkey == "") || (sslcert == "" && sslkey != "") {
+		return fmt.Errorf(`both "sslcert" and "sslkey" are required`)
+	}
+
+	cert, err := tls.LoadX509KeyPair(sslcert, sslkey)
+	if err != nil {
+		return errors.Wrap(err, "unable to read cert")
+	}
+
+	cc.TLSConfig.Certificates = []tls.Certificate{cert}
 
 	return nil
 }

--- a/conn.go
+++ b/conn.go
@@ -953,12 +953,14 @@ func configTLS(args configTLSArgs, cc *ConnConfig) error {
 		return fmt.Errorf(`both "sslcert" and "sslkey" are required`)
 	}
 
-	cert, err := tls.LoadX509KeyPair(sslcert, sslkey)
-	if err != nil {
-		return errors.Wrap(err, "unable to read cert")
-	}
+	if sslcert != "" && sslkey != "" {
+		cert, err := tls.LoadX509KeyPair(sslcert, sslkey)
+		if err != nil {
+			return errors.Wrap(err, "unable to read cert")
+		}
 
-	cc.TLSConfig.Certificates = []tls.Certificate{cert}
+		cc.TLSConfig.Certificates = []tls.Certificate{cert}
+	}
 
 	return nil
 }

--- a/conn.go
+++ b/conn.go
@@ -929,7 +929,7 @@ func configTLS(args configTLSArgs, cc *ConnConfig) error {
 		return errors.New("sslmode is invalid")
 	}
 
-	{
+	if args.sslRootCert != "" {
 		caCertPool := x509.NewCertPool()
 
 		caPath := args.sslRootCert

--- a/conn.go
+++ b/conn.go
@@ -701,7 +701,7 @@ func ParseURI(uri string) (ConnConfig, error) {
 		cp.Dial = d.Dial
 	}
 
-	err = configSSL(url.Query().Get("sslmode"), &cp)
+	err = configTLS(url.Query().Get("sslmode"), &cp)
 	if err != nil {
 		return cp, err
 	}
@@ -779,7 +779,7 @@ func ParseDSN(s string) (ConnConfig, error) {
 		}
 	}
 
-	err := configSSL(sslmode, &cp)
+	err := configTLS(sslmode, &cp)
 	if err != nil {
 		return cp, err
 	}
@@ -859,7 +859,7 @@ func ParseEnvLibpq() (ConnConfig, error) {
 
 	sslmode := os.Getenv("PGSSLMODE")
 
-	err := configSSL(sslmode, &cc)
+	err := configTLS(sslmode, &cc)
 	if err != nil {
 		return cc, err
 	}
@@ -874,7 +874,7 @@ func ParseEnvLibpq() (ConnConfig, error) {
 	return cc, nil
 }
 
-func configSSL(sslmode string, cc *ConnConfig) error {
+func configTLS(sslmode string, cc *ConnConfig) error {
 	// Match libpq default behavior
 	if sslmode == "" {
 		sslmode = "prefer"

--- a/conn_config_test.go.example
+++ b/conn_config_test.go.example
@@ -1,7 +1,14 @@
 package pgx_test
 
 import (
-  "github.com/jackc/pgx"
+	// "crypto/tls"
+	// "crypto/x509"
+	// "fmt"
+	// "go/build"
+	// "io/ioutil"
+	// "path"
+
+	"github.com/jackc/pgx"
 )
 
 var defaultConnConfig *pgx.ConnConfig = &pgx.ConnConfig{Host: "127.0.0.1", User: "pgx_md5", Password: "secret", Database: "pgx_test"}
@@ -22,7 +29,51 @@ var cratedbConnConfig *pgx.ConnConfig = nil
 // var md5ConnConfig *pgx.ConnConfig = &pgx.ConnConfig{Host: "127.0.0.1", User: "pgx_md5", Password: "secret", Database: "pgx_test"}
 // var plainPasswordConnConfig *pgx.ConnConfig = &pgx.ConnConfig{Host: "127.0.0.1", User: "pgx_pw", Password: "secret", Database: "pgx_test"}
 // var invalidUserConnConfig *pgx.ConnConfig = &pgx.ConnConfig{Host: "127.0.0.1", User: "invalid", Database: "pgx_test"}
-// var tlsConnConfig *pgx.ConnConfig = &pgx.ConnConfig{Host: "127.0.0.1", User: "pgx_md5", Password: "secret", Database: "pgx_test", TLSConfig: &tls.Config{InsecureSkipVerify: true}}
 // var customDialerConnConfig *pgx.ConnConfig = &pgx.ConnConfig{Host: "127.0.0.1", User: "pgx_md5", Password: "secret", Database: "pgx_test"}
 // var replicationConnConfig *pgx.ConnConfig = &pgx.ConnConfig{Host: "127.0.0.1", User: "pgx_replication", Password: "secret", Database: "pgx_test"}
 
+// var tlsConnConfig *pgx.ConnConfig = &pgx.ConnConfig{Host: "127.0.0.1", User: "pgx_md5", Password: "secret", Database: "pgx_test", TLSConfig: &tls.Config{InsecureSkipVerify: true}}
+//
+//// or to test client certs:
+//
+// var tlsConnConfig *pgx.ConnConfig
+//
+// func init() {
+// 	homeDir := build.Default.GOPATH
+// 	tlsConnConfig = &pgx.ConnConfig{
+// 		Host:     "127.0.0.1",
+// 		User:     "pgx_md5",
+// 		Password: "secret",
+// 		Database: "pgx_test",
+// 		TLSConfig: &tls.Config{
+// 			InsecureSkipVerify: true,
+// 		},
+// 	}
+// 	caCertPool := x509.NewCertPool()
+//
+// 	caPath := path.Join(homeDir, "/src/github.com/jackc/pgx/rootCA.pem")
+// 	caCert, err := ioutil.ReadFile(caPath)
+// 	if err != nil {
+// 		panic(fmt.Sprintf("unable to read CA file: %v", err))
+// 	}
+//
+// 	if !caCertPool.AppendCertsFromPEM(caCert) {
+// 		panic("unable to add CA to cert pool")
+// 	}
+//
+// 	tlsConnConfig.TLSConfig.RootCAs = caCertPool
+// 	tlsConnConfig.TLSConfig.ClientCAs = caCertPool
+//
+// 	sslCert := path.Join(homeDir, "/src/github.com/jackc/pgx/pg_md5.crt")
+// 	sslKey := path.Join(homeDir, "/src/github.com/jackc/pgx/pg_md5.key")
+// 	if (sslCert != "" && sslKey == "") || (sslCert == "" && sslKey != "") {
+// 		panic(`both "sslcert" and "sslkey" are required`)
+// 	}
+//
+// 	cert, err := tls.LoadX509KeyPair(sslCert, sslKey)
+// 	if err != nil {
+// 		panic(fmt.Sprintf("unable to read cert: %v", err))
+// 	}
+//
+// 	tlsConnConfig.TLSConfig.Certificates = []tls.Certificate{cert}
+// }

--- a/conn_test.go
+++ b/conn_test.go
@@ -228,7 +228,8 @@ func TestConnectWithTLSFallback(t *testing.T) {
 	}
 
 	connConfig.UseFallbackTLS = true
-	connConfig.FallbackTLSConfig = &tls.Config{InsecureSkipVerify: true}
+	connConfig.FallbackTLSConfig = tlsConnConfig.TLSConfig
+	connConfig.FallbackTLSConfig.InsecureSkipVerify = true
 
 	conn, err = pgx.Connect(connConfig)
 	if err != nil {


### PR DESCRIPTION
This PR fixes this so that `jackc/pgx` can be used by `database/sql` for TLS-enabled PostgreSQL servers (either PostgreSQL or CockroachDB).

Previously `stdlib.DriverConfig().ConnectionString()` would fail to use any of `lib/pq`'s TLS parameters in either a DSN or URI, rendering the `stdlib` shim useless for TLS workloads (note: `jackc/pgx` worked for TLS-enabled servers, just not the `stdlib` shim).

See `conn_config_test.go.example` for the example to test the new `sslrootcert`, `sslcert`, and `sslkey` keywords for PostgreSQL DSNs and URIs (these keywords are the same as [lib/pq](https://github.com/lib/pq/blob/88edab0803230a3898347e77b474f8c1820a1f20/conn.go#L1067)).