### PR TITLE
Parse URI-encoded connection strings as URIs.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -792,7 +792,7 @@ func ParseDSN(s string) (ConnConfig, error) {
 // ParseConnectionString parses either a URI or a DSN connection string.
 // see ParseURI and ParseDSN for details.
 func ParseConnectionString(s string) (ConnConfig, error) {
-	if strings.HasPrefix(s, "postgres://") || strings.HasPrefix(s, "postgresql://") {
+	if u, err := url.Parse(s); err == nil && u.Scheme != "" {
 		return ParseURI(s)
 	}
 	return ParseDSN(s)


### PR DESCRIPTION
CockroachDB is frequently referenced as: `cockroachdb://` as its
scheme.  Be scheme name agnostic.