### PR TITLE
implement json.(Un)Marshaler for primary type

### DIFF
--- a/pgtype/bool.go
+++ b/pgtype/bool.go
@@ -2,6 +2,7 @@ package pgtype
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -156,4 +157,29 @@ func (src *Bool) Value() (driver.Value, error) {
 	default:
 		return nil, errUndefined
 	}
+}
+
+func (src *Bool) MarshalJSON() ([]byte, error) {
+	switch src.Status {
+	case Present:
+		if src.Bool {
+			return []byte("true"), nil
+		}
+		return []byte("false"), nil
+	case Null:
+		return []byte("null"), nil
+	default:
+		return nil, errUndefined
+	}
+}
+
+func (dst *Bool) UnmarshalJSON(data []byte) error {
+	var b bool
+	err := json.Unmarshal(data, &b)
+	if err != nil {
+		return err
+	}
+
+	*dst = Bool{Bool: b, Status: Present}
+	return nil
 }

--- a/pgtype/bytea.go
+++ b/pgtype/bytea.go
@@ -154,3 +154,25 @@ func (src *Bytea) Value() (driver.Value, error) {
 		return nil, errUndefined
 	}
 }
+
+func (src *Bytea) MarshalJSON() ([]byte, error) {
+	switch src.Status {
+	case Present:
+		return src.Bytes, nil
+	case Null:
+		return nil, nil
+	default:
+		return nil, errUndefined
+	}
+}
+
+func (dst *Bytea) UnmarshalJSON(b []byte) error {
+	if b == nil {
+		dst.Status = Null
+		return nil
+	}
+
+	dst.Bytes = b
+	dst.Status = Present
+	return nil
+}

--- a/pgtype/bytea.go
+++ b/pgtype/bytea.go
@@ -154,25 +154,3 @@ func (src *Bytea) Value() (driver.Value, error) {
 		return nil, errUndefined
 	}
 }
-
-func (src *Bytea) MarshalJSON() ([]byte, error) {
-	switch src.Status {
-	case Present:
-		return src.Bytes, nil
-	case Null:
-		return nil, nil
-	default:
-		return nil, errUndefined
-	}
-}
-
-func (dst *Bytea) UnmarshalJSON(b []byte) error {
-	if b == nil {
-		dst.Status = Null
-		return nil
-	}
-
-	dst.Bytes = b
-	dst.Status = Present
-	return nil
-}

--- a/pgtype/float4.go
+++ b/pgtype/float4.go
@@ -3,6 +3,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"encoding/json"
 	"math"
 	"strconv"
 
@@ -194,4 +195,28 @@ func (src *Float4) Value() (driver.Value, error) {
 	default:
 		return nil, errUndefined
 	}
+}
+
+func (src *Float4) MarshalJSON() ([]byte, error) {
+	switch src.Status {
+	case Present:
+		buf := make([]byte, 4)
+		binary.BigEndian.PutUint32(buf, math.Float32bits(src.Float))
+		return buf, nil
+	case Null:
+		return nil, nil
+	default:
+		return nil, errUndefined
+	}
+}
+
+func (dst *Float4) UnmarshalJSON(b []byte) error {
+	var f float32
+	err := json.Unmarshal(b, &f)
+	if err != nil {
+		return err
+	}
+
+	*dst = Float4{Float: f, Status: Present}
+	return nil
 }

--- a/pgtype/float8.go
+++ b/pgtype/float8.go
@@ -3,6 +3,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"encoding/json"
 	"math"
 	"strconv"
 
@@ -184,4 +185,28 @@ func (src *Float8) Value() (driver.Value, error) {
 	default:
 		return nil, errUndefined
 	}
+}
+
+func (src *Float8) MarshalJSON() ([]byte, error) {
+	switch src.Status {
+	case Present:
+		buf := make([]byte, 8)
+		binary.BigEndian.PutUint64(buf, math.Float64bits(src.Float))
+		return buf, nil
+	case Null:
+		return nil, nil
+	default:
+		return nil, errUndefined
+	}
+}
+
+func (dst *Float8) UnmarshalJSON(b []byte) error {
+	var f float64
+	err := json.Unmarshal(b, &f)
+	if err != nil {
+		return err
+	}
+
+	*dst = Float8{Float: f, Status: Present}
+	return nil
 }

--- a/pgtype/int2.go
+++ b/pgtype/int2.go
@@ -3,6 +3,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"encoding/json"
 	"math"
 	"strconv"
 
@@ -206,4 +207,16 @@ func (src *Int2) MarshalJSON() ([]byte, error) {
 	}
 
 	return nil, errBadStatus
+}
+
+func (dst *Int2) UnmarshalJSON(b []byte) error {
+	var n int16
+	err := json.Unmarshal(b, &n)
+	if err != nil {
+		return err
+	}
+
+	*dst = Int2{Int: n, Status: Present}
+
+	return nil
 }

--- a/pgtype/json.go
+++ b/pgtype/json.go
@@ -159,3 +159,25 @@ func (src *JSON) Value() (driver.Value, error) {
 		return nil, errUndefined
 	}
 }
+
+func (src *JSON) MarshalJSON() ([]byte, error) {
+	switch src.Status {
+	case Present:
+		return src.Bytes, nil
+	case Null:
+		return nil, nil
+	default:
+		return nil, errUndefined
+	}
+}
+
+func (dst *JSON) UnmarshalJSON(b []byte) error {
+	if b == nil {
+		dst.Status = Null
+		return nil
+	}
+
+	dst.Bytes = b
+	dst.Status = Present
+	return nil
+}

--- a/pgtype/json.go
+++ b/pgtype/json.go
@@ -173,11 +173,10 @@ func (src *JSON) MarshalJSON() ([]byte, error) {
 
 func (dst *JSON) UnmarshalJSON(b []byte) error {
 	if b == nil {
-		dst.Status = Null
+		*dst = JSON{Status: Null}
 		return nil
 	}
 
-	dst.Bytes = b
-	dst.Status = Present
+	*dst = JSON{Bytes: b, Status: Present}
 	return nil
 }

--- a/pgtype/jsonb.go
+++ b/pgtype/jsonb.go
@@ -68,3 +68,11 @@ func (dst *JSONB) Scan(src interface{}) error {
 func (src *JSONB) Value() (driver.Value, error) {
 	return (*JSON)(src).Value()
 }
+
+func (src *JSONB) MarshalJSON() ([]byte, error) {
+	return (*JSON)(src).MarshalJSON()
+}
+
+func (dst *JSONB) UnmarshalJSON(b []byte) error {
+	return (*JSON)(dst).UnmarshalJSON(b)
+}


### PR DESCRIPTION
I think json is very popular in go, so if the primary type implement the json.(Un)Marshaler, it will very convenient to Marshal or Unmarshal without writting a lot code to make it. I did not know the array type, could you implement them?