### PR TITLE
uint should be parsed using strconv.ParseUint

### DIFF
--- a/pgtype/pgtype_test.go
+++ b/pgtype/pgtype_test.go
@@ -12,6 +12,7 @@ import (
 type _string string
 type _bool bool
 type _int8 int8
+type _uint8 uint8
 type _int16 int16
 type _int16Slice []int16
 type _int32Slice []int32

--- a/pgtype/typed_array_gen.sh
+++ b/pgtype/typed_array_gen.sh
@@ -1,6 +1,7 @@
 erb pgtype_array_type=Int2Array pgtype_element_type=Int2 go_array_types=[]int16,[]uint16 element_type_name=int2 text_null=NULL binary_format=true typed_array.go.erb > int2_array.go
 erb pgtype_array_type=Int4Array pgtype_element_type=Int4 go_array_types=[]int32,[]uint32 element_type_name=int4 text_null=NULL binary_format=true typed_array.go.erb > int4_array.go
 erb pgtype_array_type=Int8Array pgtype_element_type=Int8 go_array_types=[]int64,[]uint64 element_type_name=int8 text_null=NULL binary_format=true typed_array.go.erb > int8_array.go
+erb pgtype_array_type=Uint8Array pgtype_element_type=Uint8 go_array_types=[]int64,[]uint64 element_type_name=uint8 text_null=NULL binary_format=true typed_array.go.erb > uint8_array.go
 erb pgtype_array_type=BoolArray pgtype_element_type=Bool go_array_types=[]bool element_type_name=bool text_null=NULL binary_format=true typed_array.go.erb > bool_array.go
 erb pgtype_array_type=DateArray pgtype_element_type=Date go_array_types=[]time.Time element_type_name=date text_null=NULL binary_format=true typed_array.go.erb > date_array.go
 erb pgtype_array_type=TimestamptzArray pgtype_element_type=Timestamptz go_array_types=[]time.Time element_type_name=timestamptz text_null=NULL binary_format=true typed_array.go.erb > timestamptz_array.go

--- a/pgtype/uint8.go
+++ b/pgtype/uint8.go
@@ -1,0 +1,208 @@
+package pgtype
+
+import (
+	"database/sql/driver"
+	"encoding/binary"
+	"encoding/json"
+	"math"
+	"strconv"
+
+	"github.com/jackc/pgx/pgio"
+	"github.com/pkg/errors"
+)
+
+type Uint8 struct {
+	Uint   uint64
+	Status Status
+}
+
+func (dst *Uint8) Set(src interface{}) error {
+	if src == nil {
+		*dst = Uint8{Status: Null}
+		return nil
+	}
+
+	switch value := src.(type) {
+	case int8:
+		if value < 0 {
+			return errors.Errorf("%d is less than zero for Uint8", value)
+		}
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case uint8:
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case int16:
+		if value < 0 {
+			return errors.Errorf("%d is less than zero for Uint8", value)
+		}
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case uint16:
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case int32:
+		if value < 0 {
+			return errors.Errorf("%d is less than zero for Uint8", value)
+		}
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case uint32:
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case int64:
+		if value < 0 {
+			return errors.Errorf("%d is less than zero for Uint8", value)
+		}
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case uint64:
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case int:
+		if value < 0 {
+			return errors.Errorf("%d is less than zero for Uint8", value)
+		}
+		if uint64(value) > math.MaxUint64 {
+			return errors.Errorf("%d is greater than maximum value for Uint8", value)
+		}
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case uint:
+		if uint64(value) > math.MaxUint64 {
+			return errors.Errorf("%d is greater than maximum value for Uint8", value)
+		}
+		*dst = Uint8{Uint: uint64(value), Status: Present}
+	case string:
+		num, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return err
+		}
+		*dst = Uint8{Uint: num, Status: Present}
+	default:
+		if originalSrc, ok := underlyingNumberType(src); ok {
+			return dst.Set(originalSrc)
+		}
+		return errors.Errorf("cannot convert %v to Uint8", value)
+	}
+
+	return nil
+}
+
+func (dst *Uint8) Get() interface{} {
+	switch dst.Status {
+	case Present:
+		return dst.Uint
+	case Null:
+		return nil
+	default:
+		return dst.Status
+	}
+}
+
+func (src *Uint8) AssignTo(dst interface{}) error {
+	return uint64AssignTo(src.Uint, src.Status, dst)
+}
+
+func (dst *Uint8) DecodeText(ci *ConnInfo, src []byte) error {
+	if src == nil {
+		*dst = Uint8{Status: Null}
+		return nil
+	}
+
+	n, err := strconv.ParseUint(string(src), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*dst = Uint8{Uint: n, Status: Present}
+	return nil
+}
+
+func (dst *Uint8) DecodeBinary(ci *ConnInfo, src []byte) error {
+	if src == nil {
+		*dst = Uint8{Status: Null}
+		return nil
+	}
+
+	if len(src) != 8 {
+		return errors.Errorf("invalid length for uint8: %v", len(src))
+	}
+
+	n := binary.BigEndian.Uint64(src)
+
+	*dst = Uint8{Uint: n, Status: Present}
+	return nil
+}
+
+func (src *Uint8) EncodeText(ci *ConnInfo, buf []byte) ([]byte, error) {
+	switch src.Status {
+	case Null:
+		return nil, nil
+	case Undefined:
+		return nil, errUndefined
+	}
+
+	return append(buf, strconv.FormatUint(src.Uint, 10)...), nil
+}
+
+func (src *Uint8) EncodeBinary(ci *ConnInfo, buf []byte) ([]byte, error) {
+	switch src.Status {
+	case Null:
+		return nil, nil
+	case Undefined:
+		return nil, errUndefined
+	}
+
+	return pgio.AppendUint64(buf, src.Uint), nil
+}
+
+// Scan implements the database/sql Scanner interface.
+func (dst *Uint8) Scan(src interface{}) error {
+	if src == nil {
+		*dst = Uint8{Status: Null}
+		return nil
+	}
+
+	switch src := src.(type) {
+	case uint64:
+		*dst = Uint8{Uint: src, Status: Present}
+		return nil
+	case string:
+		return dst.DecodeText(nil, []byte(src))
+	case []byte:
+		srcCopy := make([]byte, len(src))
+		copy(srcCopy, src)
+		return dst.DecodeText(nil, srcCopy)
+	}
+
+	return errors.Errorf("cannot scan %T", src)
+}
+
+// Value implements the database/sql/driver Valuer interface.
+func (src *Uint8) Value() (driver.Value, error) {
+	switch src.Status {
+	case Present:
+		return src.Uint, nil
+	case Null:
+		return nil, nil
+	default:
+		return nil, errUndefined
+	}
+}
+
+func (src *Uint8) MarshalJSON() ([]byte, error) {
+	switch src.Status {
+	case Present:
+		return []byte(strconv.FormatUint(src.Uint, 10)), nil
+	case Null:
+		return []byte("null"), nil
+	case Undefined:
+		return nil, errUndefined
+	}
+
+	return nil, errBadStatus
+}
+
+func (dst *Uint8) UnmarshalJSON(b []byte) error {
+	var n uint64
+	err := json.Unmarshal(b, &n)
+	if err != nil {
+		return err
+	}
+
+	*dst = Uint8{Uint: n, Status: Present}
+
+	return nil
+}

--- a/pgtype/uint8_array.go
+++ b/pgtype/uint8_array.go
@@ -1,0 +1,328 @@
+package pgtype
+
+import (
+	"database/sql/driver"
+	"encoding/binary"
+
+	"github.com/jackc/pgx/pgio"
+	"github.com/pkg/errors"
+)
+
+type Uint8Array struct {
+	Elements   []Uint8
+	Dimensions []ArrayDimension
+	Status     Status
+}
+
+func (dst *Uint8Array) Set(src interface{}) error {
+	// untyped nil and typed nil interfaces are different
+	if src == nil {
+		*dst = Uint8Array{Status: Null}
+		return nil
+	}
+
+	switch value := src.(type) {
+
+	case []int64:
+		if value == nil {
+			*dst = Uint8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Uint8Array{Status: Present}
+		} else {
+			elements := make([]Uint8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Uint8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	case []uint64:
+		if value == nil {
+			*dst = Uint8Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Uint8Array{Status: Present}
+		} else {
+			elements := make([]Uint8, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Uint8Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
+	default:
+		if originalSrc, ok := underlyingSliceType(src); ok {
+			return dst.Set(originalSrc)
+		}
+		return errors.Errorf("cannot convert %v to Uint8Array", value)
+	}
+
+	return nil
+}
+
+func (dst *Uint8Array) Get() interface{} {
+	switch dst.Status {
+	case Present:
+		return dst
+	case Null:
+		return nil
+	default:
+		return dst.Status
+	}
+}
+
+func (src *Uint8Array) AssignTo(dst interface{}) error {
+	switch src.Status {
+	case Present:
+		switch v := dst.(type) {
+
+		case *[]int64:
+			*v = make([]int64, len(src.Elements))
+			for i := range src.Elements {
+				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+					return err
+				}
+			}
+			return nil
+
+		case *[]uint64:
+			*v = make([]uint64, len(src.Elements))
+			for i := range src.Elements {
+				if err := src.Elements[i].AssignTo(&((*v)[i])); err != nil {
+					return err
+				}
+			}
+			return nil
+
+		default:
+			if nextDst, retry := GetAssignToDstType(dst); retry {
+				return src.AssignTo(nextDst)
+			}
+		}
+	case Null:
+		return NullAssignTo(dst)
+	}
+
+	return errors.Errorf("cannot decode %v into %T", src, dst)
+}
+
+func (dst *Uint8Array) DecodeText(ci *ConnInfo, src []byte) error {
+	if src == nil {
+		*dst = Uint8Array{Status: Null}
+		return nil
+	}
+
+	uta, err := ParseUntypedTextArray(string(src))
+	if err != nil {
+		return err
+	}
+
+	var elements []Uint8
+
+	if len(uta.Elements) > 0 {
+		elements = make([]Uint8, len(uta.Elements))
+
+		for i, s := range uta.Elements {
+			var elem Uint8
+			var elemSrc []byte
+			if s != "NULL" {
+				elemSrc = []byte(s)
+			}
+			err = elem.DecodeText(ci, elemSrc)
+			if err != nil {
+				return err
+			}
+
+			elements[i] = elem
+		}
+	}
+
+	*dst = Uint8Array{Elements: elements, Dimensions: uta.Dimensions, Status: Present}
+
+	return nil
+}
+
+func (dst *Uint8Array) DecodeBinary(ci *ConnInfo, src []byte) error {
+	if src == nil {
+		*dst = Uint8Array{Status: Null}
+		return nil
+	}
+
+	var arrayHeader ArrayHeader
+	rp, err := arrayHeader.DecodeBinary(ci, src)
+	if err != nil {
+		return err
+	}
+
+	if len(arrayHeader.Dimensions) == 0 {
+		*dst = Uint8Array{Dimensions: arrayHeader.Dimensions, Status: Present}
+		return nil
+	}
+
+	elementCount := arrayHeader.Dimensions[0].Length
+	for _, d := range arrayHeader.Dimensions[1:] {
+		elementCount *= d.Length
+	}
+
+	elements := make([]Uint8, elementCount)
+
+	for i := range elements {
+		elemLen := int(int32(binary.BigEndian.Uint32(src[rp:])))
+		rp += 4
+		var elemSrc []byte
+		if elemLen >= 0 {
+			elemSrc = src[rp : rp+elemLen]
+			rp += elemLen
+		}
+		err = elements[i].DecodeBinary(ci, elemSrc)
+		if err != nil {
+			return err
+		}
+	}
+
+	*dst = Uint8Array{Elements: elements, Dimensions: arrayHeader.Dimensions, Status: Present}
+	return nil
+}
+
+func (src *Uint8Array) EncodeText(ci *ConnInfo, buf []byte) ([]byte, error) {
+	switch src.Status {
+	case Null:
+		return nil, nil
+	case Undefined:
+		return nil, errUndefined
+	}
+
+	if len(src.Dimensions) == 0 {
+		return append(buf, '{', '}'), nil
+	}
+
+	buf = EncodeTextArrayDimensions(buf, src.Dimensions)
+
+	// dimElemCounts is the multiples of elements that each array lies on. For
+	// example, a single dimension array of length 4 would have a dimElemCounts of
+	// [4]. A multi-dimensional array of lengths [3,5,2] would have a
+	// dimElemCounts of [30,10,2]. This is used to simplify when to render a '{'
+	// or '}'.
+	dimElemCounts := make([]int, len(src.Dimensions))
+	dimElemCounts[len(src.Dimensions)-1] = int(src.Dimensions[len(src.Dimensions)-1].Length)
+	for i := len(src.Dimensions) - 2; i > -1; i-- {
+		dimElemCounts[i] = int(src.Dimensions[i].Length) * dimElemCounts[i+1]
+	}
+
+	inElemBuf := make([]byte, 0, 32)
+	for i, elem := range src.Elements {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
+
+		for _, dec := range dimElemCounts {
+			if i%dec == 0 {
+				buf = append(buf, '{')
+			}
+		}
+
+		elemBuf, err := elem.EncodeText(ci, inElemBuf)
+		if err != nil {
+			return nil, err
+		}
+		if elemBuf == nil {
+			buf = append(buf, `NULL`...)
+		} else {
+			buf = append(buf, QuoteArrayElementIfNeeded(string(elemBuf))...)
+		}
+
+		for _, dec := range dimElemCounts {
+			if (i+1)%dec == 0 {
+				buf = append(buf, '}')
+			}
+		}
+	}
+
+	return buf, nil
+}
+
+func (src *Uint8Array) EncodeBinary(ci *ConnInfo, buf []byte) ([]byte, error) {
+	switch src.Status {
+	case Null:
+		return nil, nil
+	case Undefined:
+		return nil, errUndefined
+	}
+
+	arrayHeader := ArrayHeader{
+		Dimensions: src.Dimensions,
+	}
+
+	if dt, ok := ci.DataTypeForName("uint8"); ok {
+		arrayHeader.ElementOID = int32(dt.OID)
+	} else {
+		return nil, errors.Errorf("unable to find oid for type name %v", "uint8")
+	}
+
+	for i := range src.Elements {
+		if src.Elements[i].Status == Null {
+			arrayHeader.ContainsNull = true
+			break
+		}
+	}
+
+	buf = arrayHeader.EncodeBinary(ci, buf)
+
+	for i := range src.Elements {
+		sp := len(buf)
+		buf = pgio.AppendInt32(buf, -1)
+
+		elemBuf, err := src.Elements[i].EncodeBinary(ci, buf)
+		if err != nil {
+			return nil, err
+		}
+		if elemBuf != nil {
+			buf = elemBuf
+			pgio.SetInt32(buf[sp:], int32(len(buf[sp:])-4))
+		}
+	}
+
+	return buf, nil
+}
+
+// Scan implements the database/sql Scanner interface.
+func (dst *Uint8Array) Scan(src interface{}) error {
+	if src == nil {
+		return dst.DecodeText(nil, nil)
+	}
+
+	switch src := src.(type) {
+	case string:
+		return dst.DecodeText(nil, []byte(src))
+	case []byte:
+		srcCopy := make([]byte, len(src))
+		copy(srcCopy, src)
+		return dst.DecodeText(nil, srcCopy)
+	}
+
+	return errors.Errorf("cannot scan %T", src)
+}
+
+// Value implements the database/sql/driver Valuer interface.
+func (src *Uint8Array) Value() (driver.Value, error) {
+	buf, err := src.EncodeText(nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if buf == nil {
+		return nil, nil
+	}
+
+	return string(buf), nil
+}

--- a/pgtype/uint8_test.go
+++ b/pgtype/uint8_test.go
@@ -1,0 +1,134 @@
+package pgtype_test
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/jackc/pgx/pgtype"
+	"github.com/jackc/pgx/pgtype/testutil"
+)
+
+func TestUint8Transcode(t *testing.T) {
+	testutil.TestSuccessfulTranscode(t, "numeric", []interface{}{
+		&pgtype.Uint8{Uint: math.MaxUint64, Status: pgtype.Present},
+		&pgtype.Uint8{Uint: 0, Status: pgtype.Present},
+		&pgtype.Uint8{Uint: 1, Status: pgtype.Present},
+		&pgtype.Uint8{Uint: math.MaxInt64, Status: pgtype.Present},
+		&pgtype.Uint8{Uint: 0, Status: pgtype.Null},
+	})
+}
+
+func TestUint8Set(t *testing.T) {
+	successfulTests := []struct {
+		source interface{}
+		result pgtype.Uint8
+	}{
+		{source: int8(1), result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+		{source: int16(1), result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+		{source: int32(1), result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+		{source: int64(1), result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+		{source: uint8(1), result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+		{source: uint16(1), result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+		{source: uint32(1), result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+		{source: uint64(1), result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+		{source: "1", result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+		{source: _uint8(1), result: pgtype.Uint8{Uint: 1, Status: pgtype.Present}},
+	}
+
+	for i, tt := range successfulTests {
+		var r pgtype.Uint8
+		err := r.Set(tt.source)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if r != tt.result {
+			t.Errorf("%d: expected %v to convert to %v, but it was %v", i, tt.source, tt.result, r)
+		}
+	}
+}
+
+func TestUint8AssignTo(t *testing.T) {
+	var i8 int8
+	var i16 int16
+	var i32 int32
+	var i64 int64
+	var i int
+	var ui8 uint8
+	var ui16 uint16
+	var ui32 uint32
+	var ui64 uint64
+	var ui uint
+	var pi8 *int8
+	var _ui8 _uint8
+	var _pui8 *_uint8
+
+	simpleTests := []struct {
+		src      pgtype.Uint8
+		dst      interface{}
+		expected interface{}
+	}{
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &i8, expected: int8(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &i16, expected: int16(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &i32, expected: int32(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &i64, expected: int64(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &i, expected: int(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &ui8, expected: uint8(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &ui16, expected: uint16(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &ui32, expected: uint32(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &ui64, expected: uint64(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &ui, expected: uint(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &_ui8, expected: _uint8(42)},
+		{src: pgtype.Uint8{Uint: 0, Status: pgtype.Null}, dst: &pi8, expected: ((*int8)(nil))},
+		{src: pgtype.Uint8{Uint: 0, Status: pgtype.Null}, dst: &_pui8, expected: ((*_uint8)(nil))},
+	}
+
+	for i, tt := range simpleTests {
+		err := tt.src.AssignTo(tt.dst)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if dst := reflect.ValueOf(tt.dst).Elem().Interface(); dst != tt.expected {
+			t.Errorf("%d: expected %v to assign %v, but result was %v", i, tt.src, tt.expected, dst)
+		}
+	}
+
+	pointerAllocTests := []struct {
+		src      pgtype.Uint8
+		dst      interface{}
+		expected interface{}
+	}{
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &pi8, expected: int8(42)},
+		{src: pgtype.Uint8{Uint: 42, Status: pgtype.Present}, dst: &_pui8, expected: _uint8(42)},
+	}
+
+	for i, tt := range pointerAllocTests {
+		err := tt.src.AssignTo(tt.dst)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if dst := reflect.ValueOf(tt.dst).Elem().Elem().Interface(); dst != tt.expected {
+			t.Errorf("%d: expected %v to assign %v, but result was %v", i, tt.src, tt.expected, dst)
+		}
+	}
+
+	errorTests := []struct {
+		src pgtype.Uint8
+		dst interface{}
+	}{
+		{src: pgtype.Uint8{Uint: 150, Status: pgtype.Present}, dst: &i8},
+		{src: pgtype.Uint8{Uint: 40000, Status: pgtype.Present}, dst: &i16},
+		{src: pgtype.Uint8{Uint: 5000000000, Status: pgtype.Present}, dst: &i32},
+		{src: pgtype.Uint8{Uint: 0, Status: pgtype.Null}, dst: &i64},
+	}
+
+	for i, tt := range errorTests {
+		err := tt.src.AssignTo(tt.dst)
+		if err == nil {
+			t.Errorf("%d: expected error but none was returned (%v -> %v)", i, tt.src, tt.dst)
+		}
+	}
+}


### PR DESCRIPTION
If I have uint64 bigger than int64 (for example "9926611508173733888"), pgx returns an error: strconv.ParseInt: parsing "9926611508173733888": value out of range. 
