### PR TITLE
Add the type of the value in all decode error messages

### DIFF
--- a/pgtype/aclitem.go
+++ b/pgtype/aclitem.go
@@ -70,7 +70,7 @@ func (src *ACLItem) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *ACLItem) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/aclitem_array.go
+++ b/pgtype/aclitem_array.go
@@ -84,7 +84,7 @@ func (src *ACLItemArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *ACLItemArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/bool.go
+++ b/pgtype/bool.go
@@ -64,7 +64,7 @@ func (src *Bool) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Bool) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/bool_array.go
+++ b/pgtype/bool_array.go
@@ -86,7 +86,7 @@ func (src *BoolArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *BoolArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/bpchar_array.go
+++ b/pgtype/bpchar_array.go
@@ -86,7 +86,7 @@ func (src *BPCharArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *BPCharArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/bytea.go
+++ b/pgtype/bytea.go
@@ -64,7 +64,7 @@ func (src *Bytea) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 // DecodeText only supports the hex format. This has been the default since

--- a/pgtype/bytea_array.go
+++ b/pgtype/bytea_array.go
@@ -86,7 +86,7 @@ func (src *ByteaArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *ByteaArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/cidr_array.go
+++ b/pgtype/cidr_array.go
@@ -115,7 +115,7 @@ func (src *CIDRArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *CIDRArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/date.go
+++ b/pgtype/date.go
@@ -72,7 +72,7 @@ func (src *Date) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Date) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/date_array.go
+++ b/pgtype/date_array.go
@@ -87,7 +87,7 @@ func (src *DateArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *DateArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/enum_array.go
+++ b/pgtype/enum_array.go
@@ -84,7 +84,7 @@ func (src *EnumArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *EnumArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/float4_array.go
+++ b/pgtype/float4_array.go
@@ -86,7 +86,7 @@ func (src *Float4Array) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Float4Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/float8_array.go
+++ b/pgtype/float8_array.go
@@ -86,7 +86,7 @@ func (src *Float8Array) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Float8Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/hstore.go
+++ b/pgtype/hstore.go
@@ -59,7 +59,7 @@ func (src *Hstore) AssignTo(dst interface{}) error {
 			*v = make(map[string]string, len(src.Map))
 			for k, val := range src.Map {
 				if val.Status != Present {
-					return errors.Errorf("cannot decode %v into %T", src, dst)
+					return errors.Errorf("cannot decode %#v into %T", src, dst)
 				}
 				(*v)[k] = val.String
 			}
@@ -73,7 +73,7 @@ func (src *Hstore) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Hstore) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/hstore_array.go
+++ b/pgtype/hstore_array.go
@@ -86,7 +86,7 @@ func (src *HstoreArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *HstoreArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/inet.go
+++ b/pgtype/inet.go
@@ -91,7 +91,7 @@ func (src *Inet) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Inet) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/inet_array.go
+++ b/pgtype/inet_array.go
@@ -115,7 +115,7 @@ func (src *InetArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *InetArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/int2_array.go
+++ b/pgtype/int2_array.go
@@ -114,7 +114,7 @@ func (src *Int2Array) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Int2Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/int4_array.go
+++ b/pgtype/int4_array.go
@@ -114,7 +114,7 @@ func (src *Int4Array) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Int4Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/int8_array.go
+++ b/pgtype/int8_array.go
@@ -114,7 +114,7 @@ func (src *Int8Array) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Int8Array) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/interval.go
+++ b/pgtype/interval.go
@@ -74,7 +74,7 @@ func (src *Interval) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Interval) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/macaddr.go
+++ b/pgtype/macaddr.go
@@ -70,7 +70,7 @@ func (src *Macaddr) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Macaddr) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/numeric_array.go
+++ b/pgtype/numeric_array.go
@@ -170,7 +170,7 @@ func (src *NumericArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *NumericArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/record.go
+++ b/pgtype/record.go
@@ -67,7 +67,7 @@ func (src *Record) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Record) DecodeBinary(ci *ConnInfo, src []byte) error {

--- a/pgtype/text.go
+++ b/pgtype/text.go
@@ -74,7 +74,7 @@ func (src *Text) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Text) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/text_array.go
+++ b/pgtype/text_array.go
@@ -86,7 +86,7 @@ func (src *TextArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *TextArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -76,7 +76,7 @@ func (src *Timestamp) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 // DecodeText decodes from src into dst. The decoded time is considered to

--- a/pgtype/timestamp_array.go
+++ b/pgtype/timestamp_array.go
@@ -87,7 +87,7 @@ func (src *TimestampArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *TimestampArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/timestamptz.go
+++ b/pgtype/timestamptz.go
@@ -77,7 +77,7 @@ func (src *Timestamptz) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *Timestamptz) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/timestamptz_array.go
+++ b/pgtype/timestamptz_array.go
@@ -87,7 +87,7 @@ func (src *TimestamptzArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *TimestamptzArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/typed_array.go.erb
+++ b/pgtype/typed_array.go.erb
@@ -86,7 +86,7 @@ func (src *<%= pgtype_array_type %>) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *<%= pgtype_array_type %>) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/uuid_array.go
+++ b/pgtype/uuid_array.go
@@ -142,7 +142,7 @@ func (src *UUIDArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *UUIDArray) DecodeText(ci *ConnInfo, src []byte) error {

--- a/pgtype/varchar_array.go
+++ b/pgtype/varchar_array.go
@@ -86,7 +86,7 @@ func (src *VarcharArray) AssignTo(dst interface{}) error {
 		return NullAssignTo(dst)
 	}
 
-	return errors.Errorf("cannot decode %v into %T", src, dst)
+	return errors.Errorf("cannot decode %#v into %T", src, dst)
 }
 
 func (dst *VarcharArray) DecodeText(ci *ConnInfo, src []byte) error {


### PR DESCRIPTION
This improves the decode error message, e.g., from

`can't scan into dest[3]: cannot decode &{xyz 2} into string` to

`can't scan into dest[3]: cannot decode &pgtype.Text{String:"xyz", Status:0x2} into string`

(this is an example of me forgetting to take the address of a variable when using `Scan` 😆)
