### PR TITLE
Call context.WithTimeout cancel function

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1711,8 +1711,8 @@ func TestListenNotifySelfNotification(t *testing.T) {
 		t.Fatalf("Unexpected error on Query: %v", rows.Err())
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	ctx, cncl := context.WithTimeout(context.Background(), time.Second)
+	defer cncl()
 	notification, err = conn.WaitForNotification(ctx)
 	if err != nil {
 		t.Fatalf("Unexpected error on WaitForNotification: %v", err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -1553,7 +1553,8 @@ func TestListenNotify(t *testing.T) {
 	}
 
 	// when timeout occurs
-	ctx, _ = context.WithTimeout(context.Background(), time.Millisecond)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
 	notification, err = listener.WaitForNotification(ctx)
 	if err != context.DeadlineExceeded {
 		t.Errorf("WaitForNotification returned the wrong kind of error: %v", err)
@@ -1610,7 +1611,8 @@ func TestUnlistenSpecificChannel(t *testing.T) {
 		t.Fatalf("Unexpected error on Query: %v", rows.Err())
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 	notification, err = listener.WaitForNotification(ctx)
 	if err != context.DeadlineExceeded {
 		t.Errorf("WaitForNotification returned the wrong kind of error: %v", err)
@@ -1690,7 +1692,8 @@ func TestListenNotifySelfNotification(t *testing.T) {
 	// Notify self and WaitForNotification immediately
 	mustExec(t, conn, "notify self")
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	notification, err := conn.WaitForNotification(ctx)
 	if err != nil {
 		t.Fatalf("Unexpected error on WaitForNotification: %v", err)
@@ -1708,7 +1711,8 @@ func TestListenNotifySelfNotification(t *testing.T) {
 		t.Fatalf("Unexpected error on Query: %v", rows.Err())
 	}
 
-	ctx, _ = context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	notification, err = conn.WaitForNotification(ctx)
 	if err != nil {
 		t.Fatalf("Unexpected error on WaitForNotification: %v", err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -1553,7 +1553,7 @@ func TestListenNotify(t *testing.T) {
 	}
 
 	// when timeout occurs
-	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 	notification, err = listener.WaitForNotification(ctx)
 	if err != context.DeadlineExceeded {
@@ -1711,7 +1711,7 @@ func TestListenNotifySelfNotification(t *testing.T) {
 		t.Fatalf("Unexpected error on Query: %v", rows.Err())
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	notification, err = conn.WaitForNotification(ctx)
 	if err != nil {

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -869,7 +869,8 @@ func TestConnPingContextCancel(t *testing.T) {
 	}
 	defer closeDB(t, db)
 
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 
 	err = db.PingContext(ctx)
 	if err != context.DeadlineExceeded {
@@ -923,7 +924,8 @@ func TestConnPrepareContextCancel(t *testing.T) {
 	}
 	defer closeDB(t, db)
 
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 
 	_, err = db.PrepareContext(ctx, "select now()")
 	if err != context.DeadlineExceeded {
@@ -974,7 +976,8 @@ func TestConnExecContextCancel(t *testing.T) {
 	}
 	defer closeDB(t, db)
 
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 
 	_, err = db.ExecContext(ctx, "create temporary table exec_context_test(id serial primary key)")
 	if err != context.DeadlineExceeded {
@@ -1145,7 +1148,8 @@ func TestStmtExecContextCancel(t *testing.T) {
 	}
 	defer stmt.Close()
 
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 
 	_, err = stmt.ExecContext(ctx, 42)
 	if err != context.DeadlineExceeded {

--- a/stress_test.go
+++ b/stress_test.go
@@ -213,7 +213,8 @@ func listenAndPoolUnlistens(pool *pgx.ConnPool, actionNum int) error {
 		return err
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 	_, err = conn.WaitForNotification(ctx)
 	if err == context.DeadlineExceeded {
 		return nil

--- a/tx.go
+++ b/tx.go
@@ -147,7 +147,8 @@ func (tx *Tx) CommitEx(ctx context.Context) error {
 // defer tx.Rollback() is safe even if tx.Commit() will be called first in a
 // non-error condition.
 func (tx *Tx) Rollback() error {
-	ctx, _ := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	return tx.RollbackEx(ctx)
 }
 

--- a/tx_test.go
+++ b/tx_test.go
@@ -261,7 +261,8 @@ func TestConnBeginExContextCancel(t *testing.T) {
 
 	conn := mustConnect(t, mockConfig)
 
-	ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
 
 	_, err = conn.BeginEx(ctx, nil)
 	if err != context.DeadlineExceeded {
@@ -315,7 +316,8 @@ func TestTxCommitExCancel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
 	err = tx.CommitEx(ctx)
 	if err != context.DeadlineExceeded {
 		t.Errorf("err => %v, want %v", err, context.DeadlineExceeded)


### PR DESCRIPTION
Call cancel function returned by context.WithTimeout, to avoid a memory leak.