### PR TITLE
Handle (n > 0 and err == io.EOF) in CopyFromReader

### DIFF
--- a/copy_from.go
+++ b/copy_from.go
@@ -298,7 +298,7 @@ func (c *Conn) CopyFromReader(r io.Reader, sql string) error {
 	sp := len(buf)
 	for {
 		n, err := r.Read(buf[5:cap(buf)])
-		if err == io.EOF {
+		if err == io.EOF && n == 0 {
 			break
 		}
 		buf = buf[0 : n+5]


### PR DESCRIPTION
The CopyFromReader method does not correctly handle the case when (n > 0 and err == io.EOF). This is a valid case as per the io.Reader documentation and should be handled.

When reading a gzipped file using gzip.Reader to uncompress data on the fly the last chunk of data is often omitted due to the CopyFromReader method breaking out of the read loop on io.EOF and not processing the last bit of data. The result is that the COPY fails or that not all rows are inserted.
I've added a test case reading from a gzip.Reader which fails without the fix.
