### PR TITLE
Add path query parameter to support unix sockets

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -782,6 +782,11 @@ func ParseURI(uri string) (ConnConfig, error) {
 			continue
 		}
 
+		if k == "host" {
+			cp.Host = v[0]
+			continue
+		}
+
 		cp.RuntimeParams[k] = v[0]
 	}
 	if cp.Password == "" {

--- a/conn_test.go
+++ b/conn_test.go
@@ -458,6 +458,19 @@ func TestParseURI(t *testing.T) {
 				},
 			},
 		},
+		{
+			url: "postgres:///foo?host=/tmp",
+			connParams: pgx.ConnConfig{
+				Host:     "/tmp",
+				Database: "foo",
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				UseFallbackTLS:    true,
+				FallbackTLSConfig: nil,
+				RuntimeParams:     map[string]string{},
+			},
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Currently there is no way to specify unix sockets in the connection
url. This patch adds a `path` query parameter that allows to set the path.