### PR TITLE
tls: stop sending ssl_renegotiation_limit in startup message

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -337,14 +337,6 @@ func (c *Conn) connect(config ConnConfig, network, address string, tlsConfig *tl
 		Parameters:      make(map[string]string),
 	}
 
-	// Default to disabling TLS renegotiation.
-	//
-	// Go does not support (https://github.com/golang/go/issues/5742)
-	// PostgreSQL recommends disabling (http://www.postgresql.org/docs/9.4/static/runtime-config-connection.html#GUC-SSL-RENEGOTIATION-LIMIT)
-	if tlsConfig != nil {
-		startupMsg.Parameters["ssl_renegotiation_limit"] = "0"
-	}
-
 	// Copy default run-time params
 	for k, v := range config.RuntimeParams {
 		startupMsg.Parameters[k] = v

--- a/doc.go
+++ b/doc.go
@@ -236,6 +236,13 @@ nil, then TLS will be disabled. If it is present, then it will be used to
 configure the TLS connection. This allows total configuration of the TLS
 connection.
 
+pgx has never explicitly supported Postgres < 9.6's `ssl_renegotiation` option.
+As of v3.3.0, it doesn't send `ssl_renegotiation: 0` either to support Redshift
+(https://github.com/jackc/pgx/pull/476). If you need TLS Renegotiation,
+consider supplying `ConnConfig.TLSConfig` with a non-zero `Renegotiation`
+value and if it's not the default on your server, set `ssl_renegotiation`
+via `ConnConfig.RuntimeParams`.
+
 Logging
 
 pgx defines a simple logger interface. Connections optionally accept a logger


### PR DESCRIPTION
This addresses https://github.com/jackc/pgx/issues/321 with the
fix @jackc proposed there--

>The only reason we send ssl_renegotiation_limit is to avoid mysterious connection errors when connecting to servers that use renegotiation. But PostgreSQL defaults to 0 for all supported versions, and removed the setting for 9.6. So I guess all we need to do is remove the default startup parameter message. Anyone who really needs it can easily add it back with ConnConfig.RuntimeParams.

Redshift users that need to connect
w/ SSL currently fork the library to delete this parameter, e.g.

https://github.com/segmentio/pgx/commit/8e0028d742358e966669c28193fa65460a85ea69

And, that's annoying to keep up-to-date :)