### PR TITLE
remove PostgreSQL 10 exclusive argument

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -441,7 +441,7 @@ func (rc *ReplicationConn) StartReplication(slotName string, startLsn uint64, ti
 
 // Create the replication slot, using the given name and output plugin.
 func (rc *ReplicationConn) CreateReplicationSlot(slotName, outputPlugin string) (err error) {
-	_, err = rc.c.Exec(fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL %s NOEXPORT_SNAPSHOT", slotName, outputPlugin))
+	_, err = rc.c.Exec(fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL %s", slotName, outputPlugin))
 	return
 }
 


### PR DESCRIPTION
NOEXPORT_SNAPSHOT is added in PostgreSQL 10+
it causes CreateReplicationSlot() failed with syntax error in PostgreSQL 9.x

the fix partially reverts a recent commit https://github.com/jackc/pgx/commit/04bead7c8a8d6a647336fa74c7a31cd3d36336bf