### PR TITLE
stdlib: fix race with Driver.configs in Open

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -140,8 +140,10 @@ func (d *Driver) Open(name string) (driver.Conn, error) {
 	if len(name) >= 9 && name[0] == 0 {
 		idBuf := []byte(name)[1:9]
 		id := int64(binary.BigEndian.Uint64(idBuf))
+		d.configMutex.Lock()
 		connConfig = d.configs[id].ConnConfig
 		afterConnect = d.configs[id].AfterConnect
+		d.configMutex.Unlock()
 		name = name[9:]
 	}
 


### PR DESCRIPTION
The Driver.configs map is protected by configMutex in registerDriverConfig and unregisterDriverConfig, but not in Open. This results in a race if Open is called while another goroutine is registering/unregistering a DriverConfig.

I came across this while running a bunch of parallel tests.

	> go test -race
	==================
	WARNING: DATA RACE
	Write at 0x00c00008e9f0 by goroutine 31:
	  runtime.mapassign_fast64()
	      /usr/local/Cellar/go/1.11.2/libexec/src/runtime/map_fast64.go:92 +0x0
	  github.com/jackc/pgx/stdlib.(*Driver).registerDriverConfig()
	      /Users/gcurtis/go/pkg/mod/github.com/jackc/pgx@v3.2.0+incompatible/stdlib/sql.go:195 +0x114
	  github.com/jackc/pgx/stdlib.RegisterDriverConfig()
	      /Users/gcurtis/go/pkg/mod/github.com/jackc/pgx@v3.2.0+incompatible/stdlib/sql.go:209 +0x54
	  ...
	  testing.tRunner()
	      /usr/local/Cellar/go/1.11.2/libexec/src/testing/testing.go:827 +0x162

	Previous read at 0x00c00008e9f0 by goroutine 35:
	  runtime.mapaccess1_fast64()
	      /usr/local/Cellar/go/1.11.2/libexec/src/runtime/map_fast64.go:12 +0x0
	  github.com/jackc/pgx/stdlib.(*Driver).Open()
	      /Users/gcurtis/go/pkg/mod/github.com/jackc/pgx@v3.2.0+incompatible/stdlib/sql.go:143 +0x774
	  database/sql.dsnConnector.Connect()
	      /usr/local/Cellar/go/1.11.2/libexec/src/database/sql/sql.go:637 +0x59
	  database/sql.(*dsnConnector).Connect()
	      <autogenerated>:1 +0xaf
	  database/sql.(*DB).conn()
	      /usr/local/Cellar/go/1.11.2/libexec/src/database/sql/sql.go:1177 +0x200
	  database/sql.(*DB).PingContext()
	      /usr/local/Cellar/go/1.11.2/libexec/src/database/sql/sql.go:731 +0x97
	  database/sql.(*DB).Ping()
	      /usr/local/Cellar/go/1.11.2/libexec/src/database/sql/sql.go:749 +0x64
	  ...
	  testing.tRunner()
	      /usr/local/Cellar/go/1.11.2/libexec/src/testing/testing.go:827 +0x162