### PR TITLE
Apply UUID string length check before parsing

### DIFF
--- a/pgtype/uuid.go
+++ b/pgtype/uuid.go
@@ -87,6 +87,9 @@ func (src *UUID) AssignTo(dst interface{}) error {
 
 // parseUUID converts a string UUID in standard form to a byte array.
 func parseUUID(src string) (dst [16]byte, err error) {
+	if len(src) < 36 {
+		return dst, errors.Errorf("cannot parse UUID %v", src)
+	}
 	src = src[0:8] + src[9:13] + src[14:18] + src[19:23] + src[24:]
 	buf, err := hex.DecodeString(src)
 	if err != nil {


### PR DESCRIPTION
Simple check for UUID is not an empty string and looks correct.
Solves "slice bounds out of range" runtime error in some situations.