### PR TITLE
Adds RowsAffected for CopyToWriter and CopyFromReader

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -553,10 +553,10 @@ func (p *ConnPool) CopyFrom(tableName Identifier, columnNames []string, rowSrc C
 }
 
 // CopyFromReader acquires a connection, delegates the call to that connection, and releases the connection
-func (p *ConnPool) CopyFromReader(r io.Reader, sql string) error {
+func (p *ConnPool) CopyFromReader(r io.Reader, sql string) (CommandTag, error) {
 	c, err := p.Acquire()
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer p.Release(c)
 
@@ -564,10 +564,10 @@ func (p *ConnPool) CopyFromReader(r io.Reader, sql string) error {
 }
 
 // CopyToWriter acquires a connection, delegates the call to that connection, and releases the connection
-func (p *ConnPool) CopyToWriter(w io.Writer, sql string, args ...interface{}) error {
+func (p *ConnPool) CopyToWriter(w io.Writer, sql string, args ...interface{}) (CommandTag, error) {
 	c, err := p.Acquire()
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer p.Release(c)
 

--- a/copy_from.go
+++ b/copy_from.go
@@ -284,13 +284,13 @@ func (c *Conn) CopyFrom(tableName Identifier, columnNames []string, rowSrc CopyF
 }
 
 // CopyFromReader uses the PostgreSQL textual format of the copy protocol
-func (c *Conn) CopyFromReader(r io.Reader, sql string) error {
+func (c *Conn) CopyFromReader(r io.Reader, sql string) (CommandTag, error) {
 	if err := c.sendSimpleQuery(sql); err != nil {
-		return err
+		return "", err
 	}
 
 	if err := c.readUntilCopyInResponse(); err != nil {
-		return err
+		return "", err
 	}
 	buf := c.wbuf
 
@@ -305,7 +305,7 @@ func (c *Conn) CopyFromReader(r io.Reader, sql string) error {
 		pgio.SetInt32(buf[sp:], int32(n+4))
 
 		if _, err := c.conn.Write(buf); err != nil {
-			return err
+			return "", err
 		}
 	}
 
@@ -314,26 +314,25 @@ func (c *Conn) CopyFromReader(r io.Reader, sql string) error {
 	buf = pgio.AppendInt32(buf, 4)
 
 	if _, err := c.conn.Write(buf); err != nil {
-		return err
+		return "", err
 	}
 
 	for {
 		msg, err := c.rxMsg()
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		switch msg := msg.(type) {
 		case *pgproto3.ReadyForQuery:
 			c.rxReadyForQuery(msg)
-			return nil
+			return "", err
 		case *pgproto3.CommandComplete:
+			return CommandTag(msg.CommandTag), nil
 		case *pgproto3.ErrorResponse:
-			return c.rxErrorResponse(msg)
+			return "", c.rxErrorResponse(msg)
 		default:
-			return c.processContextFreeMsg(msg)
+			return "", c.processContextFreeMsg(msg)
 		}
 	}
-
-	return nil
 }

--- a/copy_to.go
+++ b/copy_to.go
@@ -25,19 +25,19 @@ func (c *Conn) readUntilCopyOutResponse() error {
 	}
 }
 
-func (c *Conn) CopyToWriter(w io.Writer, sql string, args ...interface{}) error {
+func (c *Conn) CopyToWriter(w io.Writer, sql string, args ...interface{}) (CommandTag, error) {
 	if err := c.sendSimpleQuery(sql, args...); err != nil {
-		return err
+		return "", err
 	}
 
 	if err := c.readUntilCopyOutResponse(); err != nil {
-		return err
+		return "", err
 	}
 
 	for {
 		msg, err := c.rxMsg()
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		switch msg := msg.(type) {
@@ -47,18 +47,17 @@ func (c *Conn) CopyToWriter(w io.Writer, sql string, args ...interface{}) error 
 			_, err := w.Write(msg.Data)
 			if err != nil {
 				c.die(err)
-				return err
+				return "", err
 			}
 		case *pgproto3.ReadyForQuery:
 			c.rxReadyForQuery(msg)
-			return nil
+			return "", nil
 		case *pgproto3.CommandComplete:
+			return CommandTag(msg.CommandTag), nil
 		case *pgproto3.ErrorResponse:
-			return c.rxErrorResponse(msg)
+			return "", c.rxErrorResponse(msg)
 		default:
-			return c.processContextFreeMsg(msg)
+			return "", c.processContextFreeMsg(msg)
 		}
 	}
-
-	return nil
 }

--- a/tx.go
+++ b/tx.go
@@ -240,18 +240,18 @@ func (tx *Tx) CopyFrom(tableName Identifier, columnNames []string, rowSrc CopyFr
 }
 
 // CopyFromReader delegates to the underlying *Conn
-func (tx *Tx) CopyFromReader(r io.Reader, sql string) error {
+func (tx *Tx) CopyFromReader(r io.Reader, sql string) (commandTag CommandTag, err error) {
 	if tx.status != TxStatusInProgress {
-		return ErrTxClosed
+		return CommandTag(""), ErrTxClosed
 	}
 
 	return tx.conn.CopyFromReader(r, sql)
 }
 
 // CopyToWriter delegates to the underlying *Conn
-func (tx *Tx) CopyToWriter(w io.Writer, sql string, args ...interface{}) error {
+func (tx *Tx) CopyToWriter(w io.Writer, sql string, args ...interface{}) (commandTag CommandTag, err error) {
 	if tx.status != TxStatusInProgress {
-		return ErrTxClosed
+		return CommandTag(""), ErrTxClosed
 	}
 
 	return tx.conn.CopyToWriter(w, sql, args...)


### PR DESCRIPTION
RowsAffected returns the number of rows affected by COPY
https://www.postgresql.org/docs/9.6/sql-copy.html