### PR TITLE
support binding of []int type to array integer

### DIFF
--- a/pgtype/int4_array.go
+++ b/pgtype/int4_array.go
@@ -23,6 +23,25 @@ func (dst *Int4Array) Set(src interface{}) error {
 
 	switch value := src.(type) {
 
+	case []int:
+		if value == nil {
+			*dst = Int4Array{Status: Null}
+		} else if len(value) == 0 {
+			*dst = Int4Array{Status: Present}
+		} else {
+			elements := make([]Int4, len(value))
+			for i := range value {
+				if err := elements[i].Set(value[i]); err != nil {
+					return err
+				}
+			}
+			*dst = Int4Array{
+				Elements:   elements,
+				Dimensions: []ArrayDimension{{Length: int32(len(elements)), LowerBound: 1}},
+				Status:     Present,
+			}
+		}
+
 	case []int32:
 		if value == nil {
 			*dst = Int4Array{Status: Null}


### PR DESCRIPTION
binding go type `int` to database type `integer` is handled, so it would also make sense to be able to bind `[]int` to array `integer`.