### PR TITLE
Close issue #481 : Give access to the registered driver instance

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -126,6 +126,12 @@ var (
 	fakeTxConns map[*pgx.Conn]*sql.Tx
 )
 
+// GetDefaultDriver return the driver initialize in the init function
+// and used when register pgx driver
+func GetDefaultDriver() *Driver {
+	return pgxDriver
+}
+
 type Driver struct {
 	configMutex sync.Mutex
 	configCount int64


### PR DESCRIPTION
Some library use a driver to wrap its behavior and give additional
functionality, as the datadog tracing library
("gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql")

This commit aims to give access to this instance which can't be
correctly initialized to due private fields without default values (the
configuration map inside the driver)