### PR TITLE
Adding support for pgpass file

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -962,7 +962,7 @@ func testConnConfigEquals(t *testing.T, expected pgx.ConnConfig, actual pgx.Conn
 }
 
 func TestParseEnvLibpq(t *testing.T) {
-	pgEnvvars := []string{"PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD", "PGAPPNAME", "PGSSLMODE", "PGCONNECT_TIMEOUT"}
+	pgEnvvars := []string{"PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD", "PGPASSFILE", "PGAPPNAME", "PGSSLMODE", "PGCONNECT_TIMEOUT"}
 
 	savedEnv := make(map[string]string)
 	for _, n := range pgEnvvars {


### PR DESCRIPTION
As per the libpq-pgpass documentation linked below:
https://www.postgresql.org/docs/9.4/libpq-pgpass.html

Support for a file format containing a single line:
hostname:port:database:username:password

Edit: I realize now there is already some functionality to parse pgpass, I shall utilize that but still add the environment variable override for the pgpass location.