### PR TITLE
Hstore can have empty keys

### DIFF
--- a/pgtype/hstore.go
+++ b/pgtype/hstore.go
@@ -296,13 +296,9 @@ func parseHstore(s string) (k []string, v []Text, err error) {
 		case hsKey:
 			switch r {
 			case '"': //End of the key
-				if buf.Len() == 0 {
-					err = errors.New("Empty Key is invalid")
-				} else {
-					keys = append(keys, buf.String())
-					buf = bytes.Buffer{}
-					state = hsSep
-				}
+				keys = append(keys, buf.String())
+				buf = bytes.Buffer{}
+				state = hsSep
 			case '\\': //Potential escaped character
 				n, end := p.Consume()
 				switch {


### PR DESCRIPTION
Postgres actually supports empty keys in hstores. You can test this with a simple:

```sql
INSERT INTO table (hstorecolumn) VALUES ('""=>3');
INSERT INTO table (hstorecolumn) VALUES ('"a"=>4');
```

One record will have an empty key with a value of 3, one will have a key of `a` with a value of 4.