### PR TITLE
added PortalSuspended message

### DIFF
--- a/pgproto3/frontend.go
+++ b/pgproto3/frontend.go
@@ -23,7 +23,7 @@ type Frontend struct {
 	copyInResponse       CopyInResponse
 	copyOutResponse      CopyOutResponse
 	copyDone             CopyDone
-        copyFail             CopyFail
+	copyFail             CopyFail
 	dataRow              DataRow
 	emptyQueryResponse   EmptyQueryResponse
 	errorResponse        ErrorResponse
@@ -36,6 +36,7 @@ type Frontend struct {
 	parseComplete        ParseComplete
 	readyForQuery        ReadyForQuery
 	rowDescription       RowDescription
+	portalSuspended      PortalSuspended
 
 	bodyLen    int
 	msgType    byte
@@ -76,8 +77,8 @@ func (b *Frontend) Receive() (BackendMessage, error) {
 		msg = &b.notificationResponse
 	case 'c':
 		msg = &b.copyDone
-        case 'f':
-                msg = &b.copyFail
+	case 'f':
+		msg = &b.copyFail
 	case 'C':
 		msg = &b.commandComplete
 	case 'd':
@@ -112,6 +113,8 @@ func (b *Frontend) Receive() (BackendMessage, error) {
 		msg = &b.copyBothResponse
 	case 'Z':
 		msg = &b.readyForQuery
+	case 's':
+		msg = &b.portalSuspended
 	default:
 		return nil, errors.Errorf("unknown message type: %c", b.msgType)
 	}

--- a/pgproto3/portal_suspended.go
+++ b/pgproto3/portal_suspended.go
@@ -1,0 +1,29 @@
+package pgproto3
+
+import (
+	"encoding/json"
+)
+
+type PortalSuspended struct{}
+
+func (*PortalSuspended) Backend() {}
+
+func (dst *PortalSuspended) Decode(src []byte) error {
+	if len(src) != 0 {
+		return &invalidMessageLenErr{messageType: "PortalSuspended", expectedLen: 0, actualLen: len(src)}
+	}
+
+	return nil
+}
+
+func (src *PortalSuspended) Encode(dst []byte) []byte {
+	return append(dst, 's', 0, 0, 0, 4)
+}
+
+func (src *PortalSuspended) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type string
+	}{
+		Type: "PortalSuspended",
+	})
+}


### PR DESCRIPTION
## Changes

- created a struct `PortalSuspended` that implements `BackendMessage`
- added `PortalSuspended` to `Frontend` as a valid backend message in `Receive()`

closes #539 