### PR TITLE
pgtype: Fix -0 for numeric types

### DIFF
--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -321,7 +321,7 @@ func parseNumericString(str string) (n *big.Int, exp int32, err error) {
 	if len(parts) > 1 {
 		exp = int32(-len(parts[1]))
 	} else {
-		for len(digits) > 1 && digits[len(digits)-1] == '0' {
+		for len(digits) > 1 && digits[len(digits)-1] == '0' && digits[len(digits)-2] != '-' {
 			digits = digits[:len(digits)-1]
 			exp++
 		}

--- a/pgtype/numeric_array_test.go
+++ b/pgtype/numeric_array_test.go
@@ -1,6 +1,7 @@
 package pgtype_test
 
 import (
+	"math"
 	"math/big"
 	"reflect"
 	"testing"
@@ -66,9 +67,23 @@ func TestNumericArraySet(t *testing.T) {
 				Status:     pgtype.Present},
 		},
 		{
+			source: []float32{float32(math.Copysign(0, -1))},
+			result: pgtype.NumericArray{
+				Elements:   []pgtype.Numeric{{Int: big.NewInt(0), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
 			source: []float64{1},
 			result: pgtype.NumericArray{
 				Elements:   []pgtype.Numeric{{Int: big.NewInt(1), Status: pgtype.Present}},
+				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}},
+				Status:     pgtype.Present},
+		},
+		{
+			source: []float64{math.Copysign(0, -1)},
+			result: pgtype.NumericArray{
+				Elements:   []pgtype.Numeric{{Int: big.NewInt(0), Status: pgtype.Present}},
 				Dimensions: []pgtype.ArrayDimension{{LowerBound: 1, Length: 1}},
 				Status:     pgtype.Present},
 		},

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -1,6 +1,7 @@
 package pgtype_test
 
 import (
+	"math"
 	"math/big"
 	"math/rand"
 	"reflect"
@@ -188,7 +189,9 @@ func TestNumericSet(t *testing.T) {
 		result *pgtype.Numeric
 	}{
 		{source: float32(1), result: &pgtype.Numeric{Int: big.NewInt(1), Status: pgtype.Present}},
+		{source: float32(math.Copysign(0, -1)), result: &pgtype.Numeric{Int: big.NewInt(0), Status: pgtype.Present}},
 		{source: float64(1), result: &pgtype.Numeric{Int: big.NewInt(1), Status: pgtype.Present}},
+		{source: float64(math.Copysign(0, -1)), result: &pgtype.Numeric{Int: big.NewInt(0), Status: pgtype.Present}},
 		{source: int8(1), result: &pgtype.Numeric{Int: big.NewInt(1), Status: pgtype.Present}},
 		{source: int16(1), result: &pgtype.Numeric{Int: big.NewInt(1), Status: pgtype.Present}},
 		{source: int32(1), result: &pgtype.Numeric{Int: big.NewInt(1), Status: pgtype.Present}},


### PR DESCRIPTION
Due to the special case of when the digits string was longer than 1 but
only contained the negative sign and a 0, it was incorrectly stripping
the 0 and attempting to parse "-" as a number.

The solution is to check an extra position along to make sure a trailing
0 is not immediately preceeded by a negetive sign.

Fixes #543