### PR TITLE
cast bytea to make []byte suitable for both string and binary string

### DIFF
--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -87,7 +87,7 @@ func QuoteString(str string) string {
 }
 
 func QuoteBytes(buf []byte) string {
-	return `'\x` + hex.EncodeToString(buf) + "'"
+	return `'\x` + hex.EncodeToString(buf) + "'::bytea"
 }
 
 type sqlLexer struct {

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -108,7 +108,7 @@ func TestQuerySanitize(t *testing.T) {
 		{
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},
 			args:     []interface{}{[]byte{0, 1, 2, 3, 255}},
-			expected: `select '\x00010203ff'`,
+			expected: `select '\x00010203ff'::bytea`,
 		},
 		{
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},


### PR DESCRIPTION
Chances are that we input `[]byte` for string type, e.g. `text`, so it's better to cast the quoted bytes explicitly.