### PR TITLE
Read OIDs for composite types on connection init.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -404,9 +404,11 @@ func initPostgresql(c *Conn) (*pgtype.ConnInfo, error) {
 from pg_type t
 left join pg_type base_type on t.typelem=base_type.oid
 left join pg_namespace nsp on t.typnamespace=nsp.oid
+left join pg_class cls on t.typrelid=cls.oid
 where (
-	  t.typtype in('b', 'p', 'r', 'e')
+	  t.typtype in('b', 'p', 'r', 'e', 'c')
 	  and (base_type.oid is null or base_type.typtype in('b', 'p', 'r'))
+	  and (cls.oid is null or cls.relkind='c')
 	)`
 	)
 

--- a/pgmock/pgmock.go
+++ b/pgmock/pgmock.go
@@ -211,9 +211,11 @@ func PgxInitSteps() []Step {
 from pg_type t
 left join pg_type base_type on t.typelem=base_type.oid
 left join pg_namespace nsp on t.typnamespace=nsp.oid
+left join pg_class cls on t.typrelid=cls.oid
 where (
-	  t.typtype in('b', 'p', 'r', 'e')
+	  t.typtype in('b', 'p', 'r', 'e', 'c')
 	  and (base_type.oid is null or base_type.typtype in('b', 'p', 'r'))
+	  and (cls.oid is null or cls.relkind='c')
 	)`,
 		}),
 		ExpectMessage(&pgproto3.Describe{


### PR DESCRIPTION
This used to be done, but pulled in tables which slowed down connections on databases with a large number of tables; see https://github.com/jackc/pgx/issues/140.

This change includes composite types but excludes tables by joining against [pg_class](https://www.postgresql.org/docs/11/catalog-pg-class.html) in which `relkind` is `'c'` for the former and `'r'` for the latter.

Fixes https://github.com/jackc/pgx/issues/420.