### PR TITLE
send simple query if no args

### DIFF
--- a/query.go
+++ b/query.go
@@ -522,6 +522,10 @@ func (c *Conn) readUntilRowDescription() ([]FieldDescription, error) {
 }
 
 func (c *Conn) sanitizeAndSendSimpleQuery(sql string, args ...interface{}) (err error) {
+	if len(args) == 0 {
+		return c.sendSimpleQuery(sql)
+	}
+
 	if c.RuntimeParams["standard_conforming_strings"] != "on" {
 		return errors.New("simple protocol queries must be run with standard_conforming_strings=on")
 	}


### PR DESCRIPTION
no need to parse and sanitize the sql string when no args.
