### PR TITLE
Use zap.Any for handling interface{} -> zap.Field conversion

### DIFF
--- a/log/zapadapter/adapter.go
+++ b/log/zapadapter/adapter.go
@@ -19,7 +19,7 @@ func (pl *Logger) Log(level pgx.LogLevel, msg string, data map[string]interface{
 	fields := make([]zapcore.Field, len(data))
 	i := 0
 	for k, v := range data {
-		fields[i] = zap.Reflect(k, v)
+		fields[i] = zap.Any(k, v)
 		i++
 	}
 


### PR DESCRIPTION
zap.Any falls back to zap.Reflect, but is better for this case, because
it first checks for the types that zap handles specially.  For example,
time.Duration, or error, which zap.Reflect will just treat as untyped
int64 or struct objects, but zap.Any is able to detect these types and
print them properly.