### PR TITLE
Reuse pool.connInfo for createConnectionUnlocked method

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -319,7 +319,7 @@ func (p *ConnPool) createConnection() (*Conn, error) {
 func (p *ConnPool) createConnectionUnlocked() (*Conn, error) {
 	p.inProgressConnects++
 	p.cond.L.Unlock()
-	c, err := Connect(p.config)
+	c, err := connect(p.config, p.connInfo)
 	p.cond.L.Lock()
 	p.inProgressConnects--
 

--- a/conn_pool.go
+++ b/conn_pool.go
@@ -319,7 +319,7 @@ func (p *ConnPool) createConnection() (*Conn, error) {
 func (p *ConnPool) createConnectionUnlocked() (*Conn, error) {
 	p.inProgressConnects++
 	p.cond.L.Unlock()
-	c, err := connect(p.config, p.connInfo)
+	c, err := connect(p.config, p.connInfo.DeepCopy())
 	p.cond.L.Lock()
 	p.inProgressConnects--
 


### PR DESCRIPTION
`ConnPool.createConnection` reuse `p.connInfo` already. So, `createConnectionUnlocked` must be consistent with it.

Otherwise, we inefficiently fetch data from DB on connection establishing. This could lead to performance degradation and downtime.

As I already notes in #546 once we got downtime due to the increased number of OID's fetching requests. But we used `database/sql` connection pool, that has no ability to reuse `connInfo` and connection established with `minimalConnInfo` each time.

(_This graph shows the number of requests for additional OID's fetching._)
![downtime](https://user-images.githubusercontent.com/2843971/59962938-e36ccc00-94f4-11e9-9217-254c449d3b4b.png)
