### PR TITLE
Add conversions that UUID types from libraries can be handled by pytype.UUID

### DIFF
--- a/pgtype/convert.go
+++ b/pgtype/convert.go
@@ -149,7 +149,7 @@ func underlyingTimeType(val interface{}) (interface{}, bool) {
 	switch refVal.Kind() {
 	case reflect.Ptr:
 		if refVal.IsNil() {
-			return time.Time{}, false
+			return nil, false
 		}
 		convVal := refVal.Elem().Interface()
 		return convVal, true
@@ -160,7 +160,7 @@ func underlyingTimeType(val interface{}) (interface{}, bool) {
 		return refVal.Convert(timeType).Interface(), true
 	}
 
-	return time.Time{}, false
+	return nil, false
 }
 
 // underlyingUUIDType gets the underlying type that can be converted to [16]byte

--- a/pgtype/convert.go
+++ b/pgtype/convert.go
@@ -163,6 +163,27 @@ func underlyingTimeType(val interface{}) (interface{}, bool) {
 	return time.Time{}, false
 }
 
+// underlyingUUIDType gets the underlying type that can be converted to [16]byte
+func underlyingUUIDType(val interface{}) (interface{}, bool) {
+	refVal := reflect.ValueOf(val)
+
+	switch refVal.Kind() {
+	case reflect.Ptr:
+		if refVal.IsNil() {
+			return time.Time{}, false
+		}
+		convVal := refVal.Elem().Interface()
+		return convVal, true
+	}
+
+	uuidType := reflect.TypeOf([16]byte{})
+	if refVal.Type().ConvertibleTo(uuidType) {
+		return refVal.Convert(uuidType).Interface(), true
+	}
+
+	return nil, false
+}
+
 // underlyingSliceType gets the underlying slice type
 func underlyingSliceType(val interface{}) (interface{}, bool) {
 	refVal := reflect.ValueOf(val)
@@ -397,6 +418,14 @@ func GetAssignToDstType(dst interface{}) (interface{}, bool) {
 		if baseElemType, ok := kindTypes[dstVal.Type().Elem().Kind()]; ok {
 			baseSliceType := reflect.PtrTo(reflect.SliceOf(baseElemType))
 			nextDst := dstPtr.Convert(baseSliceType)
+			return nextDst.Interface(), dstPtr.Type() != nextDst.Type()
+		}
+	}
+
+	if dstVal.Kind() == reflect.Array {
+		if baseElemType, ok := kindTypes[dstVal.Type().Elem().Kind()]; ok {
+			baseArrayType := reflect.PtrTo(reflect.ArrayOf(dstVal.Len(), baseElemType))
+			nextDst := dstPtr.Convert(baseArrayType)
 			return nextDst.Interface(), dstPtr.Type() != nextDst.Type()
 		}
 	}

--- a/pgtype/uuid.go
+++ b/pgtype/uuid.go
@@ -39,7 +39,7 @@ func (dst *UUID) Set(src interface{}) error {
 		}
 		*dst = UUID{Bytes: uuid, Status: Present}
 	default:
-		if originalSrc, ok := underlyingPtrType(src); ok {
+		if originalSrc, ok := underlyingUUIDType(src); ok {
 			return dst.Set(originalSrc)
 		}
 		return errors.Errorf("cannot convert %v to UUID", value)

--- a/pgtype/uuid_test.go
+++ b/pgtype/uuid_test.go
@@ -15,6 +15,8 @@ func TestUUIDTranscode(t *testing.T) {
 	})
 }
 
+type SomeUUIDType [16]byte
+
 func TestUUIDSet(t *testing.T) {
 	successfulTests := []struct {
 		source interface{}
@@ -30,6 +32,10 @@ func TestUUIDSet(t *testing.T) {
 		},
 		{
 			source: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			result: pgtype.UUID{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
+		},
+		{
+			source: SomeUUIDType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 			result: pgtype.UUID{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present},
 		},
 		{
@@ -82,6 +88,21 @@ func TestUUIDAssignTo(t *testing.T) {
 		}
 
 		if bytes.Compare(dst, expected) != 0 {
+			t.Errorf("expected %v to assign %v, but result was %v", src, expected, dst)
+		}
+	}
+
+	{
+		src := pgtype.UUID{Bytes: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Status: pgtype.Present}
+		var dst SomeUUIDType
+		expected := [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+
+		err := src.AssignTo(&dst)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if dst != expected {
 			t.Errorf("expected %v to assign %v, but result was %v", src, expected, dst)
 		}
 	}


### PR DESCRIPTION
This is similar in spirit to all the existing pgtype conversion code.

It's just that arrays (not slices) of primitive types aren't currently handled.

In my case, I was using the popular Google UUID library (https://github.com/google/uuid), which wraps `[16]byte`.