### PR TITLE
Terminate context prior to releasing when killing batch connection

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -135,7 +135,7 @@ func (b *Batch) Send(ctx context.Context, txOptions *TxOptions) error {
 
 	_, err = b.conn.conn.Write(buf)
 	if err != nil {
-		b.conn.die(err)
+		b.die(err)
 		return err
 	}
 
@@ -281,10 +281,13 @@ func (b *Batch) die(err error) {
 	}
 
 	b.err = err
-	b.conn.die(err)
+	if b.conn != nil {
+		err = b.conn.termContext(err)
+		b.conn.die(err)
 
-	if b.conn != nil && b.connPool != nil {
-		b.connPool.Release(b.conn)
+		if b.connPool != nil {
+			b.connPool.Release(b.conn)
+		}
 	}
 }
 


### PR DESCRIPTION
We've been getting errors at https://github.com/jackc/pgx/blob/6954c15ad0bd3c9aa6dd1b190732b020379beb28/conn_pool.go#L193 when a postgres connection goes bad.  I believe this is because we are not terminating the context when we kill a connection after an error writing to a connection.

I noticed two things in the code:
1. When we get a write error, we call `die` on the connection rather than the `batch`.  Everywhere else in the file we call `Batch.die` when we decide we have a fatal error.
2. We were not terminating the current context prior to closing the connection.  This is what leads to the panic and I believe can be avoided if we terminate the context prior to calling `die` on the connection.
 
Unfortunately, I couldn't construct a test that simulated a write error.  If you have pointers about how to make this happen, I'd happily add a test.