### PR TITLE
Allow specifying sql.LevelRepeatableRead in BeginTx

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -277,7 +277,7 @@ func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 		pgxOpts.IsoLevel = pgx.ReadUncommitted
 	case sql.LevelReadCommitted:
 		pgxOpts.IsoLevel = pgx.ReadCommitted
-	case sql.LevelSnapshot:
+	case sql.LevelRepeatableRead, sql.LevelSnapshot:
 		pgxOpts.IsoLevel = pgx.RepeatableRead
 	case sql.LevelSerializable:
 		pgxOpts.IsoLevel = pgx.Serializable

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -629,6 +629,7 @@ func TestConnBeginTxIsolation(t *testing.T) {
 		{sqlIso: sql.LevelDefault, pgIso: defaultIsoLevel},
 		{sqlIso: sql.LevelReadUncommitted, pgIso: "read uncommitted"},
 		{sqlIso: sql.LevelReadCommitted, pgIso: "read committed"},
+		{sqlIso: sql.LevelRepeatableRead, pgIso: "repeatable read"},
 		{sqlIso: sql.LevelSnapshot, pgIso: "repeatable read"},
 		{sqlIso: sql.LevelSerializable, pgIso: "serializable"},
 	}


### PR DESCRIPTION
When testing a migration from lib/pq I found that specifying `sql.LevelRepeatableRead` comes back with an unsupported isolation error.

This PR adds `sql.LevelRepeatableRead` to map to `pgx.RepeatableRead` along side `sql.LevelSnapshot`.

I tried digging to see if it was intentionally left out, but came up empty.

Since Postgres [docs](https://www.postgresql.org/docs/current/transaction-iso.html) reference `RepeatableRead`, and users coming from lib/pq can only use `LevelRepeatableRead` (pq does not allow/recognize `LevelSnapshot`) I think it makes sense for pgx/stdlib to support specifying it in `BeginTx`.