### PR TITLE
Correct WaitForNotification example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -225,7 +225,7 @@ notification.
         return nil
     }
 
-    if notification, err := conn.WaitForNotification(time.Second); err != nil {
+    if notification, err := conn.WaitForNotification(context.TODO()); err != nil {
         // do something with notification
     }
 


### PR DESCRIPTION
While working on a project that was using this, I tried using the
example code but instead found that WaitForNotification expects a
Context (which makes sense).

This corrects the docs for folks using that as a jumping off point.