### PR TITLE
Include ParameterOIDs when preparing statements on new pool connections

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -341,7 +341,8 @@ func (p *ConnPool) afterConnectionCreated(c *Conn) (*Conn, error) {
 	}
 
 	for _, ps := range p.preparedStatements {
-		if _, err := c.Prepare(ps.Name, ps.SQL); err != nil {
+		opts := &PrepareExOptions{ParameterOIDs: ps.ParameterOIDs}
+		if _, err := c.PrepareEx(context.Background(), ps.Name, ps.SQL, opts); err != nil {
 			c.die(err)
 			return nil, err
 		}


### PR DESCRIPTION
ParameterOIDs passed to ConnPool.PrepareEx are used to prepare the statement on existing connections in the pool. If additional connections are later created ParameterOIDs are omitted, potentially causing query failures.