### PR TITLE
Fixes #376

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -718,6 +718,38 @@ func TestParseDSN(t *testing.T) {
 			},
 		},
 		{
+			url: "user=jack\\'s password=secret host=localhost port=5432 dbname=mydb",
+			connParams: pgx.ConnConfig{
+				User:     "jack's",
+				Password: "secret",
+				Host:     "localhost",
+				Port:     5432,
+				Database: "mydb",
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				UseFallbackTLS:    true,
+				FallbackTLSConfig: nil,
+				RuntimeParams:     map[string]string{},
+			},
+		},
+		{
+			url: "user=jack password=sooper\\\\secret host=localhost port=5432 dbname=mydb",
+			connParams: pgx.ConnConfig{
+				User:     "jack",
+				Password: "sooper\\secret",
+				Host:     "localhost",
+				Port:     5432,
+				Database: "mydb",
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				UseFallbackTLS:    true,
+				FallbackTLSConfig: nil,
+				RuntimeParams:     map[string]string{},
+			},
+		},
+		{
 			url: "user=jack host=localhost port=5432 dbname=mydb",
 			connParams: pgx.ConnConfig{
 				User:     "jack",
@@ -820,6 +852,62 @@ func TestParseDSN(t *testing.T) {
 				FallbackTLSConfig:  nil,
 				RuntimeParams:      map[string]string{},
 				TargetSessionAttrs: pgx.ReadWriteTargetSession,
+			},
+		},
+		{
+			url: "user='jack' host='localhost' dbname='mydb'",
+			connParams: pgx.ConnConfig{
+				User:     "jack",
+				Host:     "localhost",
+				Database: "mydb",
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				UseFallbackTLS:    true,
+				FallbackTLSConfig: nil,
+				RuntimeParams:     map[string]string{},
+			},
+		},
+		{
+			url: "user='jack\\'s' host='localhost' dbname='mydb'",
+			connParams: pgx.ConnConfig{
+				User:     "jack's",
+				Host:     "localhost",
+				Database: "mydb",
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				UseFallbackTLS:    true,
+				FallbackTLSConfig: nil,
+				RuntimeParams:     map[string]string{},
+			},
+		},
+		{
+			url: "user='jack' password='' host='localhost' dbname='mydb'",
+			connParams: pgx.ConnConfig{
+				User:     "jack",
+				Host:     "localhost",
+				Database: "mydb",
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				UseFallbackTLS:    true,
+				FallbackTLSConfig: nil,
+				RuntimeParams:     map[string]string{},
+			},
+		},
+		{
+			url: "user = 'jack' password = '' host = 'localhost' dbname = 'mydb'",
+			connParams: pgx.ConnConfig{
+				User:     "jack",
+				Host:     "localhost",
+				Database: "mydb",
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				UseFallbackTLS:    true,
+				FallbackTLSConfig: nil,
+				RuntimeParams:     map[string]string{},
 			},
 		},
 	}


### PR DESCRIPTION
Replaced regex DSN parser with a simple parser based on how libpq handles parsing the DSN. This works with `key=value` pairs as well as `key='value'` pairs. It doesn't work with Double Quotes, as that is not listed in the documentation for PostgreSQL. If required, it should be straight forward for it to be added.