### PR TITLE
Clean up two test cases

### DIFF
--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -196,6 +196,7 @@ func TestConnReleaseChecksMaxConnLifetime(t *testing.T) {
 	config.MaxConnLifetime = 250 * time.Millisecond
 
 	db, err := pgxpool.ConnectConfig(context.Background(), config)
+	require.NoError(t, err)
 	defer db.Close()
 
 	c, err := db.Acquire(context.Background())
@@ -240,6 +241,7 @@ func TestPoolBackgroundChecksMaxConnLifetime(t *testing.T) {
 	config.HealthCheckPeriod = 100 * time.Millisecond
 
 	db, err := pgxpool.ConnectConfig(context.Background(), config)
+	require.NoError(t, err)
 	defer db.Close()
 
 	c, err := db.Acquire(context.Background())
@@ -449,7 +451,8 @@ func TestConnReleaseDestroysClosedConn(t *testing.T) {
 	c, err := pool.Acquire(ctx)
 	require.NoError(t, err)
 
-	c.Conn().Close(ctx)
+	err = c.Conn().Close(ctx)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, 1, pool.Stat().TotalConns())
 

--- a/query_test.go
+++ b/query_test.go
@@ -549,11 +549,13 @@ func TestConnQueryErrorWhileReturningRows(t *testing.T) {
 
 			for rows.Next() {
 				var n int32
-				rows.Scan(&n)
+				if err := rows.Scan(&n); err != nil {
+					t.Fatalf("Row scan failed: %v", err)
+				}
 			}
 
-			if err, ok := rows.Err().(*pgconn.PgError); !ok {
-				t.Fatalf("Expected pgx.PgError, got %v", err)
+			if _, ok := rows.Err().(*pgconn.PgError); !ok {
+				t.Fatalf("Expected pgx.PgError, got %v", rows.Err())
 			}
 
 			ensureConnValid(t, conn)


### PR DESCRIPTION
In TestListenNotifyWhileBusyIsSafe, the existing behavior is a race condition that may panic if the database does not support listen/notify.

In TestConnQueryErrorWhileReturningRows, if the conversion to PgError fails, then the PgError is nil. Also if the Scan fails, then the output was confusion.

This is a first pass for compatibility with CockroachDB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jackc/pgx/640)
<!-- Reviewable:end -->
