### PR TITLE
Add arguments count check to execParamsAndPreparedPrefix

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -501,6 +501,10 @@ func (c *Conn) execSimpleProtocol(ctx context.Context, sql string, arguments []i
 }
 
 func (c *Conn) execParamsAndPreparedPrefix(sd *pgconn.StatementDescription, arguments []interface{}) error {
+	if len(sd.ParamOIDs) != len(arguments) {
+		return errors.Errorf("expected %d arguments, got %d", len(sd.ParamOIDs), len(arguments))
+	}
+
 	c.eqb.Reset()
 
 	args, err := convertDriverValuers(arguments)

--- a/conn_test.go
+++ b/conn_test.go
@@ -200,6 +200,12 @@ func TestExecFailureWithArguments(t *testing.T) {
 		t.Fatal("Expected SQL syntax error")
 	}
 	assert.False(t, pgconn.SafeToRetry(err))
+
+	_, err = conn.Exec(context.Background(), "select $1::varchar(1);", "1", "2")
+	if err == nil {
+		t.Fatal("Expected pgx arguments count error", err)
+	}
+	assert.Equal(t, "expected 1 arguments, got 2", err.Error())
 }
 
 func TestExecContextWithoutCancelation(t *testing.T) {


### PR DESCRIPTION
Fix #656 