### PR TITLE
bail early if preloading rows.Next() results in rows.Err()

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -304,6 +304,10 @@ func (c *Conn) QueryContext(ctx context.Context, query string, argsV []driver.Na
 
 	// Preload first row because otherwise we won't know what columns are available when database/sql asks.
 	more := rows.Next()
+	if err = rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
 	return &Rows{conn: c, rows: rows, skipNext: true, skipNextMore: more}, nil
 }
 


### PR DESCRIPTION
This changes behavior a bit to be more inline with other stdlib database/sql drivers.

When a Query results in rows.Err() (eg. permission failures) the query succeeds but ends with no rows. One must check with rows.Err() after a results.Next() loop.

Most people don't expect this and for instance `lib/pq` returns permission errors straight from the query.

With this minor adjustment Query will behave similar to `lib/pq` and more importantly people will get the error early (right from the Query return params). Since the package already preloads the first row we can do this easily.

This solves the misunderstanding as identified in https://github.com/jackc/pgx/issues/416