### PR TITLE
Sanatize time to within microsecond accuracy

### DIFF
--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -48,7 +48,7 @@ func (q *Query) Sanitize(args ...interface{}) (string, error) {
 			case string:
 				str = QuoteString(arg)
 			case time.Time:
-				str = arg.Format("'2006-01-02 15:04:05.999999999Z07:00:00'")
+				str = arg.Truncate(time.Microsecond).Format("'2006-01-02 15:04:05.999999999Z07:00:00'")
 			default:
 				return "", errors.Errorf("invalid arg type: %T", arg)
 			}

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -2,6 +2,7 @@ package sanitize_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v4/internal/sanitize"
 )
@@ -129,6 +130,11 @@ func TestQuerySanitize(t *testing.T) {
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},
 			args:     []interface{}{`foo\'bar`},
 			expected: `select 'foo\''bar'`,
+		},
+		{
+			query:    sanitize.Query{Parts: []sanitize.Part{"insert ", 1}},
+			args:     []interface{}{time.Date(2020, time.March, 1, 23, 59, 59, 999999999, time.UTC)},
+			expected: `insert '2020-03-01 23:59:59.999999Z'`,
 		},
 	}
 


### PR DESCRIPTION
This is a POSTGRES limitation
https://www.postgresql.org/docs/current/datatype-datetime.html