### PR TITLE
Add ability to skip network operations on pool initialization.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b h1:cIcUpcEP55F/QuZWEt
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9 h1:KLBBPU++1T3DHtm1B1QaIHy80Vhu0wNMErIFCNgAL8Y=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jackc/puddle v1.1.0 h1:musOWczZC/rSbqut475Vfcczg7jJsdUQf0D6oKPLgNU=
-github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1 h1:PJAw7H/9hoWC4Kf3J8iNmL1SwA6E8vfsLqBiL+F6CtI=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b h1:cIcUpcEP55F/QuZWEt
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9 h1:KLBBPU++1T3DHtm1B1QaIHy80Vhu0wNMErIFCNgAL8Y=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.1.0 h1:musOWczZC/rSbqut475Vfcczg7jJsdUQf0D6oKPLgNU=
+github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1 h1:PJAw7H/9hoWC4Kf3J8iNmL1SwA6E8vfsLqBiL+F6CtI=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -41,6 +41,23 @@ func TestConnectCancel(t *testing.T) {
 	assert.Equal(t, context.Canceled, err)
 }
 
+func TestLazyConnect(t *testing.T) {
+	t.Parallel()
+
+	config, err := pgxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	assert.NoError(t, err)
+	config.LazyConnect = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	pool, err := pgxpool.ConnectConfig(ctx, config)
+	assert.NoError(t, err)
+
+	_, err = pool.Exec(ctx, "SELECT 1")
+	assert.Equal(t, context.Canceled, err)
+}
+
 func TestConnectConfigRequiresConnConfigFromParseConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
I have a proposal:
Add ability to skip network operation on pool initialization, This will allow to decouple your service from the database on startup. This will improve resilience of the service, because most likely you don't actually require the database on startup, and some transient network error can fail the whole application to start.  
Few examples:

1. `database/sql` with `pgx` as a driver, doesn't do any I/O operation on `sql.Open()` (I tested it). 
2. Official `mongoDB` driver also doesn't do any I/O operation on `Client.Connect()`, here are the [docs](https://godoc.org/go.mongodb.org/mongo-driver/mongo#Connect).

I think it will be a good feature for microservices environment. It should be opt-in, to not break expectations of existing users, but it could become the default behaviour in the next major version. What do you think?
