### PR TITLE
Improve Stdlib context timeouts

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b h1:cIcUpcEP55F/QuZWEt
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9 h1:KLBBPU++1T3DHtm1B1QaIHy80Vhu0wNMErIFCNgAL8Y=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jackc/puddle v1.1.0 h1:musOWczZC/rSbqut475Vfcczg7jJsdUQf0D6oKPLgNU=
-github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1 h1:PJAw7H/9hoWC4Kf3J8iNmL1SwA6E8vfsLqBiL+F6CtI=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -225,7 +225,9 @@ func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 }
 
 func (c *Conn) Close() error {
-	return c.conn.Close(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	return c.conn.Close(ctx)
 }
 
 func (c *Conn) Begin() (driver.Tx, error) {
@@ -325,7 +327,9 @@ type Stmt struct {
 }
 
 func (s *Stmt) Close() error {
-	return s.conn.conn.Deallocate(context.Background(), s.sd.Name)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	return s.conn.conn.Deallocate(ctx, s.sd.Name)
 }
 
 func (s *Stmt) NumInput() int {


### PR DESCRIPTION
As discussed in https://github.com/jackc/pgx/issues/732, adding a default context timeout for stdlib Conn.Close() and Stmt.Close(). 
I also ran `go mod tidy` and included the diff.