### PR TITLE
Add original connection string to Pool and Conn struct

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -30,7 +30,7 @@ type ConnConfig struct {
 	LogLevel LogLevel
 
 	// Original connection string that was parsed into config.
-	ConnStr string
+	ConnString string
 
 	// BuildStatementCache creates the stmtcache.Cache implementation for connections created with this config. Set
 	// to nil to disable automatic prepared statements.
@@ -160,7 +160,7 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 		createdByParseConfig: true,
 		LogLevel:             LogLevelInfo,
 		BuildStatementCache:  buildStatementCache,
-		ConnStr:              connString,
+		ConnString:           connString,
 	}
 
 	return connConfig, nil
@@ -422,8 +422,8 @@ func (c *Conn) StatementCache() stmtcache.Cache { return c.stmtcache }
 // ConnInfo returns the connection info used for this connection.
 func (c *Conn) ConnInfo() *pgtype.ConnInfo { return c.connInfo }
 
-// ConnStr returns the connection string that was used to establish this connection.
-func (c *Conn) ConnStr() string { return c.config.ConnStr }
+// ConnString returns the connection string that was used to establish this connection.
+func (c *Conn) ConnString() string { return c.config.ConnString }
 
 // Exec executes sql. sql can be either a prepared statement name or an SQL string. arguments should be referenced
 // positionally from the sql string as $1, $2, etc.

--- a/conn.go
+++ b/conn.go
@@ -29,6 +29,9 @@ type ConnConfig struct {
 	Logger   Logger
 	LogLevel LogLevel
 
+	// Original connection string that was parsed into config.
+	ConnStr string
+
 	// BuildStatementCache creates the stmtcache.Cache implementation for connections created with this config. Set
 	// to nil to disable automatic prepared statements.
 	BuildStatementCache BuildStatementCacheFunc
@@ -157,6 +160,7 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 		createdByParseConfig: true,
 		LogLevel:             LogLevelInfo,
 		BuildStatementCache:  buildStatementCache,
+		ConnStr:              connString,
 	}
 
 	return connConfig, nil
@@ -417,6 +421,9 @@ func (c *Conn) StatementCache() stmtcache.Cache { return c.stmtcache }
 
 // ConnInfo returns the connection info used for this connection.
 func (c *Conn) ConnInfo() *pgtype.ConnInfo { return c.connInfo }
+
+// ConnStr returns the connection string that was used to establish this connection.
+func (c *Conn) ConnStr() string { return c.config.ConnStr }
 
 // Exec executes sql. sql can be either a prepared statement name or an SQL string. arguments should be referenced
 // positionally from the sql string as $1, $2, etc.

--- a/conn.go
+++ b/conn.go
@@ -30,7 +30,7 @@ type ConnConfig struct {
 	LogLevel LogLevel
 
 	// Original connection string that was parsed into config.
-	ConnString string
+	connString string
 
 	// BuildStatementCache creates the stmtcache.Cache implementation for connections created with this config. Set
 	// to nil to disable automatic prepared statements.
@@ -46,6 +46,8 @@ type ConnConfig struct {
 
 	createdByParseConfig bool // Used to enforce created by ParseConfig rule.
 }
+
+func (cc *ConnConfig) ConnString() string { return cc.connString }
 
 // BuildStatementCacheFunc is a function that can be used to create a stmtcache.Cache implementation for connection.
 type BuildStatementCacheFunc func(conn *pgconn.PgConn) stmtcache.Cache
@@ -160,7 +162,7 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 		createdByParseConfig: true,
 		LogLevel:             LogLevelInfo,
 		BuildStatementCache:  buildStatementCache,
-		ConnString:           connString,
+		connString:           connString,
 	}
 
 	return connConfig, nil
@@ -423,7 +425,10 @@ func (c *Conn) StatementCache() stmtcache.Cache { return c.stmtcache }
 func (c *Conn) ConnInfo() *pgtype.ConnInfo { return c.connInfo }
 
 // ConnString returns the connection string that was used to establish this connection.
-func (c *Conn) ConnString() string { return c.config.ConnString }
+func (c *Conn) ConnString() string { return c.config.ConnString() }
+
+// Config returns config that was used to establish this connection.
+func (c *Conn) Config() *ConnConfig { return c.config }
 
 // Exec executes sql. sql can be either a prepared statement name or an SQL string. arguments should be referenced
 // positionally from the sql string as $1, $2, etc.

--- a/conn_test.go
+++ b/conn_test.go
@@ -28,6 +28,8 @@ func TestCrateDBConnect(t *testing.T) {
 	require.Nil(t, err)
 	defer closeConn(t, conn)
 
+	assert.Equal(t, connString, conn.ConnStr())
+
 	var result int
 	err = conn.QueryRow(context.Background(), "select 1 +1").Scan(&result)
 	if err != nil {
@@ -41,12 +43,15 @@ func TestCrateDBConnect(t *testing.T) {
 func TestConnect(t *testing.T) {
 	t.Parallel()
 
-	config := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+	connStr := os.Getenv("PGX_TEST_DATABASE")
+	config := mustParseConfig(t, connStr)
 
 	conn, err := pgx.ConnectConfig(context.Background(), config)
 	if err != nil {
 		t.Fatalf("Unable to establish connection: %v", err)
 	}
+
+	assert.Equal(t, connStr, conn.ConnStr())
 
 	var currentDB string
 	err = conn.QueryRow(context.Background(), "select current_database()").Scan(&currentDB)
@@ -102,6 +107,13 @@ func TestConnectConfigRequiresConnConfigFromParseConfig(t *testing.T) {
 	require.PanicsWithValue(t, "config must be created by ParseConfig", func() {
 		pgx.ConnectConfig(context.Background(), config)
 	})
+}
+
+func TestConfigContainsConnStr(t *testing.T) {
+	connStr := os.Getenv("PGX_TEST_DATABASE")
+	config, err := pgx.ParseConfig(connStr)
+	require.NoError(t, err)
+	assert.Equal(t, connStr, config.ConnStr)
 }
 
 func TestParseConfigExtractsStatementCacheOptions(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -28,7 +28,7 @@ func TestCrateDBConnect(t *testing.T) {
 	require.Nil(t, err)
 	defer closeConn(t, conn)
 
-	assert.Equal(t, connString, conn.ConnStr())
+	assert.Equal(t, connString, conn.ConnString())
 
 	var result int
 	err = conn.QueryRow(context.Background(), "select 1 +1").Scan(&result)
@@ -51,7 +51,7 @@ func TestConnect(t *testing.T) {
 		t.Fatalf("Unable to establish connection: %v", err)
 	}
 
-	assert.Equal(t, connStr, conn.ConnStr())
+	assert.Equal(t, connStr, conn.ConnString())
 
 	var currentDB string
 	err = conn.QueryRow(context.Background(), "select current_database()").Scan(&currentDB)
@@ -113,7 +113,7 @@ func TestConfigContainsConnStr(t *testing.T) {
 	connStr := os.Getenv("PGX_TEST_DATABASE")
 	config, err := pgx.ParseConfig(connStr)
 	require.NoError(t, err)
-	assert.Equal(t, connStr, config.ConnStr)
+	assert.Equal(t, connStr, config.ConnString)
 }
 
 func TestParseConfigExtractsStatementCacheOptions(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -28,6 +28,7 @@ func TestCrateDBConnect(t *testing.T) {
 	require.Nil(t, err)
 	defer closeConn(t, conn)
 
+	assert.Equal(t, connString, conn.Config().ConnString())
 	assert.Equal(t, connString, conn.ConnString())
 
 	var result int
@@ -43,15 +44,16 @@ func TestCrateDBConnect(t *testing.T) {
 func TestConnect(t *testing.T) {
 	t.Parallel()
 
-	connStr := os.Getenv("PGX_TEST_DATABASE")
-	config := mustParseConfig(t, connStr)
+	connString := os.Getenv("PGX_TEST_DATABASE")
+	config := mustParseConfig(t, connString)
 
 	conn, err := pgx.ConnectConfig(context.Background(), config)
 	if err != nil {
 		t.Fatalf("Unable to establish connection: %v", err)
 	}
 
-	assert.Equal(t, connStr, conn.ConnString())
+	assert.Equal(t, connString, conn.Config().ConnString())
+	assert.Equal(t, connString, conn.ConnString())
 
 	var currentDB string
 	err = conn.QueryRow(context.Background(), "select current_database()").Scan(&currentDB)
@@ -113,7 +115,7 @@ func TestConfigContainsConnStr(t *testing.T) {
 	connStr := os.Getenv("PGX_TEST_DATABASE")
 	config, err := pgx.ParseConfig(connStr)
 	require.NoError(t, err)
-	assert.Equal(t, connStr, config.ConnString)
+	assert.Equal(t, connStr, config.ConnString())
 }
 
 func TestParseConfigExtractsStatementCacheOptions(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	github.com/cockroachdb/apd v1.1.0
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/jackc/pgconn v1.5.0
 	github.com/jackc/pgio v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b h1:cIcUpcEP55F/QuZWEt
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9 h1:KLBBPU++1T3DHtm1B1QaIHy80Vhu0wNMErIFCNgAL8Y=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1 h1:PJAw7H/9hoWC4Kf3J8iNmL1SwA6E8vfsLqBiL+F6CtI=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
@@ -53,12 +54,6 @@ github.com/jackc/pgtype v0.0.0-20190824184912-ab885b375b90/go.mod h1:KcahbBH1nCM
 github.com/jackc/pgtype v0.0.0-20190828014616-a8802b16cc59 h1:xOamcCJ9MFJTxR5bvw3ZXmiP8evQMohdt2VJ57C0W8Q=
 github.com/jackc/pgtype v0.0.0-20190828014616-a8802b16cc59/go.mod h1:MWlu30kVJrUS8lot6TQqcg7mtthZ9T0EoIBFiJcmcyw=
 github.com/jackc/pgtype v1.2.0/go.mod h1:5m2OfMh1wTK7x+Fk952IDmI4nw3nPrvtQdM0ZT4WpC0=
-github.com/jackc/pgtype v1.3.1-0.20200505182314-3b7c47a2a7da h1:ZbfsOjqJ1nHsryU03mdXZy6ZEsymYvihkXxN9tUx1YU=
-github.com/jackc/pgtype v1.3.1-0.20200505182314-3b7c47a2a7da/go.mod h1:vaogEUkALtxZMCH411K+tKzNpwzCKU+AnPzBKZ+I+Po=
-github.com/jackc/pgtype v1.3.1-0.20200508211315-97bbe6ae20e2 h1:Y6cErz3hUojOwnjUEWoZPRCBQcB7avM9ntGiYkB0wJo=
-github.com/jackc/pgtype v1.3.1-0.20200508211315-97bbe6ae20e2/go.mod h1:vaogEUkALtxZMCH411K+tKzNpwzCKU+AnPzBKZ+I+Po=
-github.com/jackc/pgtype v1.3.1-0.20200510045248-7e66ab1e146c h1:id5j6vOwHhbR7BYdGyb0sDMQjNsKTO+mXWaJxiwKu5M=
-github.com/jackc/pgtype v1.3.1-0.20200510045248-7e66ab1e146c/go.mod h1:vaogEUkALtxZMCH411K+tKzNpwzCKU+AnPzBKZ+I+Po=
 github.com/jackc/pgtype v1.3.1-0.20200510190516-8cd94a14c75a h1:XUNeoL8E15IgWouQ8gfA6EPHOfTqVetdxBhAKMYKNGo=
 github.com/jackc/pgtype v1.3.1-0.20200510190516-8cd94a14c75a/go.mod h1:vaogEUkALtxZMCH411K+tKzNpwzCKU+AnPzBKZ+I+Po=
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
@@ -142,6 +137,7 @@ go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
+go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1 h1:XCJQEf3W6eZaVwhRBof6ImoYGJSITeKWsyeh3HFu/5o=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -156,6 +152,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 h1:3zb4D3T4G8jdExgVU/95+vQXfpEPiMdCaZgmGVxjNHM=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -185,6 +182,7 @@ golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190823170909-c4a336ef6a2f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373 h1:PPwnA7z1Pjf7XYaBP9GL1VAMZmcIWyFz7QCMSIIa3Bg=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -202,4 +200,5 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec h1:RlWgLqCM
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -69,7 +69,7 @@ func (cr *connResource) getPoolRows(c *Conn, r pgx.Rows) *poolRows {
 
 type Pool struct {
 	p                 *puddle.Pool
-	connString        string
+	config            *Config
 	afterConnect      func(context.Context, *pgx.Conn) error
 	beforeAcquire     func(context.Context, *pgx.Conn) bool
 	afterRelease      func(*pgx.Conn) bool
@@ -142,7 +142,7 @@ func ConnectConfig(ctx context.Context, config *Config) (*Pool, error) {
 	}
 
 	p := &Pool{
-		connString:        config.ConnConfig.ConnString,
+		config:            config,
 		afterConnect:      config.AfterConnect,
 		beforeAcquire:     config.BeforeAcquire,
 		afterRelease:      config.AfterRelease,
@@ -372,7 +372,10 @@ func (p *Pool) AcquireAllIdle(ctx context.Context) []*Conn {
 }
 
 // ConnString returns the connection string that was used to initialize this pool.
-func (p *Pool) ConnString() string { return p.connString }
+func (p *Pool) ConnString() string { return p.config.ConnConfig.ConnString() }
+
+// Config returns config that was used to initialize this pool.
+func (p *Pool) Config() *Config { return p.config }
 
 func (p *Pool) Stat() *Stat {
 	return &Stat{s: p.p.Stat()}

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -69,7 +69,7 @@ func (cr *connResource) getPoolRows(c *Conn, r pgx.Rows) *poolRows {
 
 type Pool struct {
 	p                 *puddle.Pool
-	connStr           string
+	connString        string
 	afterConnect      func(context.Context, *pgx.Conn) error
 	beforeAcquire     func(context.Context, *pgx.Conn) bool
 	afterRelease      func(*pgx.Conn) bool
@@ -142,7 +142,7 @@ func ConnectConfig(ctx context.Context, config *Config) (*Pool, error) {
 	}
 
 	p := &Pool{
-		connStr:           config.ConnConfig.ConnStr,
+		connString:        config.ConnConfig.ConnString,
 		afterConnect:      config.AfterConnect,
 		beforeAcquire:     config.BeforeAcquire,
 		afterRelease:      config.AfterRelease,
@@ -371,8 +371,8 @@ func (p *Pool) AcquireAllIdle(ctx context.Context) []*Conn {
 	return conns
 }
 
-// ConnStr returns the connection string that was used to initialize this pool.
-func (p *Pool) ConnStr() string { return p.connStr }
+// ConnString returns the connection string that was used to initialize this pool.
+func (p *Pool) ConnString() string { return p.connString }
 
 func (p *Pool) Stat() *Stat {
 	return &Stat{s: p.p.Stat()}

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -69,6 +69,7 @@ func (cr *connResource) getPoolRows(c *Conn, r pgx.Rows) *poolRows {
 
 type Pool struct {
 	p                 *puddle.Pool
+	connStr           string
 	afterConnect      func(context.Context, *pgx.Conn) error
 	beforeAcquire     func(context.Context, *pgx.Conn) bool
 	afterRelease      func(*pgx.Conn) bool
@@ -141,6 +142,7 @@ func ConnectConfig(ctx context.Context, config *Config) (*Pool, error) {
 	}
 
 	p := &Pool{
+		connStr:           config.ConnConfig.ConnStr,
 		afterConnect:      config.AfterConnect,
 		beforeAcquire:     config.BeforeAcquire,
 		afterRelease:      config.AfterRelease,
@@ -368,6 +370,9 @@ func (p *Pool) AcquireAllIdle(ctx context.Context) []*Conn {
 
 	return conns
 }
+
+// ConnStr returns the connection string that was used to initialize this pool.
+func (p *Pool) ConnStr() string { return p.connStr }
 
 func (p *Pool) Stat() *Stat {
 	return &Stat{s: p.p.Stat()}

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -14,9 +14,10 @@ import (
 
 func TestConnect(t *testing.T) {
 	t.Parallel()
-
-	pool, err := pgxpool.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	connStr := os.Getenv("PGX_TEST_DATABASE")
+	pool, err := pgxpool.Connect(context.Background(), connStr)
 	require.NoError(t, err)
+	assert.Equal(t, connStr, pool.ConnStr())
 	pool.Close()
 }
 

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -14,10 +14,21 @@ import (
 
 func TestConnect(t *testing.T) {
 	t.Parallel()
-	connStr := os.Getenv("PGX_TEST_DATABASE")
-	pool, err := pgxpool.Connect(context.Background(), connStr)
+	connString := os.Getenv("PGX_TEST_DATABASE")
+	pool, err := pgxpool.Connect(context.Background(), connString)
 	require.NoError(t, err)
-	assert.Equal(t, connStr, pool.ConnString())
+	assert.Equal(t, connString, pool.ConnString())
+	pool.Close()
+}
+
+func TestConnectConfig(t *testing.T) {
+	t.Parallel()
+	connString := os.Getenv("PGX_TEST_DATABASE")
+	config, err := pgxpool.ParseConfig(connString)
+	require.NoError(t, err)
+	pool, err := pgxpool.ConnectConfig(context.Background(), config)
+	require.NoError(t, err)
+	assert.Equal(t, config, pool.Config())
 	pool.Close()
 }
 

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -17,7 +17,7 @@ func TestConnect(t *testing.T) {
 	connStr := os.Getenv("PGX_TEST_DATABASE")
 	pool, err := pgxpool.Connect(context.Background(), connStr)
 	require.NoError(t, err)
-	assert.Equal(t, connStr, pool.ConnStr())
+	assert.Equal(t, connStr, pool.ConnString())
 	pool.Close()
 }
 


### PR DESCRIPTION
Now we can access connection string that was used to initialize pool or connection as it was requested in https://github.com/jackc/pgx/issues/742