### PR TITLE
Fix invalid field decoding in stdlib, performance improvement

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -507,6 +507,11 @@ func (r *Rows) Next(dest []driver.Value) error {
 		r.valueFuncs = make([]rowValueFunc, len(fieldDescriptions))
 
 		for i, fd := range fieldDescriptions {
+			// The functions in valueFuncs refer to fd. But, since fd is a range variable,
+			// it may be the wrong value by the time a given valueFunc is run. Capture it
+			// to make sure each function refers to the correct description.
+			fd := fd
+
 			switch fd.DataTypeOID {
 			case pgtype.BoolOID:
 				var d bool


### PR DESCRIPTION
Fixes #781.

I'm still unsure what the right way to test this would be. It seems like it should happen any time you try to scan more than one value, given `fd` will contain whichever value came last in the slice.