### PR TITLE
Cache column names in stdlib Rows

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -412,15 +412,20 @@ type Rows struct {
 	valueFuncs   []rowValueFunc
 	skipNext     bool
 	skipNextMore bool
+
+	columnNames []string
 }
 
 func (r *Rows) Columns() []string {
-	fieldDescriptions := r.rows.FieldDescriptions()
-	names := make([]string, 0, len(fieldDescriptions))
-	for _, fd := range fieldDescriptions {
-		names = append(names, string(fd.Name))
+	if r.columnNames == nil {
+		fields := r.rows.FieldDescriptions()
+		r.columnNames = make([]string, len(fields))
+		for i, fd := range fields {
+			r.columnNames[i] = string(fd.Name)
+		}
 	}
-	return names
+
+	return r.columnNames
 }
 
 // ColumnTypeDatabaseTypeName returns the database system type name. If the name is unknown the OID is returned.


### PR DESCRIPTION
A recent PR to pgconn fixed a bug where the field descriptions were cleared when they shouldn't be. That had a knockon effect of making `Columns` do more work here (since its data wasn't being deleted), but caused a performance impact. See jackc/pgconn#45.

This PR caches the column names, so long as the field descriptions do not change. I'm uncertain if they ever will in the current code, given this driver does not implement `driver.RowsNextResultSet`, but I've attempted to handle it anyway.

Note that the way I'm checking that the field descriptions do not change relies on the fact that `pgconn` will never modify its field description slices and instead make new ones. If you do not believe this to be a good thing to rely on, then I can do a simple equality check against a single string slice, as code that looks like this does not allocate either:

```go
func BytesEqualString(b []byte, s string) bool {
    return string(b) == s  // Compiler proves that b is not modified, so does not allocate.
}
```