### PR TITLE
Fix SimpleProtocol with prepared statement

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -473,12 +473,12 @@ optionLoop:
 		}
 	}
 
-	if simpleProtocol {
-		return c.execSimpleProtocol(ctx, sql, arguments)
-	}
-
 	if sd, ok := c.preparedStatements[sql]; ok {
 		return c.execPrepared(ctx, sd, arguments)
+	}
+
+	if simpleProtocol {
+		return c.execSimpleProtocol(ctx, sql, arguments)
 	}
 
 	if len(arguments) == 0 {
@@ -624,7 +624,9 @@ optionLoop:
 	rows := c.getRows(ctx, sql, args)
 
 	var err error
-	if simpleProtocol {
+	sd, ok := c.preparedStatements[sql]
+
+	if simpleProtocol && !ok {
 		sql, err = c.sanitizeForSimpleQuery(sql, args...)
 		if err != nil {
 			rows.fatal(err)
@@ -646,7 +648,6 @@ optionLoop:
 
 	c.eqb.Reset()
 
-	sd, ok := c.preparedStatements[sql]
 	if !ok {
 		if c.stmtcache != nil {
 			sd, err = c.stmtcache.Get(ctx, sql)


### PR DESCRIPTION
Hello,

When I am testing the SimpleProtocol with prepared statement, the `pgx` driver returns error `unused argument: 0` which from https://github.com/jackc/pgx/blob/43ce317556c724144d1a44bc8d176c2882ad6ebf/internal/sanitize/sanitize.go#L236

The SQL here is something like `pgx_0` because it is a prepared statement, so it can't pass the `Sanitizer` 

The issue should be fixed after this change, thank you.

