### PR TITLE
remove unused definitions on messages.go

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -3,14 +3,7 @@ package pgx
 import (
 	"database/sql/driver"
 
-	"github.com/jackc/pgio"
 	"github.com/jackc/pgtype"
-)
-
-const (
-	copyData = 'd'
-	copyFail = 'f'
-	copyDone = 'c'
 )
 
 func convertDriverValuers(args []interface{}) ([]interface{}, error) {
@@ -27,16 +20,4 @@ func convertDriverValuers(args []interface{}) ([]interface{}, error) {
 		}
 	}
 	return args, nil
-}
-
-// appendQuery appends a PostgreSQL wire protocol query message to buf and returns it.
-func appendQuery(buf []byte, query string) []byte {
-	buf = append(buf, 'Q')
-	sp := len(buf)
-	buf = pgio.AppendInt32(buf, -1)
-	buf = append(buf, query...)
-	buf = append(buf, 0)
-	pgio.SetInt32(buf[sp:], int32(len(buf[sp:])))
-
-	return buf
 }


### PR DESCRIPTION
Looks like it was added and not used for a long time, safe to delete.

```
messages.go:11:2: `copyData` is unused (deadcode)
messages.go:12:2: `copyFail` is unused (deadcode)
messages.go:13:2: `copyDone` is unused (deadcode)
messages.go:33:6: `appendQuery` is unused (deadcode)
```

By the way, those consts aren't used too https://github.com/jackc/pgx/blob/master/conn.go#L18 and one func https://github.com/jackc/pgx/blob/master/conn.go#L401 Have decided to ask first and then remove, if you're ok with it.

```
conn.go:19:2: `connStatusUninitialized` is unused (deadcode)
conn.go:20:2: `connStatusClosed` is unused (deadcode)
conn.go:21:2: `connStatusIdle` is unused (deadcode)
conn.go:22:2: `connStatusBusy` is unused (deadcode)
conn.go:384:6: `connInfoFromRows` is unused (deadcode)

conn.go:313:16: func `(*Conn).processContextFreeMsg` is unused (unused)
conn.go:322:16: func `(*Conn).rxErrorResponse` is unused (unused)
```