### PR TITLE
Add MaxConnLifetime config setting to pool in v3

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -224,6 +224,7 @@ func (cc *ConnConfig) networkAddresses() ([]net.Addr, error) {
 // goroutines.
 type Conn struct {
 	conn               net.Conn  // the underlying TCP or unix domain socket connection
+	creationTime       time.Time // the time indicating when the connection is established
 	lastActivityTime   time.Time // the last time the connection was used
 	wbuf               []byte
 	pid                uint32            // backend pid
@@ -457,7 +458,7 @@ func connect(config ConnConfig, connInfo *pgtype.ConnInfo) (c *Conn, err error) 
 		}
 
 		c.addr = addr
-
+		c.creationTime = time.Now()
 		return c, nil
 	}
 
@@ -600,6 +601,10 @@ func (c *Conn) connect(config ConnConfig, network, address string, tlsConfig *tl
 			}
 		}
 	}
+}
+
+func (c *Conn) CreationTime() time.Time {
+	return c.creationTime
 }
 
 func initPostgresql(c *Conn) (*pgtype.ConnInfo, error) {


### PR DESCRIPTION
In our usage, we want to enforce our connections to be recycled so that the application can pick up the newly added replicas in ur aurora cluster.

In light of the issue we are experiencing with https://github.com/jackc/pgx/issues/845,
and the fact that we want to have the ability to recycle our connections,
this patch proposes to add the `MaxConnLifetime` config value and its behaviour to v3 releases.

The work done in this PR is trying to mimic what has done for v4 track, but w/o the idle connection check since that has turned out be an harder port than the simple implementation of just checking the conn lifetime after its usage during `Release` phase: https://github.com/jackc/pgx/commit/c604afba82679df5ca91fbd6da922fdd205d4310

The the other difference is that this one doesn't have a default maxConnLifetime value defined,
which means that the current v3 usage out there shouldn't be impacted by this change.