### PR TITLE
Add Ping method to pgxpool.Conn

### DIFF
--- a/pgxpool/conn.go
+++ b/pgxpool/conn.go
@@ -78,6 +78,10 @@ func (c *Conn) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, er
 	return c.Conn().BeginTx(ctx, txOptions)
 }
 
+func (c *Conn) Ping(ctx context.Context) error {
+	return c.Conn().Ping(ctx)
+}
+
 func (c *Conn) Conn() *pgx.Conn {
 	return c.connResource().conn
 }

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -492,3 +492,12 @@ func (p *Pool) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNam
 
 	return c.Conn().CopyFrom(ctx, tableName, columnNames, rowSrc)
 }
+
+func (p *Pool) Ping(ctx context.Context) error {
+	c, err := p.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.Release()
+	return c.Ping(ctx)
+}


### PR DESCRIPTION
Adds the Ping method to pgxpool.Conn, returning the result of calling Ping on the underlying pgx.Conn.

Closes #918 