### PR TITLE
Make ScanArgError public to allow identification of offending column

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -221,7 +221,7 @@ func (rows *connRows) Scan(dest ...interface{}) error {
 
 		err := rows.scanPlans[i].Scan(ci, fieldDescriptions[i].DataTypeOID, fieldDescriptions[i].Format, values[i], dst)
 		if err != nil {
-			err = scanArgError{col: i, err: err}
+			err = ScanArgError{col: i, err: err}
 			rows.fatal(err)
 			return err
 		}
@@ -306,12 +306,12 @@ func (rows *connRows) RawValues() [][]byte {
 	return rows.values
 }
 
-type scanArgError struct {
+type ScanArgError struct {
 	col int
 	err error
 }
 
-func (e scanArgError) Error() string {
+func (e ScanArgError) Error() string {
 	return fmt.Sprintf("can't scan into dest[%d]: %v", e.col, e.err)
 }
 
@@ -336,7 +336,7 @@ func ScanRow(connInfo *pgtype.ConnInfo, fieldDescriptions []pgproto3.FieldDescri
 
 		err := connInfo.Scan(fieldDescriptions[i].DataTypeOID, fieldDescriptions[i].Format, values[i], d)
 		if err != nil {
-			return scanArgError{col: i, err: err}
+			return ScanArgError{col: i, err: err}
 		}
 	}
 


### PR DESCRIPTION
I'm working on fixing some things on https://github.com/randallmlough/pgxscan library, which builds on top of the amazing pgx. I found the limitation of not being able to identify column name when this error arises, and we can improve error reporting a lot with this feature (I mean, it can be done without this, but requires doing some extra parsing of a string, which hurts performance and is a pity taking into account that the information is already there).

I've created this ticket to report the problem, but since the change is straightforward I made it myself.
https://github.com/jackc/pgx/issues/931

Thanks a lot for considering it.