### PR TITLE
Add Row.Err method

### DIFF
--- a/pgxpool/rows.go
+++ b/pgxpool/rows.go
@@ -23,6 +23,7 @@ type errRow struct {
 	err error
 }
 
+func (e errRow) Err() error                     { return e.err }
 func (e errRow) Scan(dest ...interface{}) error { return e.err }
 
 type poolRows struct {
@@ -90,6 +91,10 @@ type poolRow struct {
 	r   pgx.Row
 	c   *Conn
 	err error
+}
+
+func (row *poolRow) Err() error {
+	return row.err
 }
 
 func (row *poolRow) Scan(dest ...interface{}) error {

--- a/rows.go
+++ b/rows.go
@@ -64,6 +64,9 @@ type Row interface {
 	// rows were found it returns ErrNoRows. If multiple rows are returned it
 	// ignores all but the first.
 	Scan(dest ...interface{}) error
+
+	// Err returns any error that occurred while running the query.
+	Err() error
 }
 
 // connRow implements the Row interface for Conn.QueryRow.
@@ -85,6 +88,11 @@ func (r *connRow) Scan(dest ...interface{}) (err error) {
 
 	rows.Scan(dest...)
 	rows.Close()
+	return rows.Err()
+}
+
+func (r *connRow) Err() error {
+	rows := (*connRows)(r)
 	return rows.Err()
 }
 


### PR DESCRIPTION
Expose Rows.Err as a method on Row, to allow for easily checking
whether the query returned an error without calling Scan.