### PR TITLE
Prevent NPE when calling Query/QueryRow on a BatchResults from SendBatch called on a closed transaction.

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -70,10 +70,10 @@ func (br *batchResults) Exec() (pgconn.CommandTag, error) {
 			err = errors.New("no result")
 		}
 		if br.conn.shouldLog(LogLevelError) {
-			br.conn.log(br.ctx, LogLevelError, "BatchResult.Exec", map[string]interface{} {
-				"sql": query,
+			br.conn.log(br.ctx, LogLevelError, "BatchResult.Exec", map[string]interface{}{
+				"sql":  query,
 				"args": logQueryArgs(arguments),
-				"err": err,
+				"err":  err,
 			})
 		}
 		return nil, err
@@ -90,9 +90,9 @@ func (br *batchResults) Exec() (pgconn.CommandTag, error) {
 			})
 		}
 	} else if br.conn.shouldLog(LogLevelInfo) {
-		br.conn.log(br.ctx, LogLevelInfo, "BatchResult.Exec", map[string]interface{} {
-			"sql": query,
-			"args": logQueryArgs(arguments),
+		br.conn.log(br.ctx, LogLevelInfo, "BatchResult.Exec", map[string]interface{}{
+			"sql":        query,
+			"args":       logQueryArgs(arguments),
 			"commandTag": commandTag,
 		})
 	}
@@ -107,13 +107,11 @@ func (br *batchResults) Query() (Rows, error) {
 		query = "batch query"
 	}
 
-	rows := br.conn.getRows(br.ctx, query, arguments)
-
 	if br.err != nil {
-		rows.err = br.err
-		rows.closed = true
-		return rows, br.err
+		return &connRows{err: br.err, closed: true}, br.err
 	}
+
+	rows := br.conn.getRows(br.ctx, query, arguments)
 
 	if !br.mrr.NextResult() {
 		rows.err = br.mrr.Close()
@@ -123,10 +121,10 @@ func (br *batchResults) Query() (Rows, error) {
 		rows.closed = true
 
 		if br.conn.shouldLog(LogLevelError) {
-			br.conn.log(br.ctx, LogLevelError, "BatchResult.Query", map[string]interface{} {
-				"sql": query,
+			br.conn.log(br.ctx, LogLevelError, "BatchResult.Query", map[string]interface{}{
+				"sql":  query,
 				"args": logQueryArgs(arguments),
-				"err": rows.err,
+				"err":  rows.err,
 			})
 		}
 
@@ -159,8 +157,8 @@ func (br *batchResults) Close() error {
 		}
 
 		if br.conn.shouldLog(LogLevelInfo) {
-			br.conn.log(br.ctx, LogLevelInfo, "BatchResult.Close", map[string]interface{} {
-				"sql": query,
+			br.conn.log(br.ctx, LogLevelInfo, "BatchResult.Close", map[string]interface{}{
+				"sql":  query,
 				"args": logQueryArgs(args),
 			})
 		}


### PR DESCRIPTION
# Summary
While using the transaction `SendBatch` call, I noticed that if the transaction is closed, calling `SendBatch` and attempting to read the results of a `Query` or `QueryRow` call on the `BatchResults` produces an NPE. Calls to `Exec` work properly because the `BatchResults` instance exits immediately with an error if the `error` member is populated. `Query` and `QueryRow` fail because the `BatchResults` instance attempts to call `getRows` on a nil connection. The fix in this PR is just returning a new `*connRows` instance to wrap the error on the `BatchResults`. Another solution might be to handle the case of a nil `*Conn` receiver in the `getRows` call itself. I'm happy to amend this PR if there's another way this should be solved. (Apologies for the `go fmt` masking the change a bit.)

# Reproduction Steps
1. Obtain a connection.
2. Begin a transaction.
3. Commit or rollback the transaction to close it.
4. Call `SendBatch` on the transaction with a non-empty batch.
5. Attempt to call `Query` or `QueryRow` on the `BatchResults`.
6. Observe panic due to the connection being nil.