### PR TITLE
Prevent panics caused by attempting to close an already closed pgxpool.Pool.

### DIFF
--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -789,3 +789,14 @@ func TestTxBeginFuncNestedTransactionRollback(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 2, n)
 }
+
+func TestIdempotentPoolClose(t *testing.T) {
+	pool, err := pgxpool.Connect(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+
+	// Close the open pool.
+	require.NotPanics(t, func() { pool.Close() })
+
+	// Close the already closed pool.
+	require.NotPanics(t, func() { pool.Close() })
+}


### PR DESCRIPTION
# Summary
Attempting to close a `pgxpool.Pool` instance that was previously closed will result in a panic because the `closeChan` member will have already been closed. This simply checks the if the channel is open by attempting to read from it before calling close. One case in which this change will help is when a function contains both a `defer pool.Close()` and a manual closure (however contrived that might be in the real world.)

# Reproduction Steps
1. Connect a pool.
2. Close the pool.
3. Attempt to close the pool again.
4. Observe the panic due to multiple `close` calls against the `closeChan` member.