### PR TITLE
stdlib: Do not reuse ConnConfig strings

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -169,6 +169,7 @@ func GetDefaultDriver() driver.Driver {
 type Driver struct {
 	configMutex sync.Mutex
 	configs     map[string]*pgx.ConnConfig
+	sequence    int
 }
 
 func (d *Driver) Open(name string) (driver.Conn, error) {
@@ -188,7 +189,8 @@ func (d *Driver) OpenConnector(name string) (driver.Connector, error) {
 
 func (d *Driver) registerConnConfig(c *pgx.ConnConfig) string {
 	d.configMutex.Lock()
-	connStr := fmt.Sprintf("registeredConnConfig%d", len(d.configs))
+	connStr := fmt.Sprintf("registeredConnConfig%d", d.sequence)
+	d.sequence++
 	d.configs[connStr] = c
 	d.configMutex.Unlock()
 	return connStr

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -1067,8 +1067,15 @@ func TestRegisterConnConfig(t *testing.T) {
 	logger := &testLogger{}
 	connConfig.Logger = logger
 
+	// Issue 947: Register and unregister a ConnConfig and ensure that the
+	// returned connection string is not reused.
 	connStr := stdlib.RegisterConnConfig(connConfig)
+	require.Equal(t, "registeredConnConfig0", connStr)
+	stdlib.UnregisterConnConfig(connStr)
+
+	connStr = stdlib.RegisterConnConfig(connConfig)
 	defer stdlib.UnregisterConnConfig(connStr)
+	require.Equal(t, "registeredConnConfig1", connStr)
 
 	db, err := sql.Open("pgx", connStr)
 	require.NoError(t, err)


### PR DESCRIPTION
Previously, stdlib.RegisterConnConfig would sometimes reuse the same connection
string for different ConnConfig options (specifically, it happened when a connection
was open and then closed, and then a new, different connection was opened). This
behavior interferes with callers that expect that two connections with the same data
source name are connecting to the same backend database in the same way.

This fix updates stdlib.RegisterConnConfig to use an incrementing sequence
counter to uniquify all returned connection strings.

Fixes #947