### PR TITLE
Call pgxpool AfterRelease inline, not in a goroutine

### DIFF
--- a/pgxpool/conn.go
+++ b/pgxpool/conn.go
@@ -32,18 +32,12 @@ func (c *Conn) Release() {
 		return
 	}
 
-	if c.p.afterRelease == nil {
+	if c.p.afterRelease == nil || c.p.afterRelease(conn) {
 		res.Release()
 		return
 	}
 
-	go func() {
-		if c.p.afterRelease(conn) {
-			res.Release()
-		} else {
-			res.Destroy()
-		}
-	}()
+	go res.Destroy()
 }
 
 func (c *Conn) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {


### PR DESCRIPTION
Happy to discuss. I think the change makes sense because it gives more control to the
caller.

This is a partial revert of f572b336. This makes AfterRelease more useful since
it will always run before the Query methods return.

My specific use-case was adding events to a distributed trace. The problem was
that events were getting dropped because the goroutine for AfterRelease was
consistently scheduled after request and corresponding trace ended. As an
example:

```go
func TestRacyAfterRelease(t *testing.T) {
	var connStr string
	ctx := context.Background()

	ctx, span := trace.OpenSpan(ctx, "test DB")
	cfg, _ := pgxpool.ParseConfig(connStr)
	cfg.BeforeConnect = func(ctx context.Context, cfg *pgx.ConnConfig) error {
		span.AddEvent("BeforeConnect")
		return nil
	}
	cfg.AfterRelease = func(conn *pgx.Conn) bool {
		span.AddEvent("AfterRelease")
		return true
	}
	pool, _ := pgxpool.ConnectConfig(ctx, cfg)

	dest := 0
	row := pool.QueryRow(ctx, `SELECT 1`)
	_ = row.Scan(&dest)

	// The "AfterRelease" event is probably not part of the trace since it
	// runs in a goroutine triggered by Scan.
	span.Close()
}
```

This commit runs AfterRelease inline instead of in the goroutine. If the caller
doesn't want to block on AfterRelease, they should create the goroutine, e.g.:

```go
	cfg.BeforeConnect = func(ctx context.Context, cfg *pgx.ConnConfig) error {
		go func() {
			span.AddEvent("BeforeConnect")
		}()
		return nil
	}
```