### PR TITLE
Checking that connection was not closed by the server before reusing it from the pool.

### DIFF
--- a/stdlib/conncheck.go
+++ b/stdlib/conncheck.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build !windows
+
+package stdlib
+
+import (
+	"errors"
+	"io"
+	"net"
+	"syscall"
+)
+
+var errUnexpectedRead = errors.New("unexpected read from socket")
+
+func connCheck(c net.Conn) error {
+	var (
+		n    int
+		err  error
+		buff [1]byte
+	)
+
+	sconn, ok := c.(syscall.Conn)
+	if !ok {
+		return nil
+	}
+	rc, err := sconn.SyscallConn()
+	if err != nil {
+		return err
+	}
+	rerr := rc.Read(func(fd uintptr) bool {
+		n, err = syscall.Read(int(fd), buff[:])
+		return true
+	})
+	switch {
+	case rerr != nil:
+		return rerr
+	case n == 0 && err == nil:
+		return io.EOF
+	case n > 0:
+		return errUnexpectedRead
+	case err == syscall.EAGAIN || err == syscall.EWOULDBLOCK:
+		return nil
+	default:
+		return err
+	}
+}

--- a/stdlib/conncheck_test.go
+++ b/stdlib/conncheck_test.go
@@ -1,0 +1,28 @@
+// +build go1.10,!windows
+
+package stdlib_test
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaleConnectionChecks(t *testing.T) {
+	db, err := sql.Open("pgx", os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+
+	_, err = db.Exec("SET SESSION idle_in_transaction_session_timeout = 100; BEGIN;")
+	require.NoError(t, err)
+
+	// wait for PostgreSQL to close our connection
+	time.Sleep(150 * time.Millisecond)
+
+	err = db.Ping()
+	require.NoError(t, err)
+
+	closeDB(t, db)
+}

--- a/stdlib/conncheck_windows.go
+++ b/stdlib/conncheck_windows.go
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package stdlib
+
+import "net"
+
+func connCheck(c net.Conn) error {
+	return nil
+}

--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -391,6 +391,11 @@ func (c *Conn) ResetSession(ctx context.Context) error {
 	if c.conn.IsClosed() {
 		return driver.ErrBadConn
 	}
+
+	if err := connCheck(c.Conn().PgConn().Conn()); err != nil {
+		return driver.ErrBadConn
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Checking that conn.write() doesn't return an error during query execution is not enough to prevent errors like EOF for closed connections by the server because write() syscall returns success for the socket that received FIN packet (half-closed TCP connection).
EOF error will be returned only after the read() call but in this case, we cannot distinguish half-closed connection(after the previous query) and read timeout for the new query so query retry is not safe and driver propagates the error to the application.
We use a lightweight non-blocking read from the socket that immediately returns the result in driver.ResetSession() method before a connection is reused for another query so a new connection will be taken from the pool if server initiated connection closing and application can work smoothly.

Implementation was taken from [go mysql driver](https://github.com/go-sql-driver/mysql/pull/934/files).

https://github.blog/2020-05-20-three-bugs-in-the-go-mysql-driver/
https://github.com/golang/go/issues/15735#issuecomment-481519888