### PR TITLE
Don't allocate buffer when tx opts are empty

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -42,7 +42,12 @@ type TxOptions struct {
 	DeferrableMode TxDeferrableMode
 }
 
+var emptyTxOptions TxOptions
+
 func (txOptions TxOptions) beginSQL() string {
+	if txOptions == emptyTxOptions {
+		return "begin"
+	}
 	buf := &bytes.Buffer{}
 	buf.WriteString("begin")
 	if txOptions.IsoLevel != "" {


### PR DESCRIPTION
In majority of cases TX'es are started with no options, this PR adds a fast path that avoids extra allocations.

Here's small benchmark of `(txOptions TxOptions) beginSQL()` before and after:

```
Benchmark-12            17057540               182.0 ns/op           112 B/op          2 allocs/op
Benchmark-12            1000000000               0.2560 ns/op          0 B/op          0 allocs/op
```