### PR TITLE
Implement timeout error

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -409,6 +409,7 @@ func (c *Conn) Exec(ctx context.Context, sql string, arguments ...interface{}) (
 
 	commandTag, err := c.exec(ctx, sql, arguments...)
 	if err != nil {
+		err = wrapErrIfTimeout(err)
 		if c.shouldLog(LogLevelError) {
 			c.log(ctx, LogLevelError, "Exec", map[string]interface{}{"sql": sql, "args": logQueryArgs(arguments), "err": err})
 		}
@@ -603,7 +604,7 @@ optionLoop:
 			rows.resultReader = mrr.ResultReader()
 			rows.multiResultReader = mrr
 		} else {
-			err = mrr.Close()
+			err = wrapErrIfTimeout(mrr.Close())
 			rows.fatal(err)
 			return rows, err
 		}

--- a/rows.go
+++ b/rows.go
@@ -161,7 +161,7 @@ func (rows *connRows) CommandTag() pgconn.CommandTag {
 }
 
 func (rows *connRows) Err() error {
-	return rows.err
+	return wrapErrIfTimeout(rows.err)
 }
 
 // fatal signals an error occurred after the query was sent to the server. It

--- a/timeout.go
+++ b/timeout.go
@@ -1,0 +1,55 @@
+package pgx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+)
+
+// ErrPostgresTimeout occurs when an error was caused by a timeout. Specifically, it is true if err is or was caused
+// by a context.Canceled, context.DeadlineExceeded or an implementer of net.Error where Timeout() is true.
+type ErrPostgresTimeout struct {
+	Err         error
+	isTimeout   bool
+	isTemporary bool
+}
+
+func (e *ErrPostgresTimeout) Error() string { return fmt.Sprint("postgres timeout: " + e.Err.Error()) }
+
+func (e *ErrPostgresTimeout) Unwrap() error { return e.Err }
+
+func (e *ErrPostgresTimeout) Temporary() bool {
+	return e.isTemporary
+}
+
+func (e *ErrPostgresTimeout) Timeout() bool {
+	return e.isTimeout
+}
+
+// wrapErrIfTimeout wraps an error if it was caused by a timeout. Otherwise, the passed error is returned as-is.
+func wrapErrIfTimeout(err error) error {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return &ErrPostgresTimeout{
+			Err:         err,
+			isTimeout:   true,
+			isTemporary: netErr.Temporary(),
+		}
+	}
+	if errors.Is(err, context.Canceled) {
+		return &ErrPostgresTimeout{
+			Err:         err,
+			isTimeout:   false,
+			isTemporary: false,
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &ErrPostgresTimeout{
+			Err:         err,
+			isTimeout:   true,
+			isTemporary: false,
+		}
+	}
+	return err
+}

--- a/timeout.go
+++ b/timeout.go
@@ -10,46 +10,20 @@ import (
 // ErrPostgresTimeout occurs when an error was caused by a timeout. Specifically, it is true if err is or was caused
 // by a context.Canceled, context.DeadlineExceeded or an implementer of net.Error where Timeout() is true.
 type ErrPostgresTimeout struct {
-	Err         error
-	isTimeout   bool
-	isTemporary bool
+	Err error
 }
 
 func (e *ErrPostgresTimeout) Error() string { return fmt.Sprint("postgres timeout: " + e.Err.Error()) }
 
 func (e *ErrPostgresTimeout) Unwrap() error { return e.Err }
 
-func (e *ErrPostgresTimeout) Temporary() bool {
-	return e.isTemporary
-}
-
-func (e *ErrPostgresTimeout) Timeout() bool {
-	return e.isTimeout
-}
-
 // wrapErrIfTimeout wraps an error if it was caused by a timeout. Otherwise, the passed error is returned as-is.
 func wrapErrIfTimeout(err error) error {
 	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return &ErrPostgresTimeout{
-			Err:         err,
-			isTimeout:   true,
-			isTemporary: netErr.Temporary(),
-		}
-	}
-	if errors.Is(err, context.Canceled) {
-		return &ErrPostgresTimeout{
-			Err:         err,
-			isTimeout:   false,
-			isTemporary: false,
-		}
-	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		return &ErrPostgresTimeout{
-			Err:         err,
-			isTimeout:   true,
-			isTemporary: false,
-		}
+	if (errors.As(err, &netErr) && netErr.Timeout()) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return &ErrPostgresTimeout{Err: err}
 	}
 	return err
 }

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -1,0 +1,80 @@
+package pgx_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v4"
+)
+
+type timeoutErrTest struct {
+	executor             string // Whether to use Exec() or Query()
+	preferSimpleProtocol bool   // Disables implicit prepared statement usage
+	timeoutMethod        string // Whether a timeout is triggered by canceling a context or by passing its deadline
+}
+
+func TestTimeoutErr(t *testing.T) {
+	t.Parallel()
+
+	config := mustParseConfig(t, os.Getenv("PGX_TEST_DATABASE"))
+
+	// Generate all permutations of timeoutErrTest.
+	tests := make([]timeoutErrTest, 8)
+	for i, executor := range []string{"exec", "query"} {
+		for j, preferSimpleProtocol := range []bool{true, false} {
+			for k, timeoutMethod := range []string{"cancel", "deadline"} {
+				idx := (i * 4) + (j * 2) + k
+				tests[idx] = timeoutErrTest{executor, preferSimpleProtocol, timeoutMethod}
+			}
+		}
+	}
+
+	for _, tt := range tests {
+		func() {
+			config.PreferSimpleProtocol = tt.preferSimpleProtocol
+			conn := mustConnect(t, config)
+			defer closeConn(t, conn)
+
+			var ctx context.Context
+			var cancel context.CancelFunc
+			switch tt.timeoutMethod {
+			case "cancel":
+				ctx, cancel = context.WithCancel(context.Background())
+				go func() {
+					time.Sleep(time.Millisecond * 100)
+					cancel()
+				}()
+			case "deadline":
+				d := time.Now().Add(time.Millisecond * 100)
+				ctx, cancel = context.WithDeadline(context.Background(), d)
+				defer cancel()
+			default:
+				t.Fatalf("unexpected timeout method: %v", tt.timeoutMethod)
+			}
+
+			var err error
+			switch tt.executor {
+			case "exec":
+				_, err = conn.Exec(ctx, "select pg_sleep(5);")
+			case "query":
+				var rows pgx.Rows
+				rows, err = conn.Query(ctx, "select pg_sleep(5);")
+				// When querying with the extended protocol, the error only appears after reading the first row.
+				if !tt.preferSimpleProtocol {
+					rows.Next()
+					err = rows.Err()
+				}
+			default:
+				t.Fatalf("unexpected executor: %v", tt.executor)
+			}
+
+			var e *pgx.ErrPostgresTimeout
+			if !errors.As(err, &e) {
+				t.Errorf("expected ErrPostgresTimeout, received %v - %+v", err, tt)
+			}
+		}()
+	}
+}


### PR DESCRIPTION
These changes address #831. In the issue thread, @atombender [summed up the issue and the solution](https://github.com/jackc/pgx/issues/831#issuecomment-819881537) implemented by these changes:

>The problem is distinguishing the error from a cancellation that occurs for other reasons. pgconn.Timeout() tests for context.Cancelled, which isn't universally a timeout signal.
>
> The only way to use pgconn.Timeout() "safely" is to always use it immediately on errors returned by pgx (or pgconn, etc.). If you wrap or pass the error on to higher-level layers, those layers can no longer know if the error came from pgx.
>
> This would really benefit from being wrapped in some special error type at the origin, in pgx. Otherwise we'll have to do this in every single pgx call:
>
> ```go
> func FetchStuff() (Data, error) {
>   // ...
>   if err := rows.Err(); err != nil {
>     return nil, convertError(err)
>   }
>   // ...
> }
>
> func convertError(err error) error {
>   if pgconn.Timeout(err) {
>     return ErrPostgresTimeout
>   }
>   return err
> }
>
> var ErrPostgresTimeout = errors.New("timeout")
> ```

These changes wrap timeout errors in a new error type, `ErrPostgresTimeout`. Because of error unwrapping, `ErrPostgresTimeout`  is fully compatible with the existing code, including `pgconn.Timeout`. Tests that utilize this function, such as `TestStmtExecContextCancel`, did not have to be altered to be compatible with these changes.

These changes also add a new function to the test suite, `TestTimeoutErr`. This exhaustive test ensures that all timeout errors are detected and wrapped by `ErrPostgresTimeout`.