### PR TITLE
Support time.Duration with simple protocol

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1061,3 +1061,16 @@ func TestStmtCacheInvalidationTx(t *testing.T) {
 
 	ensureConnValid(t, conn)
 }
+
+func TestInsertDurationInterval(t *testing.T) {
+	testWithAndWithoutPreferSimpleProtocol(t, func(t *testing.T, conn *pgx.Conn) {
+		_, err := conn.Exec(context.Background(), "create temporary table t(duration INTERVAL(0) NOT NULL)")
+		require.NoError(t, err)
+
+		result, err := conn.Exec(context.Background(), "insert into t(duration) values($1)", time.Minute)
+		require.NoError(t, err)
+
+		n := result.RowsAffected()
+		require.EqualValues(t, 1, n)
+	})
+}

--- a/values.go
+++ b/values.go
@@ -78,6 +78,8 @@ func convertSimpleArgument(ci *pgtype.ConnInfo, arg interface{}) (interface{}, e
 		return arg, nil
 	case bool:
 		return arg, nil
+	case time.Duration:
+		return fmt.Sprintf("%d microsecond", int64(arg)/1000), nil
 	case time.Time:
 		return arg, nil
 	case string:


### PR DESCRIPTION
These changes address #748, which notes that `time.Duration` can't be used as a PostgreSQL interval. The underlying problem isn't `stdlib`, as was postulated there - it's the simple protocol. This is easily rectified by converting `time.Duration` to a string in the [expected PostgreSQL syntax](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT) instead of to an integer.