### PR TITLE
Switch from github.com/go-kit/kit/log to github.com/go-kit/log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,7 @@ go 1.13
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/cockroachdb/apd v1.1.0
-	github.com/go-kit/kit v0.10.0
-	github.com/go-kit/log v0.1.0 // indirect
+	github.com/go-kit/log v0.1.0
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/jackc/pgconn v1.9.0
 	github.com/jackc/pgio v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/cockroachdb/apd v1.1.0
 	github.com/go-kit/kit v0.10.0
+	github.com/go-kit/log v0.1.0 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/jackc/pgconn v1.9.0
 	github.com/jackc/pgio v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0 h1:dXFJfIHVvUcpSgDOV+Ne6t7jXri8Tfv2uOLHUZ2XNuo=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
+github.com/go-kit/log v0.1.0 h1:DGJh0Sm43HbOeYDNnVZFl8BvcYVvjD5bqYJvp0REbwQ=
+github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=

--- a/go.sum
+++ b/go.sum
@@ -62,7 +62,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
-github.com/go-kit/kit v0.10.0 h1:dXFJfIHVvUcpSgDOV+Ne6t7jXri8Tfv2uOLHUZ2XNuo=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
 github.com/go-kit/log v0.1.0 h1:DGJh0Sm43HbOeYDNnVZFl8BvcYVvjD5bqYJvp0REbwQ=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=

--- a/log/kitlogadapter/adapter.go
+++ b/log/kitlogadapter/adapter.go
@@ -3,8 +3,8 @@ package kitlogadapter
 import (
 	"context"
 
-	"github.com/go-kit/kit/log"
-	kitlevel "github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	kitlevel "github.com/go-kit/log/level"
 	"github.com/jackc/pgx/v4"
 )
 


### PR DESCRIPTION
v0.11.0 of go-kit/kit was released.
The following  is a quotation from https://github.com/go-kit/kit/releases/tag/v0.11.0.

> The biggest thing: package log has been extracted to a separate repository and module, go-kit/log. This means that if you or your project was importing go-kit/kit just to get package log, you can significantly reduce your go.mod and dep graph by switching to the new module.

Although I switched  from github.com/go-kit/kit/log to github.com/go-kit/log,  I couldn't reduce go.mod sadly  maybe because PGX Family Libraries depend on each other(cyclic dependencies between module).

Anyway, I think my PR improve the situation.

related: https://github.com/jackc/pgx/issues/977