### PR TITLE
Release the connection in pool.QueryRow

### DIFF
--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -458,6 +458,7 @@ func (p *Pool) QueryRow(ctx context.Context, sql string, args ...interface{}) pg
 	if err != nil {
 		return errRow{err: err}
 	}
+	defer c.Release()
 
 	row := c.QueryRow(ctx, sql, args...)
 	return c.getPoolRow(row)


### PR DESCRIPTION
This PR fixes a bug I ran into in production. My app hangs after a while, and querying `pg_stat_activity` indicated connections building up over time. They are all running queries with `pool.queryRow`.

I was able to reproduce the issue by setting my local max pool size to 1 and calling `QueryRow` a few times.

Adding `c.Release()` fixed the issue.

Thanks for the great library!.