### PR TITLE
Add context options to zerologadapter

### DIFF
--- a/log/zerologadapter/adapter_test.go
+++ b/log/zerologadapter/adapter_test.go
@@ -1,0 +1,81 @@
+package zerologadapter_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/log/zerologadapter"
+	"github.com/rs/zerolog"
+)
+
+func TestLogger(t *testing.T) {
+
+	t.Run("default", func(t *testing.T) {
+		var buf bytes.Buffer
+		zlogger := zerolog.New(&buf)
+		logger := zerologadapter.NewLogger(zlogger)
+		logger.Log(context.Background(), pgx.LogLevelInfo, "hello", map[string]interface{}{"one": "two"})
+		const want = `{"level":"info","module":"pgx","one":"two","message":"hello"}
+`
+		got := buf.String()
+		if got != want {
+			t.Errorf("%s != %s", got, want)
+		}
+	})
+
+	t.Run("disable pgx module", func(t *testing.T) {
+		var buf bytes.Buffer
+		zlogger := zerolog.New(&buf)
+		logger := zerologadapter.NewLogger(zlogger, zerologadapter.WithoutPGXModule())
+		logger.Log(context.Background(), pgx.LogLevelInfo, "hello", nil)
+		const want = `{"level":"info","message":"hello"}
+`
+		got := buf.String()
+		if got != want {
+			t.Errorf("%s != %s", got, want)
+		}
+	})
+
+	var buf bytes.Buffer
+	type key string
+	var ck key
+	zlogger := zerolog.New(&buf)
+	logger := zerologadapter.NewLogger(zlogger,
+		zerologadapter.WithContextFunc(func(ctx context.Context, logWith zerolog.Context) zerolog.Context {
+			// You can use zerolog.hlog.IDFromCtx(ctx) or even
+			// zerolog.log.Ctx(ctx) to fetch the whole logger instance from the
+			// context if you want.
+			id, ok := ctx.Value(ck).(string)
+			if ok {
+				logWith = logWith.Str("req_id", id)
+			}
+			return logWith
+		}))
+
+	t.Run("no request id", func(t *testing.T) {
+		buf.Reset()
+		ctx := context.Background()
+		logger.Log(ctx, pgx.LogLevelInfo, "hello", nil)
+		const want = `{"level":"info","module":"pgx","message":"hello"}
+`
+		got := buf.String()
+		if got != want {
+			t.Errorf("%s != %s", got, want)
+		}
+	})
+
+	t.Run("with request id", func(t *testing.T) {
+		buf.Reset()
+		ctx := context.WithValue(context.Background(), ck, "1")
+		logger.Log(ctx, pgx.LogLevelInfo, "hello", map[string]interface{}{"two": "2"})
+		const want = `{"level":"info","module":"pgx","req_id":"1","two":"2","message":"hello"}
+`
+		got := buf.String()
+		if got != want {
+			t.Errorf("%s != %s", got, want)
+		}
+	})
+
+}


### PR DESCRIPTION
### WithContextFunc
WithContextFunc adds possibility to get request scoped values from the ctx.Context before logging lines.

I usually insert the request id from `zerolog.hlog.IDFromCtx` in the pgx logger and this lets users do that or even get the whole logger from `zerolog/log.Ctx` to get the whole logger from the context if they want to.

### WithoutPGXModule
WithoutPGXModule disables adding module:pgx to the default logger context.

I usually set the caller to pgx instead so I have just removed the module:pgx from my own modified version. 
