### PR TITLE
Clarify that `COPY` is a specific command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pgx supports many features beyond what is available through `database/sql`:
 * Single-round trip query mode
 * Full TLS connection control
 * Binary format support for custom types (allows for much quicker encoding/decoding)
-* Copy protocol support for faster bulk data loads
+* COPY protocol support for faster bulk data loads
 * Extendable logging support including built-in support for `log15adapter`, [`logrus`](https://github.com/sirupsen/logrus), [`zap`](https://github.com/uber-go/zap), and [`zerolog`](https://github.com/rs/zerolog)
 * Connection pool with after-connect hook for arbitrary connection setup
 * Listen / notify


### PR DESCRIPTION
COPY is a specific postgres command.

Personally, I'd prefer to wrap it in '`' for code syntax, but other bullet points in this readme that I'd expect to do that aren't formatted in code syntax so I was unclear if that's purposefully omitted or not.