### PR TITLE
Fixes a typo in the docs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -309,7 +309,7 @@ CopyFrom can be faster than an insert with as few as 5 rows.
 Listen and Notify
 
 pgx can listen to the PostgreSQL notification system with the `Conn.WaitForNotification` method. It blocks until a
-context is received or the context is canceled.
+notification is received or the context is canceled.
 
     _, err := conn.Exec(context.Background(), "listen channelname")
     if err != nil {


### PR DESCRIPTION
I think this meant to say "until a notification is received" rather than "until a context is received".