### PR TITLE
Add zerologadapter.NewContextLogger

### DIFF
--- a/log/zerologadapter/adapter_test.go
+++ b/log/zerologadapter/adapter_test.go
@@ -38,6 +38,23 @@ func TestLogger(t *testing.T) {
 		}
 	})
 
+	t.Run("from context", func(t *testing.T) {
+		var buf bytes.Buffer
+		zlogger := zerolog.New(&buf)
+		ctx := zlogger.WithContext(context.Background())
+		logger := zerologadapter.NewContextLogger()
+		logger.Log(ctx, pgx.LogLevelInfo, "hello", map[string]interface{}{"one": "two"})
+		const want = `{"level":"info","module":"pgx","one":"two","message":"hello"}
+`
+
+		got := buf.String()
+		if got != want {
+			t.Log(got)
+			t.Log(want)
+			t.Errorf("%s != %s", got, want)
+		}
+	})
+
 	var buf bytes.Buffer
 	type key string
 	var ck key
@@ -52,7 +69,8 @@ func TestLogger(t *testing.T) {
 				logWith = logWith.Str("req_id", id)
 			}
 			return logWith
-		}))
+		}),
+	)
 
 	t.Run("no request id", func(t *testing.T) {
 		buf.Reset()
@@ -77,5 +95,4 @@ func TestLogger(t *testing.T) {
 			t.Errorf("%s != %s", got, want)
 		}
 	})
-
 }


### PR DESCRIPTION
This change introduces a new zerologadapter that allows
users to pass the actual logger via context.Context. Especially HTTP
middleware might choose to use `(*zerolog.Logger).WithContext` and
`zerolog.Ctx`. Allowing users to extract the logger from the context
keeps the full enriched logger available when pgx emits logs.