### PR TITLE
Fix *pgxpool.Pool Acquire lock issue if nil is passed as context.

### DIFF
--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -410,6 +410,9 @@ func (p *Pool) createIdleResources(parentCtx context.Context, targetResources in
 
 // Acquire returns a connection (*Conn) from the Pool
 func (p *Pool) Acquire(ctx context.Context) (*Conn, error) {
+	if ctx == nil {
+		panic("tried to acquire connection with nil context")
+	}
 	for {
 		res, err := p.p.Acquire(ctx)
 		if err != nil {


### PR DESCRIPTION
Panic immediately if nil is used as value for context.Context.

I'm not sure where it'd be preferred to solve this (or if in both places).

Related: https://github.com/jackc/puddle/pull/13