### PR TITLE
Change constant definition syntax so they show up in godoc

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -15,10 +15,10 @@ type TxIsoLevel string
 
 // Transaction isolation levels
 const (
-	Serializable    = TxIsoLevel("serializable")
-	RepeatableRead  = TxIsoLevel("repeatable read")
-	ReadCommitted   = TxIsoLevel("read committed")
-	ReadUncommitted = TxIsoLevel("read uncommitted")
+	Serializable    TxIsoLevel = "serializable"
+	RepeatableRead  TxIsoLevel = "repeatable read"
+	ReadCommitted   TxIsoLevel = "read committed"
+	ReadUncommitted TxIsoLevel = "read uncommitted"
 )
 
 // TxAccessMode is the transaction access mode (read write or read only)
@@ -26,8 +26,8 @@ type TxAccessMode string
 
 // Transaction access modes
 const (
-	ReadWrite = TxAccessMode("read write")
-	ReadOnly  = TxAccessMode("read only")
+	ReadWrite TxAccessMode = "read write"
+	ReadOnly  TxAccessMode = "read only"
 )
 
 // TxDeferrableMode is the transaction deferrable mode (deferrable or not deferrable)
@@ -35,8 +35,8 @@ type TxDeferrableMode string
 
 // Transaction deferrable modes
 const (
-	Deferrable    = TxDeferrableMode("deferrable")
-	NotDeferrable = TxDeferrableMode("not deferrable")
+	Deferrable    TxDeferrableMode = "deferrable"
+	NotDeferrable TxDeferrableMode = "not deferrable"
 )
 
 // TxOptions are transaction modes within a transaction block


### PR DESCRIPTION
for TxAccessMode, TxDeferrableMode and TxIsoLevel

After this commit, Godoc understands these are the valid values of these types and shows them together in the documentation.