### PR TITLE
Allocate connRows on demand instead of preallocating in bulk

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -73,9 +73,8 @@ type Conn struct {
 
 	connInfo *pgtype.ConnInfo
 
-	wbuf             []byte
-	preallocatedRows []connRows
-	eqb              extendedQueryBuilder
+	wbuf []byte
+	eqb  extendedQueryBuilder
 }
 
 // Identifier a PostgreSQL identifier or name. Identifiers can be composed of
@@ -537,12 +536,7 @@ func (c *Conn) execPrepared(ctx context.Context, sd *pgconn.StatementDescription
 }
 
 func (c *Conn) getRows(ctx context.Context, sql string, args []interface{}) *connRows {
-	if len(c.preallocatedRows) == 0 {
-		c.preallocatedRows = make([]connRows, 64)
-	}
-
-	r := &c.preallocatedRows[len(c.preallocatedRows)-1]
-	c.preallocatedRows = c.preallocatedRows[0 : len(c.preallocatedRows)-1]
+	r := &connRows{}
 
 	r.ctx = ctx
 	r.logger = c


### PR DESCRIPTION
The 64 element preallocatedRows may be pinning memory from previous
queries.

See https://github.com/jackc/pgx/issues/1127