### PR TITLE
Add configurable log filter to be able to skip certain logs

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -47,6 +47,9 @@ type Logger interface {
 	Log(ctx context.Context, level LogLevel, msg string, data map[string]interface{})
 }
 
+// LogFilter is the function to filter out some logs based on custom logic, returns true if log should be filtered
+type LogFilter func(ctx context.Context, level LogLevel, msg string, data map[string]interface{}) bool
+
 // LogLevelFromString converts log level string to constant
 //
 // Valid levels:


### PR DESCRIPTION
Hi Jack!

First and foremost, thank you for this great project, it's very useful! 🙇🏻 

While using this library, I found it inconvenient that I cannot skip logging some internal queries. For example, I use `conn.Ping()` for health checks and it results in plenty of `Exec` logs with the query being `;` (which is the default empty query used for pinging). I could switch the log level but I do want to log the actual queries. So I was thinking of adding an (optional) filter function that can be customised and used for this purpose - to skip certain logs depending on their data rather than log level. I'm not absolutely sure it's the best approach but it's quite straightforward and simple with minimal changes required. What do you think? Looking forward to your reply 🙏🏻 