### PR TITLE
Clarify that Values() and Scan() require Next() to have been called on the rows object

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -41,10 +41,13 @@ type Rows interface {
 
 	// Scan reads the values from the current row into dest values positionally.
 	// dest can include pointers to core types, values implementing the Scanner
-	// interface, and nil. nil will skip the value entirely.
+	// interface, and nil. nil will skip the value entirely. It is an error to
+	// call Scan without first calling Next() and checking that it returned true.
 	Scan(dest ...interface{}) error
 
-	// Values returns the decoded row values.
+	// Values returns the decoded row values. As with Scan(), it is an error to
+	// call Values without first calling Next() and checking that it returned
+	// true.
 	Values() ([]interface{}, error)
 
 	// RawValues returns the unparsed bytes of the row values. The returned [][]byte is only valid until the next Next


### PR DESCRIPTION
I ran into the same issue as the author of https://github.com/jackc/pgx/issues/467 and didn't find the disclaimer where I'd expect to see this info in the documentation. Therefore, I made this PR to put it there. 

I am of course willing to reword this to @jackc's satisfaction. Thanks so much for creating this library, `pgx` is pretty damn awesome. 
