### PR TITLE
exposing stdlib DB connector

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -163,7 +163,7 @@ func RandomizeHostOrderFunc(ctx context.Context, connConfig *pgx.ConnConfig) err
 	return nil
 }
 
-func OpenDB(config pgx.ConnConfig, opts ...OptionOpenDB) *sql.DB {
+func GetConnector(config pgx.ConnConfig, opts ...OptionOpenDB) driver.Connector {
 	c := connector{
 		ConnConfig:    config,
 		BeforeConnect: func(context.Context, *pgx.ConnConfig) error { return nil }, // noop before connect by default
@@ -175,7 +175,11 @@ func OpenDB(config pgx.ConnConfig, opts ...OptionOpenDB) *sql.DB {
 	for _, opt := range opts {
 		opt(&c)
 	}
+	return c
+}
 
+func OpenDB(config pgx.ConnConfig, opts ...OptionOpenDB) *sql.DB {
+	c := GetConnector(config, opts...)
 	return sql.OpenDB(c)
 }
 


### PR DESCRIPTION
Hello,

Following https://github.com/jackc/pgx/issues/481 
I'm having an issue while using `gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql` with `pgx`, specifically, I'm looking for a way to set the `BeforeConnect` while still using sqltrace. 

Allowing access to the connector will allow me to do this:

```
// add stdlib.OptionBeforeConnect to opts here 

// pass connector with BeforeConnect callback to be used in sqltrace
 sqltrace.OpenDB(stdlib.GetConnector(*cfg, opts...))
```

Is there is another way of doing this?

Thanks,