### PR TITLE
Fix single line comment for line endings in mac when sanitizing.

### DIFF
--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -246,7 +246,7 @@ func oneLineCommentState(l *sqlLexer) stateFn {
 		case '\\':
 			_, width = utf8.DecodeRuneInString(l.src[l.pos:])
 			l.pos += width
-		case '\n':
+		case '\n', '\r':
 			return rawState
 		case utf8.RuneError:
 			if l.pos-l.start > 0 {

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -77,12 +77,16 @@ func TestNewQuery(t *testing.T) {
 			expected: sanitize.Query{Parts: []sanitize.Part{"select -- a baby's toy\n'barbie', ", 1}},
 		},
 		{
-			sql:      "select 42 -- is a Thinker's favorite number",
-			expected: sanitize.Query{Parts: []sanitize.Part{"select 42 -- is a Thinker's favorite number"}},
+			sql:      "select 42 -- is a Deep Thought's favorite number",
+			expected: sanitize.Query{Parts: []sanitize.Part{"select 42 -- is a Deep Thought's favorite number"}},
 		},
 		{
-			sql:      "select 42, -- \\nis a Thinker's favorite number\n$1",
-			expected: sanitize.Query{Parts: []sanitize.Part{"select 42, -- \\nis a Thinker's favorite number\n", 1}},
+			sql:      "select 42, -- \\nis a Deep Thought's favorite number\n$1",
+			expected: sanitize.Query{Parts: []sanitize.Part{"select 42, -- \\nis a Deep Thought's favorite number\n", 1}},
+		},
+		{
+			sql:      "select 42, -- \\nis a Deep Thought's favorite number\r$1",
+			expected: sanitize.Query{Parts: []sanitize.Part{"select 42, -- \\nis a Deep Thought's favorite number\r", 1}},
 		},
 	}
 


### PR DESCRIPTION
Line endings on macs are \r, so sanitizing single-line comments did not correctly parse query arguments up to \n