### PR TITLE
feat: add prefer execParams option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 
 .envrc
+.idea

--- a/conn.go
+++ b/conn.go
@@ -687,7 +687,7 @@ optionLoop:
 		resultFormats = c.eqb.resultFormats
 	}
 
-	if c.stmtcache == nil || (c.stmtcache != nil && c.stmtcache.Mode() == stmtcache.ModeDescribe) {
+	if (c.stmtcache == nil && c.config.PreferExecParams) || (c.stmtcache != nil && c.stmtcache.Mode() == stmtcache.ModeDescribe) {
 		rows.resultReader = c.pgConn.ExecParams(ctx, sql, c.eqb.paramValues, sd.ParamOIDs, c.eqb.paramFormats, resultFormats)
 	} else {
 		rows.resultReader = c.pgConn.ExecPrepared(ctx, sd.Name, c.eqb.paramValues, c.eqb.paramFormats, resultFormats)

--- a/conn_test.go
+++ b/conn_test.go
@@ -328,10 +328,17 @@ func TestExecStatementCacheModes(t *testing.T) {
 	tests := []struct {
 		name                string
 		buildStatementCache pgx.BuildStatementCacheFunc
+		preferExecParams    bool
 	}{
 		{
-			name:                "disabled",
+			name:                "disabled - execPrepared",
 			buildStatementCache: nil,
+			preferExecParams:    false,
+		},
+		{
+			name:                "disabled - execParams",
+			buildStatementCache: nil,
+			preferExecParams:    true,
 		},
 		{
 			name: "prepare",
@@ -344,12 +351,14 @@ func TestExecStatementCacheModes(t *testing.T) {
 			buildStatementCache: func(conn *pgconn.PgConn) stmtcache.Cache {
 				return stmtcache.New(conn, stmtcache.ModeDescribe, 32)
 			},
+			preferExecParams: false,
 		},
 	}
 
 	for _, tt := range tests {
 		func() {
 			config.BuildStatementCache = tt.buildStatementCache
+			config.PreferExecParams = tt.preferExecParams
 			conn := mustConnect(t, config)
 			defer closeConn(t, conn)
 


### PR DESCRIPTION
Adds an option to skip the DescribeStatement step when the statement cache has been disabled. This reduces the number of round trips to the server by one. Instead the driver will do:
1. Parse (including parameter OID types derived from the actual values)
2. Bind
3. Execute

The option has been enabled by default in this PR to verify that all tests succeed when this option is enabled. This should probably be changed to default off before merging to prevent an unexpected change in behavior.