### PR TITLE
Added Row unwrap method to allow low-level operations on it

### DIFF
--- a/pgxpool/rows.go
+++ b/pgxpool/rows.go
@@ -25,6 +25,8 @@ type errRow struct {
 
 func (e errRow) Scan(dest ...any) error { return e.err }
 
+func (e errRow) AsRows() pgx.Rows { return errRows{err: e.err} }
+
 type poolRows struct {
 	r   pgx.Rows
 	c   *Conn

--- a/rows.go
+++ b/rows.go
@@ -67,6 +67,9 @@ type Row interface {
 	// rows were found it returns ErrNoRows. If multiple rows are returned it
 	// ignores all but the first.
 	Scan(dest ...any) error
+
+	// AsRows unwraps Row into Rows to give access to the full Rows-level functionality.
+	AsRows() Rows
 }
 
 // connRow implements the Row interface for Conn.QueryRow.
@@ -96,6 +99,10 @@ func (r *connRow) Scan(dest ...any) (err error) {
 	rows.Scan(dest...)
 	rows.Close()
 	return rows.Err()
+}
+
+func (r *connRow) AsRows() Rows {
+	return (*connRows)(r)
 }
 
 type rowLog interface {


### PR DESCRIPTION
Refs https://github.com/jackc/pgx/issues/627

Added `AsRows()` method to `Row` interface to allow rows-level operations on it.

Not really sure about the method name, had `AsRows`, `ToRows`, `Rows`, `Unwrap`, `UnwrapRows` in mind, but not sure which one is better.