### PR TITLE
Increase level of connection open/close log messages

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -216,8 +216,8 @@ func connect(ctx context.Context, config *ConnConfig) (c *Conn, err error) {
 		}
 	}
 
-	if c.shouldLog(LogLevelInfo) {
-		c.log(ctx, LogLevelInfo, "Dialing PostgreSQL server", map[string]interface{}{"host": config.Config.Host})
+	if c.shouldLog(LogLevelTrace) {
+		c.log(ctx, LogLevelTrace, "Dialing PostgreSQL server", map[string]interface{}{"host": config.Config.Host})
 	}
 	c.pgConn, err = pgconn.ConnectConfig(ctx, &config.Config)
 	if err != nil {
@@ -253,8 +253,8 @@ func (c *Conn) Close(ctx context.Context) error {
 	}
 
 	err := c.pgConn.Close(ctx)
-	if c.shouldLog(LogLevelInfo) {
-		c.log(ctx, LogLevelInfo, "closed connection", nil)
+	if c.shouldLog(LogLevelTrace) {
+		c.log(ctx, LogLevelTrace, "Closed connection", nil)
 	}
 	return err
 }


### PR DESCRIPTION
Hey, this might be a bit bold, but when our app starts I see bunch of open/close messages logged at info level and I feel like as an app developer I am not too interested in these. What matters are SQL statements typically, these are unfortunately also at info level.

So I propose to increase level of these connection-related messages to trace (or at least debug) if you don't mind. Also, I've noticed that most of the logging messages start with capital letter.

Cheers!