### PR TITLE
pgxpool: kill connections after max configured life time.

### DIFF
--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -227,7 +227,7 @@ func ConnectConfig(ctx context.Context, config *Config) (*Pool, error) {
 			return cr, nil
 		},
 		func(value interface{}) {
-			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), config.MaxConnLifetime)
 			conn := value.(*connResource).conn
 			conn.Close(ctx)
 			select {


### PR DESCRIPTION
We ran into issues of a web request erring out after 15 seconds due to the underlying DB request taking more than 15 seconds. Investigating the issue lead me to believe the destructor should also respect the configured timeout.

Looking at the introduction, 39b096d0 ("pgxpool waits for connection cleanup to finish before making room in pool", 2020-08-20), I am unsure how to add a proper test.