### PR TITLE
Make FieldDescription.Name a string to avoid corruption

### DIFF
--- a/internal/pgmock/pgmock_test.go
+++ b/internal/pgmock/pgmock_test.go
@@ -24,7 +24,7 @@ func TestScript(t *testing.T) {
 	script.Steps = append(script.Steps, pgmock.SendMessage(&pgproto3.RowDescription{
 		Fields: []pgproto3.FieldDescription{
 			pgproto3.FieldDescription{
-				Name:                 []byte("?column?"),
+				Name:                 "?column?",
 				TableOID:             0,
 				TableAttributeNumber: 0,
 				DataTypeOID:          23,

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -1475,6 +1475,10 @@ func (rr *ResultReader) receiveMessage() (msg pgproto3.BackendMessage, err error
 	case *pgproto3.RowDescription:
 		rr.fieldDescriptions = make([]pgproto3.FieldDescription, len(msg.Fields))
 		copy(rr.fieldDescriptions, msg.Fields)
+		for i := range rr.fieldDescriptions {
+			rr.fieldDescriptions[i].Name = make([]byte, len(msg.Fields[i].Name))
+			copy(rr.fieldDescriptions[i].Name, msg.Fields[i].Name)
+		}
 	case *pgproto3.CommandComplete:
 		rr.concludeCommand(rr.pgConn.makeCommandTag(msg.CommandTag), nil)
 	case *pgproto3.EmptyQueryResponse:

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -1473,7 +1473,8 @@ func (rr *ResultReader) receiveMessage() (msg pgproto3.BackendMessage, err error
 
 	switch msg := msg.(type) {
 	case *pgproto3.RowDescription:
-		rr.fieldDescriptions = msg.Fields
+		rr.fieldDescriptions = make([]pgproto3.FieldDescription, len(msg.Fields))
+		copy(rr.fieldDescriptions, msg.Fields)
 	case *pgproto3.CommandComplete:
 		rr.concludeCommand(rr.pgConn.makeCommandTag(msg.CommandTag), nil)
 	case *pgproto3.EmptyQueryResponse:

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -1473,12 +1473,7 @@ func (rr *ResultReader) receiveMessage() (msg pgproto3.BackendMessage, err error
 
 	switch msg := msg.(type) {
 	case *pgproto3.RowDescription:
-		rr.fieldDescriptions = make([]pgproto3.FieldDescription, len(msg.Fields))
-		copy(rr.fieldDescriptions, msg.Fields)
-		for i := range rr.fieldDescriptions {
-			rr.fieldDescriptions[i].Name = make([]byte, len(msg.Fields[i].Name))
-			copy(rr.fieldDescriptions[i].Name, msg.Fields[i].Name)
-		}
+		rr.fieldDescriptions = msg.Fields
 	case *pgproto3.CommandComplete:
 		rr.concludeCommand(rr.pgConn.makeCommandTag(msg.CommandTag), nil)
 	case *pgproto3.EmptyQueryResponse:

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -641,13 +641,13 @@ func TestConnExecMultipleQueriesEagerFieldDescriptions(t *testing.T) {
 
 	require.True(t, mrr.NextResult())
 	require.Len(t, mrr.ResultReader().FieldDescriptions(), 1)
-	assert.Equal(t, []byte("msg"), mrr.ResultReader().FieldDescriptions()[0].Name)
+	assert.Equal(t, "msg", mrr.ResultReader().FieldDescriptions()[0].Name)
 	_, err = mrr.ResultReader().Close()
 	require.NoError(t, err)
 
 	require.True(t, mrr.NextResult())
 	require.Len(t, mrr.ResultReader().FieldDescriptions(), 1)
-	assert.Equal(t, []byte("num"), mrr.ResultReader().FieldDescriptions()[0].Name)
+	assert.Equal(t, "num", mrr.ResultReader().FieldDescriptions()[0].Name)
 	_, err = mrr.ResultReader().Close()
 	require.NoError(t, err)
 
@@ -771,7 +771,7 @@ func TestConnExecParams(t *testing.T) {
 
 	result := pgConn.ExecParams(context.Background(), "select $1::text as msg", [][]byte{[]byte("Hello, world")}, nil, nil, nil)
 	require.Len(t, result.FieldDescriptions(), 1)
-	assert.Equal(t, []byte("msg"), result.FieldDescriptions()[0].Name)
+	assert.Equal(t, "msg", result.FieldDescriptions()[0].Name)
 
 	rowCount := 0
 	for result.NextRow() {
@@ -936,7 +936,7 @@ func TestResultReaderValuesHaveSameCapacityAsLength(t *testing.T) {
 
 	result := pgConn.ExecParams(context.Background(), "select $1::text as msg", [][]byte{[]byte("Hello, world")}, nil, nil, nil)
 	require.Len(t, result.FieldDescriptions(), 1)
-	assert.Equal(t, []byte("msg"), result.FieldDescriptions()[0].Name)
+	assert.Equal(t, "msg", result.FieldDescriptions()[0].Name)
 
 	rowCount := 0
 	for result.NextRow() {
@@ -967,7 +967,7 @@ func TestConnExecPrepared(t *testing.T) {
 
 	result := pgConn.ExecPrepared(context.Background(), "ps1", [][]byte{[]byte("Hello, world")}, nil, nil)
 	require.Len(t, result.FieldDescriptions(), 1)
-	assert.Equal(t, []byte("msg"), result.FieldDescriptions()[0].Name)
+	assert.Equal(t, "msg", result.FieldDescriptions()[0].Name)
 
 	rowCount := 0
 	for result.NextRow() {
@@ -2013,7 +2013,7 @@ func TestFatalErrorReceivedAfterCommandComplete(t *testing.T) {
 	steps = append(steps, pgmock.ExpectAnyMessage(&pgproto3.Execute{}))
 	steps = append(steps, pgmock.ExpectAnyMessage(&pgproto3.Sync{}))
 	steps = append(steps, pgmock.SendMessage(&pgproto3.RowDescription{Fields: []pgproto3.FieldDescription{
-		{Name: []byte("mock")},
+		{Name: "mock"},
 	}}))
 	steps = append(steps, pgmock.SendMessage(&pgproto3.CommandComplete{CommandTag: []byte("SELECT 0")}))
 	steps = append(steps, pgmock.SendMessage(&pgproto3.ErrorResponse{Severity: "FATAL", Code: "57P01"}))
@@ -2156,7 +2156,7 @@ func TestPipelinePrepare(t *testing.T) {
 	sd, ok := results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "a")
+	require.Equal(t, sd.Fields[0].Name, "a")
 	require.Equal(t, []uint32{pgtype.Int8OID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2164,7 +2164,7 @@ func TestPipelinePrepare(t *testing.T) {
 	sd, ok = results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "b")
+	require.Equal(t, sd.Fields[0].Name, "b")
 	require.Equal(t, []uint32{pgtype.TextOID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2172,7 +2172,7 @@ func TestPipelinePrepare(t *testing.T) {
 	sd, ok = results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "c")
+	require.Equal(t, sd.Fields[0].Name, "c")
 	require.Equal(t, []uint32{}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2223,7 +2223,7 @@ func TestPipelinePrepareError(t *testing.T) {
 	sd, ok := results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "a")
+	require.Equal(t, sd.Fields[0].Name, "a")
 	require.Equal(t, []uint32{pgtype.Int8OID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2264,7 +2264,7 @@ func TestPipelinePrepareAndDeallocate(t *testing.T) {
 	sd, ok := results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "a")
+	require.Equal(t, sd.Fields[0].Name, "a")
 	require.Equal(t, []uint32{pgtype.Int8OID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2395,7 +2395,7 @@ func TestPipelinePrepareQuery(t *testing.T) {
 	sd, ok := results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "msg")
+	require.Equal(t, sd.Fields[0].Name, "msg")
 	require.Equal(t, []uint32{pgtype.TextOID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()

--- a/pgproto3/example/pgfortune/server.go
+++ b/pgproto3/example/pgfortune/server.go
@@ -48,7 +48,7 @@ func (p *PgFortuneBackend) Run() error {
 
 			buf := (&pgproto3.RowDescription{Fields: []pgproto3.FieldDescription{
 				{
-					Name:                 []byte("fortune"),
+					Name:                 "fortune",
 					TableOID:             0,
 					TableAttributeNumber: 0,
 					DataTypeOID:          25,

--- a/pgproto3/json_test.go
+++ b/pgproto3/json_test.go
@@ -314,7 +314,7 @@ func TestJSONUnmarshalRowDescription(t *testing.T) {
 	want := RowDescription{
 		Fields: []FieldDescription{
 			{
-				Name:         []byte("generate_series"),
+				Name:         "generate_series",
 				DataTypeOID:  23,
 				DataTypeSize: 4,
 				TypeModifier: -1,

--- a/pgproto3/row_description.go
+++ b/pgproto3/row_description.go
@@ -34,7 +34,7 @@ func (fd FieldDescription) MarshalJSON() ([]byte, error) {
 		TypeModifier         int32
 		Format               int16
 	}{
-		Name:                 string(fd.Name),
+		Name:                 fd.Name,
 		TableOID:             fd.TableOID,
 		TableAttributeNumber: fd.TableAttributeNumber,
 		DataTypeOID:          fd.DataTypeOID,

--- a/pgproto3/row_description.go
+++ b/pgproto3/row_description.go
@@ -14,7 +14,7 @@ const (
 )
 
 type FieldDescription struct {
-	Name                 []byte
+	Name                 string
 	TableOID             uint32
 	TableAttributeNumber uint16
 	DataTypeOID          uint32
@@ -70,7 +70,7 @@ func (dst *RowDescription) Decode(src []byte) error {
 		if idx < 0 {
 			return &invalidMessageFormatErr{messageType: "RowDescription"}
 		}
-		fd.Name = src[rp : rp+idx]
+		fd.Name = string(src[rp : rp+idx])
 		rp += idx + 1
 
 		// Since buf.Next() doesn't return an error if we hit the end of the buffer
@@ -152,7 +152,7 @@ func (dst *RowDescription) UnmarshalJSON(data []byte) error {
 	dst.Fields = make([]FieldDescription, len(msg.Fields))
 	for n, field := range msg.Fields {
 		dst.Fields[n] = FieldDescription{
-			Name:                 []byte(field.Name),
+			Name:                 field.Name,
 			TableOID:             field.TableOID,
 			TableAttributeNumber: field.TableAttributeNumber,
 			DataTypeOID:          field.DataTypeOID,

--- a/pgproto3/trace.go
+++ b/pgproto3/trace.go
@@ -365,7 +365,7 @@ func (t *tracer) traceRowDescription(sender byte, encodedLen int32, msg *RowDesc
 	t.beginTrace(sender, encodedLen, "RowDescription")
 	fmt.Fprintf(t.buf, "\t %d", len(msg.Fields))
 	for _, fd := range msg.Fields {
-		fmt.Fprintf(t.buf, ` %s %d %d %d %d %d %d`, traceDoubleQuotedString(fd.Name), fd.TableOID, fd.TableAttributeNumber, fd.DataTypeOID, fd.DataTypeSize, fd.TypeModifier, fd.Format)
+		fmt.Fprintf(t.buf, ` %s %d %d %d %d %d %d`, traceDoubleQuotedString([]byte(fd.Name)), fd.TableOID, fd.TableAttributeNumber, fd.DataTypeOID, fd.DataTypeSize, fd.TypeModifier, fd.Format)
 	}
 	t.finishTrace()
 }

--- a/query_test.go
+++ b/query_test.go
@@ -66,7 +66,7 @@ func TestConnQueryRowsFieldDescriptionsBeforeNext(t *testing.T) {
 	defer rows.Close()
 
 	require.Len(t, rows.FieldDescriptions(), 1)
-	assert.Equal(t, []byte("msg"), rows.FieldDescriptions()[0].Name)
+	assert.Equal(t, "msg", rows.FieldDescriptions()[0].Name)
 }
 
 func TestConnQueryWithoutResultSetCommandTag(t *testing.T) {

--- a/rows.go
+++ b/rows.go
@@ -478,7 +478,7 @@ func (rs *mapRowScanner) ScanRow(rows Rows) error {
 	*rs = make(mapRowScanner, len(values))
 
 	for i := range values {
-		(*rs)[string(rows.FieldDescriptions()[i].Name)] = values[i]
+		(*rs)[rows.FieldDescriptions()[i].Name] = values[i]
 	}
 
 	return nil

--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -510,7 +510,7 @@ func (r *Rows) Columns() []string {
 		fields := r.rows.FieldDescriptions()
 		r.columnNames = make([]string, len(fields))
 		for i, fd := range fields {
-			r.columnNames[i] = string(fd.Name)
+			r.columnNames[i] = fd.Name
 		}
 	}
 


### PR DESCRIPTION
I sometimes get corrupted column names returned from v5's `func (r *Rows) Columns() []string` method. The `Name` field on `FieldDescription` is getting overwritten.

The `Name` field can be changed to a `string`, which would implicitly copy the bytes and avoid corruption. If it will remain a `[]byte`, the name should be copied from the buffer so the name will not get corrupted if the buffer is overwritten.