### PR TITLE
Add DisableNestedTransactions as a configurable flag

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -171,6 +171,26 @@ func TestParseConfigExtractsStatementCacheOptions(t *testing.T) {
 	require.Equal(t, stmtcache.ModeDescribe, c.Mode())
 }
 
+func TestParseConfigExtractsDisableNestedTransactions(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		connString           string
+		disableNestedTransactions bool
+	}{
+		{"", false},
+		{"disable_nested_transactions=false", false},
+		{"disable_nested_transactions=0", false},
+		{"disable_nested_transactions=true", true},
+		{"disable_nested_transactions=1", true},
+	} {
+		config, err := pgx.ParseConfig(tt.connString)
+		require.NoError(t, err)
+		require.Equalf(t, tt.disableNestedTransactions, config.DisableNestedTransactions, "connString: `%s`", tt.connString)
+		require.Empty(t, config.RuntimeParams["disable_nested_transactions"])
+	}
+}
+
 func TestParseConfigExtractsPreferSimpleProtocol(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
These changes introduce an optional connect flag `disable_nested_transactions` and the config value DisableNestedTransactions (default is False, preserving savepoint behaviour).

Enabling this will cause nested transactions to behave as no-ops (begin, commit, rollback inside an existing txn), relying on the parent transaction to commit/rollback any changes.

The motivation behind these changes were:
* we were observing the performance impacts of having long running nested transactions on our postgres database. (yes, long running transactions is a problem we gradually are fixing)
* our code is structured such that nested helper functions also invoked transactions
* we concluded that allowing the parent transaction to handle the commit/rollback of txns would be acceptable, and we didn't require the savepoint functionality in our codebase.