### PR TITLE
Rewrite context watcher to use single background goroutine

### DIFF
--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -860,7 +860,7 @@ func (pgConn *PgConn) CancelRequest(ctx context.Context) error {
 			func() { cancelConn.SetDeadline(time.Time{}) },
 		)
 		contextWatcher.Watch(ctx)
-		defer contextWatcher.Unwatch()
+		defer contextWatcher.Stop()
 	}
 
 	buf := make([]byte, 16)
@@ -1955,7 +1955,7 @@ func (p *Pipeline) Close() error {
 		}
 	}
 
-	p.conn.contextWatcher.Unwatch()
+	p.conn.contextWatcher.Stop()
 	p.conn.unlock()
 
 	return p.err

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -564,7 +564,7 @@ func (pgConn *PgConn) Close(ctx context.Context) error {
 		pgConn.contextWatcher.Unwatch()
 
 		pgConn.contextWatcher.Watch(ctx)
-		defer pgConn.contextWatcher.Unwatch()
+		defer pgConn.contextWatcher.Stop()
 	}
 
 	// Ignore any errors sending Terminate message and waiting for server to close connection.


### PR DESCRIPTION
This removes the need to start a new gouroutine each query supplied with a non-`context.Background` context, instead it maintains a background routine that handles all `Watch` requests.

This can save some cpu cycles for applications that pass down `net/http.(*Request).Context` or grpc-generated Context to every single sql query.

Here is `benchcmp` for `ctxwatch` package:

```
benchmark                                  old ns/op     new ns/op     delta
BenchmarkContextWatcherUncancellable-8     27.3          13.6          -50.18%
BenchmarkContextWatcherCancelled-8         599           454           -24.20%
BenchmarkContextWatcherCancellable-8       420           319           -24.04%

benchmark                                  old allocs     new allocs     delta
BenchmarkContextWatcherUncancellable-8     0              0              +0.00%
BenchmarkContextWatcherCancelled-8         4              3              -25.00%
BenchmarkContextWatcherCancellable-8       1              0              -100.00%

benchmark                                  old bytes     new bytes     delta
BenchmarkContextWatcherUncancellable-8     0             0             +0.00%
BenchmarkContextWatcherCancelled-8         208           176           -15.38%
BenchmarkContextWatcherCancellable-8       32            0             -100.00%
```

Unfortunately go benchmarks don't include info about goroutines used since they're handled by the runtime.