### PR TITLE
Fix some bad rows.Err() handlings in tests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -575,7 +575,7 @@ func TestListenNotifyWhileBusyIsSafe(t *testing.T) {
 			}
 
 			if rows.Err() != nil {
-				t.Errorf("conn.Query failed: %v", err)
+				t.Errorf("conn.Query failed: %v", rows.Err())
 				return
 			}
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -79,7 +79,7 @@ func ensureConnValid(t testing.TB, conn *pgx.Conn) {
 	}
 
 	if rows.Err() != nil {
-		t.Fatalf("conn.Query failed: %v", err)
+		t.Fatalf("conn.Query failed: %v", rows.Err())
 	}
 
 	if rowCount != 10 {

--- a/query_test.go
+++ b/query_test.go
@@ -42,7 +42,7 @@ func TestConnQueryScan(t *testing.T) {
 	}
 
 	if rows.Err() != nil {
-		t.Fatalf("conn.Query failed: %v", err)
+		t.Fatalf("conn.Query failed: %v", rows.Err())
 	}
 
 	assert.Equal(t, "SELECT 10", rows.CommandTag().String())
@@ -126,7 +126,7 @@ func TestConnQueryScanWithManyColumns(t *testing.T) {
 	}
 
 	if rows.Err() != nil {
-		t.Fatalf("conn.Query failed: %v", err)
+		t.Fatalf("conn.Query failed: %v", rows.Err())
 	}
 
 	if rowCount != 5 {
@@ -162,7 +162,7 @@ func TestConnQueryValues(t *testing.T) {
 	}
 
 	if rows.Err() != nil {
-		t.Fatalf("conn.Query failed: %v", err)
+		t.Fatalf("conn.Query failed: %v", rows.Err())
 	}
 
 	if rowCount != 10 {
@@ -1988,7 +1988,7 @@ insert into products (name, price) values
 
 	// The first error encountered by the original Query call, rows.Next or rows.Scan will be returned here.
 	if rows.Err() != nil {
-		fmt.Printf("rows error: %v", err)
+		fmt.Printf("rows error: %v", rows.Err())
 		return
 	}
 


### PR DESCRIPTION
This fixes a couple tests in which there was a variant of this code:

```go
err := ...

if rows.Err() != nil {
    return err
}
```

It’s very likely that the intent of the person who wrote the code was to return `rows.Err()` rather than `err`, which is often `nil` at this point.