### PR TITLE
Set tracer in 1 LoC

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -181,6 +181,7 @@ func ParseConfig(connString string) (*ConnConfig, error) {
 
 	connConfig := &ConnConfig{
 		Config:                   *config,
+		Tracer:                   defaultQueryTracer,
 		createdByParseConfig:     true,
 		StatementCacheCapacity:   statementCacheCapacity,
 		DescriptionCacheCapacity: descriptionCacheCapacity,

--- a/tracer.go
+++ b/tracer.go
@@ -105,3 +105,10 @@ type TraceConnectEndData struct {
 	Conn *Conn
 	Err  error
 }
+
+var defaultQueryTracer QueryTracer
+
+// SetDefaultQueryTracer allows to set the default tracer
+func SetDefaultQueryTracer(tracer QueryTracer) {
+	defaultQueryTracer = tracer
+}


### PR DESCRIPTION
Added a global private variable (_defaultQueryTracer_) and setter for this variable (_SetDefaultTracer_) for more convenient work with tracing. The old method remains working.

Example of the new method:
```golang
ctx, cancel := context.WithTimeout(context.Background(), time.Second * 10)
defer cancel()


// allows you set your tracer (custom log, otel, etc.) in 1 LoC
//    ↓           ↓            ↓           ↓ 
pgx.SetDefaultTracer(tracing.NewPgxTracer())

connect, err := pgx.Connect(ctx, "")
if err != nil{
    log.Fatal(err)
}
```