### PR TITLE
Add DeallocateAll to pgx.Conn to clear prepared statement cache

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -326,6 +326,13 @@ func (c *Conn) Deallocate(ctx context.Context, name string) error {
 	return err
 }
 
+// Deallocate all released prepared statements
+func (c *Conn) DeallocateAll(ctx context.Context, name string) error {
+	c.preparedStatements = map[string]*pgconn.StatementDescription{}
+	_, err := c.pgConn.Exec(ctx, "deallocate all").ReadAll()
+	return err
+}
+
 func (c *Conn) bufferNotifications(_ *pgconn.PgConn, n *pgconn.Notification) {
 	c.notifications = append(c.notifications, n)
 }

--- a/conn.go
+++ b/conn.go
@@ -326,9 +326,15 @@ func (c *Conn) Deallocate(ctx context.Context, name string) error {
 	return err
 }
 
-// Deallocate all released prepared statements
+// DeallocateAll releases all previously prepared statements from the server and client, where it also resets the statement and description cache.
 func (c *Conn) DeallocateAll(ctx context.Context, name string) error {
 	c.preparedStatements = map[string]*pgconn.StatementDescription{}
+	if c.config.StatementCacheCapacity > 0 {
+		c.statementCache = stmtcache.NewLRUCache(c.config.StatementCacheCapacity)
+	}
+	if c.config.DescriptionCacheCapacity > 0 {
+		c.descriptionCache = stmtcache.NewLRUCache(c.config.DescriptionCacheCapacity)
+	}
 	_, err := c.pgConn.Exec(ctx, "deallocate all").ReadAll()
 	return err
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -424,7 +424,7 @@ func TestPrepare(t *testing.T) {
 		t.Errorf("Prepared statement did not return expected value: %v", s)
 	}
 
-	err = conn.Deallocate(context.Background(), "test")
+	err = conn.DeallocateAll(context.Background(), "test")
 	if err != nil {
 		t.Errorf("conn.Deallocate failed: %v", err)
 	}


### PR DESCRIPTION
Please provide feedback to the PR. Related [discussion](https://github.com/jackc/pgx/discussions/1370).