### PR TITLE
perf: use uuid module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jackc/pgx/v5
 go 1.18
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/jackc/pgpassfile v1.0.0
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b
 	github.com/jackc/puddle/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,12 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b h1:C8S2+VttkHFdOOCXJe+YGfa4vHYwlt4Zx+IVXQ97jYg=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
-github.com/jackc/puddle/v2 v2.0.1 h1:s8ZKO/+G8DLJNzPY8N58zA34IM1R9OjTel1pdTAunVk=
-github.com/jackc/puddle/v2 v2.0.1/go.mod h1:itE7ZJY8xnoo0JqJEpSMprN0f+NQkMCuEV/N9j8h0oc=
 github.com/jackc/puddle/v2 v2.1.2 h1:0f7vaaXINONKTsxYDn4otOAiJanX/BMeAtY//BXqzlg=
 github.com/jackc/puddle/v2 v2.1.2/go.mod h1:2lpufsF5mRHO6SuZkm0fNYxM6SWHfvyFj62KwNzgels=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/pgtype/uuid.go
+++ b/pgtype/uuid.go
@@ -5,6 +5,8 @@ import (
 	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
+
+	"github.com/google/uuid"
 )
 
 type UUIDScanner interface {
@@ -52,7 +54,7 @@ func parseUUID(src string) (dst [16]byte, err error) {
 
 // encodeUUID converts a uuid byte array to UUID standard string form.
 func encodeUUID(src [16]byte) string {
-	return fmt.Sprintf("%x-%x-%x-%x-%x", src[0:4], src[4:6], src[6:8], src[8:10], src[10:16])
+	return uuid.UUID(src).String()
 }
 
 // Scan implements the database/sql Scanner interface.


### PR DESCRIPTION
I was trying to benchmark some projects and figure it encodeUUID is using too much memory.

![image](https://user-images.githubusercontent.com/1001175/201537651-53309ac5-ac1d-48d0-8308-579abcd83446.png)

Looks like fmt.Sprintf is not performant and output of uuid string has fixed length.
I was trying to roll my own but looks google/uuid doing best on this purpose. 
Also it is compatible with pgx datatype which is [16]byte.

Benchmark results is here (I am not included those, since I am not sure, I should even add google/uuid to the pgx)

```
BenchmarkEncodeUUID-16                   1000000              2482 ns/op             552 B/op         21 allocs/op
BenchmarkGoogleEncodeUUID-16             2829258               417.9 ns/op           144 B/op          3 allocs/op
```

And the results are good. I am personally ok with custom data type that pgx provided, so I don't mind even if you not accepting this kind of PR.

![image](https://user-images.githubusercontent.com/1001175/201537835-c05f74f0-bbe9-4bd4-a72b-11f3ebb3834c.png)
