### PR TITLE
removed unnecessary name argument from DeallocateAll

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -327,7 +327,7 @@ func (c *Conn) Deallocate(ctx context.Context, name string) error {
 }
 
 // DeallocateAll releases all previously prepared statements from the server and client, where it also resets the statement and description cache.
-func (c *Conn) DeallocateAll(ctx context.Context, name string) error {
+func (c *Conn) DeallocateAll(ctx context.Context) error {
 	c.preparedStatements = map[string]*pgconn.StatementDescription{}
 	if c.config.StatementCacheCapacity > 0 {
 		c.statementCache = stmtcache.NewLRUCache(c.config.StatementCacheCapacity)

--- a/conn_test.go
+++ b/conn_test.go
@@ -424,7 +424,7 @@ func TestPrepare(t *testing.T) {
 		t.Errorf("Prepared statement did not return expected value: %v", s)
 	}
 
-	err = conn.DeallocateAll(context.Background(), "test")
+	err = conn.DeallocateAll(context.Background())
 	if err != nil {
 		t.Errorf("conn.Deallocate failed: %v", err)
 	}


### PR DESCRIPTION
Hey Jack,

In our last commit, I forgot to remove the `name` argument (copied from `Deallocate`), which does not make any sense for `DeallocateAll`.

This PR removes it.

Best wishes,
Bodo