### PR TITLE
Optimize 'beginSQL' runtime and memory allocations

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -1,7 +1,6 @@
 package pgx
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -52,19 +51,23 @@ func (txOptions TxOptions) beginSQL() string {
 	if txOptions == emptyTxOptions {
 		return "begin"
 	}
-	buf := &bytes.Buffer{}
-	buf.WriteString("begin")
+
+	buf := make([]byte, 0, 64) // 64 - maximum length of string with available options
+	buf = append(buf, "begin"...)
 	if txOptions.IsoLevel != "" {
-		fmt.Fprintf(buf, " isolation level %s", txOptions.IsoLevel)
+		buf = append(buf, " isolation level "...)
+		buf = append(buf, txOptions.IsoLevel...)
 	}
 	if txOptions.AccessMode != "" {
-		fmt.Fprintf(buf, " %s", txOptions.AccessMode)
+		buf = append(buf, ' ')
+		buf = append(buf, txOptions.AccessMode...)
 	}
 	if txOptions.DeferrableMode != "" {
-		fmt.Fprintf(buf, " %s", txOptions.DeferrableMode)
+		buf = append(buf, ' ')
+		buf = append(buf, txOptions.DeferrableMode...)
 	}
 
-	return buf.String()
+	return string(buf)
 }
 
 var ErrTxClosed = errors.New("tx is closed")


### PR DESCRIPTION
Hi!
I found out that "beginSQL" method is very slow by using "Fprintf" operation.
I optimize the runtime of "beginSQL" method and memory allocations via using []byte slice.

The results of benchmarking:
BenchmarkBeginSQLOld
BenchmarkBeginSQLOld-12                                               --- 	 2144254	---       556.7 ns/op	---     176 B/op	---       3 allocs/op
BenchmarkBeginSQLNew
BenchmarkBeginSQLNew-12                                         ---     	20466733	---        58.88 ns/op	---      64 B/op	---       1 allocs/op

Runtime decreased in ~10 times, memory allocations decreased from 3 to 1.