### PR TITLE
Config cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 
 .envrc
 /.testdb
+.scannerwork

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+  sonar.projectKey=lib-pgx
+  sonar.projectName=lib-pgx
+
+  sonar.exclusions=**/*_test.go,**/*main.go
+
+
+  sonar.tests=.
+  sonar.test.inclusions=**/*_test.go
+  sonar.go.coverage.reportPaths=coverage-report/report.out


### PR DESCRIPTION
In pgconn/config.go I found a function with a complexity score of 44 and reduced it to under 15. I did this by breaking up the complex if statements, inside of the function, into smaller helper functions each with comments. I also made a sonarqube properties file and added .scannerwork to gitignore.

here is the before and after sonarqube scan:
![image](https://user-images.githubusercontent.com/111247018/205165036-3aacf8e9-451e-4fa9-9d18-7563d46f28b3.png)
![image](https://user-images.githubusercontent.com/111247018/205165089-716addd6-a5ae-4b6f-9f38-334f10de5ae5.png)
![image](https://user-images.githubusercontent.com/111247018/205165121-47508a11-98fd-4652-a494-7aeab36e3ee6.png)
