### PR TITLE
pgtype Int fix minimum error message.

### DIFF
--- a/pgtype/int.go
+++ b/pgtype/int.go
@@ -33,7 +33,7 @@ func (dst *Int2) ScanInt64(n Int8) error {
 	}
 
 	if n.Int64 < math.MinInt16 {
-		return fmt.Errorf("%d is greater than maximum value for Int2", n.Int64)
+		return fmt.Errorf("%d is less than minimum value for Int2", n.Int64)
 	}
 	if n.Int64 > math.MaxInt16 {
 		return fmt.Errorf("%d is greater than maximum value for Int2", n.Int64)
@@ -593,7 +593,7 @@ func (dst *Int4) ScanInt64(n Int8) error {
 	}
 
 	if n.Int64 < math.MinInt32 {
-		return fmt.Errorf("%d is greater than maximum value for Int4", n.Int64)
+		return fmt.Errorf("%d is less than minimum value for Int4", n.Int64)
 	}
 	if n.Int64 > math.MaxInt32 {
 		return fmt.Errorf("%d is greater than maximum value for Int4", n.Int64)
@@ -1164,7 +1164,7 @@ func (dst *Int8) ScanInt64(n Int8) error {
 	}
 
 	if n.Int64 < math.MinInt64 {
-		return fmt.Errorf("%d is greater than maximum value for Int8", n.Int64)
+		return fmt.Errorf("%d is less than minimum value for Int8", n.Int64)
 	}
 	if n.Int64 > math.MaxInt64 {
 		return fmt.Errorf("%d is greater than maximum value for Int8", n.Int64)

--- a/pgtype/int.go.erb
+++ b/pgtype/int.go.erb
@@ -3,6 +3,7 @@ package pgtype
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -34,7 +35,7 @@ func (dst *Int<%= pg_byte_size %>) ScanInt64(n Int8) error {
 	}
 
 	if n.Int64 < math.MinInt<%= pg_bit_size %> {
-		return fmt.Errorf("%d is greater than maximum value for Int<%= pg_byte_size %>", n.Int64)
+		return fmt.Errorf("%d is less than minimum value for Int<%= pg_byte_size %>", n.Int64)
 	}
 	if n.Int64 > math.MaxInt<%= pg_bit_size %> {
 		return fmt.Errorf("%d is greater than maximum value for Int<%= pg_byte_size %>", n.Int64)


### PR DESCRIPTION
Previously on the minimum condition the error would be:

  `is greater than maximum`

Also add encoding/json import into the .erb template as the import was missing after running rake generate.