### PR TITLE
fix: Improve errors in batch modes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1106,6 +1106,8 @@ func (c *Conn) sendBatchExtendedWithDescription(ctx context.Context, b *Batch, d
 	for _, bi := range b.queuedQueries {
 		err := c.eqb.Build(c.typeMap, bi.sd, bi.arguments)
 		if err != nil {
+			// we wrap the error so we the user can understand which query failed inside the batch
+			err = fmt.Errorf("error building query %s: %w", bi.query, err)
 			return &pipelineBatchResults{ctx: ctx, conn: c, err: err}
 		}
 


### PR DESCRIPTION
Hi there! Thanks for this great library and we are long time users of `v4` (in process of migrating to `v5` already have a PR in place but have a few more tests to run).

Specifically we are using batch jobs heavily and we have an issue that errors don't include which query caused the error even though this information is available in `pgx`. This adds the needed error wrapping and tested with this [code](https://github.com/cloudquery/cloudquery/blob/main/plugins/destination/postgresql/client/write.go#L43) (this code still uses `v4` but I tested locally also on our `v5` branch).

Also, to clarify when the error is hapening on the Postgres side `pgx` is already returning the useful information via `pgErr.TableName` so it's only when it fails in the prepared statement before hand on the client side.

Hopefully this fix will help others as well.