### PR TITLE
pgtype.Numeric numberTextBytes() bug for negative 0.0X

### DIFF
--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -243,7 +243,14 @@ func (n Numeric) MarshalJSON() ([]byte, error) {
 // numberString returns a string of the number. undefined if NaN, infinite, or NULL
 func (n Numeric) numberTextBytes() []byte {
 	intStr := n.Int.String()
+
 	buf := &bytes.Buffer{}
+
+	if len(intStr) > 0 && intStr[:1] == "-" {
+		intStr = intStr[1:]
+		buf.WriteByte('-')
+	}
+
 	exp := int(n.Exp)
 	if exp > 0 {
 		buf.WriteString(intStr)

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -213,6 +213,12 @@ func TestNumericMarshalJSON(t *testing.T) {
 			{"123e-3"},
 			{"243723409723490243842378942378901237502734019231380123e23790"},
 			{"3409823409243892349028349023482934092340892390101e-14021"},
+			{"-1.1"},
+			{"-1.0231"},
+			{"-10.0231"},
+			{"-0.1"},   // failed with "invalid character '.' in numeric literal"
+			{"-0.01"},  // failed with "invalid character '-' after decimal point in numeric literal"
+			{"-0.001"}, // failed with "invalid character '-' after top-level value"
 		} {
 			var num pgtype.Numeric
 			var pgJSON string


### PR DESCRIPTION
I'm not sure what the best fix is. The first commit demonstrates in the tests an issue with MarshalJSON and Scan() as per https://github.com/jackc/pgx/issues/1426.

Second commit as a quick workaround.