### PR TITLE
Adds CollectOneRowOK

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -449,6 +449,23 @@ func CollectOneRow[T any](rows Rows, fn RowToFunc[T]) (T, error) {
 	return value, rows.Err()
 }
 
+// CollectOneRowOK is CollectOneRow with the "comma OK idiom": think 'val, ok := myMap["foo"]'
+// or os.GetEnv (no comma OK idiom) versus os.LookupEnv (follows comma OK idiom).
+// If no rows are found, the second return value is false (instead of returning error ErrNoRows
+// as CollectOneRow does). If a row is found, the second return value is true.
+func CollectOneRowOK[T any](rows Rows, fn RowToFunc[T]) (T, bool, error) {
+	var value T
+	var err error
+	value, err = CollectOneRow(rows, fn)
+	if err != nil {
+		if err == ErrNoRows {
+			return value, false, nil
+		}
+		return value, false, err
+	}
+	return value, true, nil
+}
+
 // RowTo returns a T scanned from row.
 func RowTo[T any](row CollectableRow) (T, error) {
 	var value T


### PR DESCRIPTION
`CollectOneRowOK()` is a "comma OK idom" wrapper around `CollectOneRow()`.

Compare `CollectRows()` to `CollectOneRow()`: when `CollectRows()` finds no rows, it does not return an error; it's just that the returned slice is length 0. But when `CollectOneRow()` finds no rows, it returns an error (`ErrNoRows`).

`CollectOneRowOK()` provides a way to also return without error when no rows are found. Whereas a caller of `CollectRows()` can check if the returned slice is length > 0 to determine if rows were found, a caller of CollectOneRowOK can check the second return value (usually named `ok`) to see if a row was found.