### PR TITLE
Remove unused test struct, replace deprecated ioutil, return err fix, and spelling.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -484,7 +484,7 @@ func multiInsert(conn *pgx.Conn, tableName string, columnNames []string, rowSrc 
 	}
 
 	if err := tx.Commit(context.Background()); err != nil {
-		return 0, nil
+		return 0, err
 	}
 
 	return rowCount, nil

--- a/internal/nbconn/nbconn.go
+++ b/internal/nbconn/nbconn.go
@@ -54,7 +54,7 @@ type Conn interface {
 	// Flush flushes any buffered writes.
 	Flush() error
 
-	// BufferReadUntilBlock reads and buffers any sucessfully read bytes until the read would block.
+	// BufferReadUntilBlock reads and buffers any successfully read bytes until the read would block.
 	BufferReadUntilBlock() error
 }
 

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net"
 	"net/url"
@@ -687,7 +686,7 @@ func configTLS(settings map[string]string, thisHost string, parseConfigOptions P
 		caCertPool := x509.NewCertPool()
 
 		caPath := sslrootcert
-		caCert, err := ioutil.ReadFile(caPath)
+		caCert, err := os.ReadFile(caPath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read CA file: %w", err)
 		}
@@ -705,7 +704,7 @@ func configTLS(settings map[string]string, thisHost string, parseConfigOptions P
 	}
 
 	if sslcert != "" && sslkey != "" {
-		buf, err := ioutil.ReadFile(sslkey)
+		buf, err := os.ReadFile(sslkey)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read sslkey: %w", err)
 		}
@@ -744,7 +743,7 @@ func configTLS(settings map[string]string, thisHost string, parseConfigOptions P
 		} else {
 			pemKey = pem.EncodeToMemory(block)
 		}
-		certfile, err := ioutil.ReadFile(sslcert)
+		certfile, err := os.ReadFile(sslcert)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read cert: %w", err)
 		}

--- a/pgconn/config_test.go
+++ b/pgconn/config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"runtime"
@@ -1031,7 +1030,7 @@ func TestParseConfigEnvLibpq(t *testing.T) {
 func TestParseConfigReadsPgPassfile(t *testing.T) {
 	t.Parallel()
 
-	tf, err := ioutil.TempFile("", "")
+	tf, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 
 	defer tf.Close()
@@ -1060,7 +1059,7 @@ func TestParseConfigReadsPgPassfile(t *testing.T) {
 func TestParseConfigReadsPgServiceFile(t *testing.T) {
 	t.Parallel()
 
-	tf, err := ioutil.TempFile("", "")
+	tf, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 
 	defer tf.Close()

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"net"
@@ -1819,7 +1818,7 @@ func TestConnCopyFromGzipReader(t *testing.T) {
 	)`).ReadAll()
 	require.NoError(t, err)
 
-	f, err := ioutil.TempFile("", "*")
+	f, err := os.CreateTemp("", "*")
 	require.NoError(t, err)
 
 	gw := gzip.NewWriter(f)

--- a/pgproto3/backend.go
+++ b/pgproto3/backend.go
@@ -196,7 +196,7 @@ func (b *Backend) Receive() (FrontendMessage, error) {
 		case AuthTypeCleartextPassword, AuthTypeMD5Password:
 			fallthrough
 		default:
-			// to maintain backwards compatability
+			// to maintain backwards compatibility
 			msg = &PasswordMessage{}
 		}
 	case 'Q':

--- a/query_test.go
+++ b/query_test.go
@@ -1226,11 +1226,6 @@ func TestConnQueryDatabaseSQLNullFloat64NegativeZeroPointZero(t *testing.T) {
 	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
 	defer closeConn(t, conn)
 
-	type test struct {
-		want sql.NullFloat64
-		in   float64
-	}
-
 	tests := []float64{
 		-0.01,
 		-0.001,


### PR DESCRIPTION
Done as separate commits should you want to cherry-pick.