### PR TITLE
Use Go 1.19's lists for proper formatting

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -197,17 +197,17 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 // ParseConfig creates a ConnConfig from a connection string. ParseConfig handles all options that pgconn.ParseConfig
 // does. In addition, it accepts the following options:
 //
-//	default_query_exec_mode
-//		Possible values: "cache_statement", "cache_describe", "describe_exec", "exec", and "simple_protocol". See
-//		QueryExecMode constant documentation for the meaning of these values. Default: "cache_statement".
+//   - default_query_exec_mode.
+//     Possible values: "cache_statement", "cache_describe", "describe_exec", "exec", and "simple_protocol". See
+//     QueryExecMode constant documentation for the meaning of these values. Default: "cache_statement".
 //
-//	statement_cache_capacity
-//		The maximum size of the statement cache used when executing a query with "cache_statement" query exec mode.
-//		Default: 512.
+//   - statement_cache_capacity.
+//     The maximum size of the statement cache used when executing a query with "cache_statement" query exec mode.
+//     Default: 512.
 //
-//	description_cache_capacity
-//		The maximum size of the description cache used when executing a query with "cache_describe" query exec mode.
-//		Default: 512.
+//   - description_cache_capacity.
+//     The maximum size of the description cache used when executing a query with "cache_describe" query exec mode.
+//     Default: 512.
 func ParseConfig(connString string) (*ConnConfig, error) {
 	return ParseConfigWithOptions(connString, ParseConfigOptions{})
 }

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -210,9 +210,9 @@ func NetworkAddress(host string, port uint16) (network, address string) {
 //
 // In addition, ParseConfig accepts the following options:
 //
-//	servicefile
-//		libpq only reads servicefile from the PGSERVICEFILE environment variable. ParseConfig accepts servicefile as a
-//		part of the connection string.
+//   - servicefile.
+//     libpq only reads servicefile from the PGSERVICEFILE environment variable. ParseConfig accepts servicefile as a
+//     part of the connection string.
 func ParseConfig(connString string) (*Config, error) {
 	var parseConfigOptions ParseConfigOptions
 	return ParseConfigWithOptions(connString, parseConfigOptions)

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -261,12 +261,12 @@ func NewWithConfig(ctx context.Context, config *Config) (*Pool, error) {
 // ParseConfig builds a Config from connString. It parses connString with the same behavior as pgx.ParseConfig with the
 // addition of the following variables:
 //
-// pool_max_conns: integer greater than 0
-// pool_min_conns: integer 0 or greater
-// pool_max_conn_lifetime: duration string
-// pool_max_conn_idle_time: duration string
-// pool_health_check_period: duration string
-// pool_max_conn_lifetime_jitter: duration string
+//   - pool_max_conns: integer greater than 0
+//   - pool_min_conns: integer 0 or greater
+//   - pool_max_conn_lifetime: duration string
+//   - pool_max_conn_idle_time: duration string
+//   - pool_health_check_period: duration string
+//   - pool_max_conn_lifetime_jitter: duration string
 //
 // See Config for definitions of these arguments.
 //


### PR DESCRIPTION
Before (https://pkg.go.dev/github.com/jackc/pgx/v5@v5.2.0/pgxpool#ParseConfig):

<img width="1033" alt="CleanShot 2023-01-23 at 07 23 37@2x" src="https://user-images.githubusercontent.com/11512/213960817-c89e80a2-6245-43bd-b973-c88d599d9887.png">

After (locally):

<img width="402" alt="CleanShot 2023-01-23 at 07 23 54@2x" src="https://user-images.githubusercontent.com/11512/213960832-e95e292c-a78d-45e0-a6be-8052f2e92968.png">

See https://tip.golang.org/doc/comment.

Additionally, I noticed there are a few changed files after running 1.19's `gofmt -w -s .`. Would you be interested in merging a PR with them?