### PR TITLE
Fix for passing the context in pgxpool.ConnectConfig to BeforeConnect

### DIFF
--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -73,6 +73,26 @@ func TestLazyConnect(t *testing.T) {
 	assert.Equal(t, context.Canceled, err)
 }
 
+func TestBeforeConnectWithContextWithValueAndOneMinConn(t *testing.T) {
+	t.Parallel()
+
+	config, err := pgxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	assert.NoError(t, err)
+	config.MinConns = 1
+	config.BeforeConnect = func(ctx context.Context, config *pgx.ConnConfig) error {
+		val := ctx.Value("key")
+		if val == nil {
+			return errors.New("no value found with key 'key'")
+		}
+		return nil
+	}
+
+	ctx := context.WithValue(context.Background(), "key", "value")
+
+	_, err = pgxpool.ConnectConfig(ctx, config)
+	assert.NoError(t, err)
+}
+
 func TestConstructorIgnoresContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes bug where the context passed to a `config.BeforeConnect` function (of type `func(context.Context, *pgx.ConnConfig) error`) is not the same as the context passed to the invoking `pgxpool.ConnectConfig(ctx, config)` function.  This happens when `config.MinConns` is greater than 0.

This bug was introduced in 4.17 from this commit line: https://github.com/jackc/pgx/pull/1213/files#diff-dfb45ae842e6d6603aae7f6631cd38ee1c56d2053289b1914aff4bef35e39d2dR243