### PR TITLE
replace erroneous reflect.New with reflect.Zero in TryWrapStructScanPlan

### DIFF
--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -1028,7 +1028,7 @@ func TryWrapStructScanPlan(target any) (plan WrappedScanPlanNextSetter, nextValu
 
 	var targetElemValue reflect.Value
 	if targetValue.IsNil() {
-		targetElemValue = reflect.New(targetValue.Type().Elem())
+		targetElemValue = reflect.Zero(targetValue.Type().Elem())
 	} else {
 		targetElemValue = targetValue.Elem()
 	}

--- a/pgtype/pgtype_test.go
+++ b/pgtype/pgtype_test.go
@@ -313,13 +313,8 @@ func TestPointerPointerStructScan(t *testing.T) {
 	m.RegisterType(pgt)
 
 	var c *composite
-	plan := m.PlanScan(pgt.OID, pgtype.BinaryFormatCode, &c)
-	err := plan.Scan([]byte{
-		0, 0, 0, 1,
-		0, 0, 0, 23,
-		0, 0, 0, 4,
-		0, 0, 0, 1,
-	}, &c)
+	plan := m.PlanScan(pgt.OID, pgtype.TextFormatCode, &c)
+	err := plan.Scan([]byte("(1)"), &c)
 	require.NoError(t, err)
 	require.Equal(t, c.ID, 1)
 }


### PR DESCRIPTION
Fix as said in the title. This only had effect in conjunction with `TryPointerPointerScanPlan`, where nextDest is a nil pointer.
The `TestMapScanPointerToNilStructDoesNotCrash` still passes, but the error thrown seems different than what test is intended for.

Also adds a test case.