### PR TITLE
simplify duplicate `pgx` registration guard

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -58,7 +58,6 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -86,9 +85,9 @@ func init() {
 	}
 	fakeTxConns = make(map[*pgx.Conn]*sql.Tx)
 
-	drivers := sql.Drivers()
-	// if pgx driver was already registered by different pgx major version then we skip registration under the default name.
-	if i := sort.SearchStrings(sql.Drivers(), "pgx"); len(drivers) >= i || drivers[i] != "pgx" {
+	// if pgx driver was already registered by different pgx major version then we
+	// skip registration under the default name.
+	if !contains(sql.Drivers(), "pgx") {
 		sql.Register("pgx", pgxDriver)
 	}
 	sql.Register("pgx/v4", pgxDriver)
@@ -108,6 +107,17 @@ func init() {
 		pgtype.TimestamptzOID: 1,
 		pgtype.XIDOID:         1,
 	}
+}
+
+// TODO replace by slices.Contains when experimental package will be merged to stdlib
+// https://pkg.go.dev/golang.org/x/exp/slices#Contains
+func contains(list []string, y string) bool {
+	for _, x := range list {
+		if x == y {
+			return true
+		}
+	}
+	return false
 }
 
 var (


### PR DESCRIPTION
The binary search is overkill here.
Readability first.