### PR TITLE
simplify duplicate `pgx` registration guard

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -66,7 +66,6 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -87,9 +86,9 @@ func init() {
 		configs: make(map[string]*pgx.ConnConfig),
 	}
 
-	drivers := sql.Drivers()
-	// if pgx driver was already registered by different pgx major version then we skip registration under the default name.
-	if i := sort.SearchStrings(sql.Drivers(), "pgx"); len(drivers) >= i || drivers[i] != "pgx" {
+	// if pgx driver was already registered by different pgx major version then we
+	// skip registration under the default name.
+	if !contains(sql.Drivers(), "pgx") {
 		sql.Register("pgx", pgxDriver)
 	}
 	sql.Register("pgx/v5", pgxDriver)
@@ -109,6 +108,17 @@ func init() {
 		pgtype.TimestamptzOID: 1,
 		pgtype.XIDOID:         1,
 	}
+}
+
+// TODO replace by slices.Contains when experimental package will be merged to stdlib
+// https://pkg.go.dev/golang.org/x/exp/slices#Contains
+func contains(list []string, y string) bool {
+	for _, x := range list {
+		if x == y {
+			return true
+		}
+	}
+	return false
 }
 
 // OptionOpenDB options for configuring the driver when opening a new db pool.


### PR DESCRIPTION
The binary search is overkill here.
Readability first.