### PR TITLE
Add QueuedQuery.Result()

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -57,6 +57,12 @@ func (qq *QueuedQuery) Exec(fn func(ct pgconn.CommandTag) error) {
 	}
 }
 
+// Result sets fn to be called when the response to qq is received and gives
+// access to the pgx error immediately (unlike Query, QueryRow or Exec).
+func (qq *QueuedQuery) Result(fn func(br BatchResults) error) {
+	qq.fn = fn
+}
+
 // Batch queries are a way of bundling multiple queries together to avoid
 // unnecessary network round trips. A Batch must only be sent once.
 type Batch struct {


### PR DESCRIPTION
This allows the user to have access to the pgconn.PgError early on instead of after BatchResults.Close(). This allows for error parsing in the QueuedQuery context. With the existing functions, QueuedQuery.Query(), QueuedQuery.QueryRow() and QueuedQuery.Exec(), the associated QueuedQuery has to be deduced.

Another reason to use QueuedQuery.Result() is that the other functions result (potentially) in multiple kinds of error types: pgconn.PgError and the error types returned from the functions passed in through QueuedQuery.Query(), QueuedQuery.QueryRow() and QueuedQuery.Exec()