### PR TITLE
fix build on 32-bit Windows

### DIFF
--- a/internal/nbconn/nbconn_real_non_block_windows.go
+++ b/internal/nbconn/nbconn_real_non_block_windows.go
@@ -24,7 +24,7 @@ var ioctlsocket = dll.MustFindProc("ioctlsocket")
 type sockMode int
 
 const (
-	FIONBIO             int      = 0x8004667e
+	FIONBIO             uint32   = 0x8004667e
 	sockModeBlocking    sockMode = 0
 	sockModeNonBlocking sockMode = 1
 )


### PR DESCRIPTION
I've included #1525 in SFTPGo. Manual tests are ok and SFTPGo test suite passes too, thanks for improving Windows support!
However CI fails with this error

```
C:\Users\runneradmin\go\pkg\mod\github.com\jackc\pgx\v5@v5.3.2-0.20230304152536-0dbb0a52ab75\internal\nbconn\nbconn_real_non_block_windows.go:27:33: cannot use 0x8004667e (untyped int constant 2147772030) as int value in constant declaration (overflows)
```

https://github.com/drakkan/sftpgo/actions/runs/4336134809/jobs/7571210333

CI builds SFTPGo for amd64, arm64 and 386. This patch fixes the 32-bit build
