### PR TITLE
fix: handle null interface for json

### DIFF
--- a/pgtype/json.go
+++ b/pgtype/json.go
@@ -150,7 +150,7 @@ func (scanPlanJSONToJSONUnmarshal) Scan(src []byte, dst any) error {
 		if dstValue.Kind() == reflect.Ptr {
 			el := dstValue.Elem()
 			switch el.Kind() {
-			case reflect.Ptr, reflect.Slice, reflect.Map:
+			case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface:
 				el.Set(reflect.Zero(el.Type()))
 				return nil
 			}

--- a/pgtype/json_test.go
+++ b/pgtype/json_test.go
@@ -83,6 +83,11 @@ func TestJSONCodecUnmarshalSQLNull(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, m)
 
+		m = map[string]interface{}{"foo": "bar"}
+		err = conn.QueryRow(ctx, "select null::json").Scan(&m)
+		require.NoError(t, err)
+		require.Nil(t, m)
+
 		// Pointer to pointer are nilified
 		n := 42
 		p := &n


### PR DESCRIPTION
When using `scany` I encountered the [following case](https://github.com/georgysavva/scany/issues/104). This change seems to fix it. I can add test cases as well if you could point me to the right place.

Looks like null `jsonb` columns cause a problem. If you create a table like below you can see that the following code fails.

```sql
CREATE TABLE test (
	a int4 NULL,
	b int4 NULL,
	c jsonb NULL
);

INSERT INTO test (a, b, c) VALUES (1, null, null);
```

```go
package main

import (
	"context"
	"log"

	"github.com/georgysavva/scany/v2/pgxscan"
	"github.com/jackc/pgx/v5"
)

func main() {
	var rows []map[string]interface{}
	conn, _ := pgx.Connect(context.Background(), , ts.PGURL().String())
	
	// this will fail with can't scan into dest[0]: cannot scan NULL into *interface {}
	err := pgxscan.Select(context.Background(), conn, &rows, `SELECT c from test`) 
	
	// this works
	// err = pgxscan.Select(context.Background(), conn, &rows, `SELECT a,b from test`)
	
	if err != nil {
		panic(err)
	}

	log.Printf("%+v", rows)
}
```