### PR TITLE
add extra tests for `RowToStructByNameLax`

### DIFF
--- a/rows_test.go
+++ b/rows_test.go
@@ -751,6 +751,8 @@ func TestRowToStructByNameLaxRowValue(t *testing.T) {
 	}
 
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		pgxtest.SkipCockroachDB(t, conn, "")
+
 		rows, _ := conn.Query(ctx, `
 		WITH user_api_keys AS (
 			SELECT 1 AS user_id, 101 AS user_api_key_id, 'abc123' AS api_key
@@ -763,6 +765,7 @@ func TestRowToStructByNameLaxRowValue(t *testing.T) {
 		WHERE user_api_keys.api_key = 'abc123';
 		`)
 		slice, err := pgx.CollectRows(rows, pgx.RowToStructByNameLax[UserAPIKey])
+
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, slice, []UserAPIKey{{UserAPIKeyID: 101, UserID: 1, User: &User{UserID: 1, Name: "John Doe"}, AnotherTable: nil}})
 	})

--- a/rows_test.go
+++ b/rows_test.go
@@ -751,17 +751,13 @@ func TestRowToStructByNameLaxJSON(t *testing.T) {
 	}
 
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-		// FIXME
-		// user_api_key_id  │ user_id │              user
-		// ═════════════════╪═════════╪═════════════════════════════════
-		//             101  │       1 │ {"user_id":1,"name":"John Doe"}
 		rows, _ := conn.Query(ctx, `
 		WITH user_api_keys AS (
 			SELECT 1 AS user_id, 101 AS user_api_key_id, 'abc123' AS api_key
 		), users AS (
 			SELECT 1 AS user_id, 'John Doe' AS name
 		)
-		SELECT user_api_keys.user_api_key_id, user_api_keys.user_id, row_to_json(users.*) AS user
+		SELECT user_api_keys.user_api_key_id, user_api_keys.user_id, row(users.*) AS user
 		FROM user_api_keys
 		LEFT JOIN users ON users.user_id = user_api_keys.user_id
 		WHERE user_api_keys.api_key = 'abc123';

--- a/rows_test.go
+++ b/rows_test.go
@@ -736,7 +736,7 @@ func TestRowToStructByNameLaxEmbeddedStruct(t *testing.T) {
 	})
 }
 
-func TestRowToStructByNameLaxJSON(t *testing.T) {
+func TestRowToStructByNameLaxRowValue(t *testing.T) {
 	type AnotherTable struct{}
 	type User struct {
 		UserID int    `json:"userId" db:"user_id"`


### PR DESCRIPTION
NOTE: currently, these tests fail for some reason (`user.user_id` is zero valued, which can be reproduced with `int`, `string`, changing column name to a unique one instead of `user_id`...)

I don't know if it's a known problem, let me know if you want me to open accompanying issue