### PR TITLE
Add KSQL on the 3rd party section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ These adapters can be used with the tracelog package.
 
 Library for scanning data from a database into Go structs and more.
 
+### [github.com/vingarcia/ksql](https://github.com/vingarcia/ksql)
+
+A carefully designed SQL client for making using SQL easier,
+more productive, and less error-prone on Golang.
+
 ### [https://github.com/otan/gopgkrb5](https://github.com/otan/gopgkrb5)
 
 Adds GSSAPI / Kerberos authentication support.


### PR DESCRIPTION
As discussed on https://github.com/jackc/pgx/issues/1568 this PR adds KSQL to the list of 3rd party tools that support PGX.

I tried to keep the description brief and to the point, and I've put it after Scany using the number of stars as the criteria. If you prefer I can also move it to the bottom.

Regards, and thank you for your time.