### PR TITLE
Add a BeforeClose hook to pgxpool.Pool

### DIFF
--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -310,14 +310,6 @@ func TestPoolAfterRelease(t *testing.T) {
 		pool, err := pgxpool.New(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
 		require.NoError(t, err)
 		defer pool.Close()
-
-		err = pool.AcquireFunc(context.Background(), func(conn *pgxpool.Conn) error {
-			if conn.Conn().PgConn().ParameterStatus("crdb_version") != "" {
-				t.Skip("Server does not support backend PID")
-			}
-			return nil
-		})
-		require.NoError(t, err)
 	}()
 
 	config, err := pgxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
@@ -354,14 +346,6 @@ func TestPoolBeforeClose(t *testing.T) {
 		pool, err := pgxpool.New(context.Background(), os.Getenv("PGX_TEST_DATABASE"))
 		require.NoError(t, err)
 		defer pool.Close()
-
-		err = pool.AcquireFunc(context.Background(), func(conn *pgxpool.Conn) error {
-			if conn.Conn().PgConn().ParameterStatus("crdb_version") != "" {
-				t.Skip("Server does not support backend PID")
-			}
-			return nil
-		})
-		require.NoError(t, err)
 	}()
 
 	config, err := pgxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
@@ -719,14 +703,6 @@ func TestConnReleaseClosesConnInFailedTransaction(t *testing.T) {
 	require.NoError(t, err)
 	defer pool.Close()
 
-	err = pool.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
-		if conn.Conn().PgConn().ParameterStatus("crdb_version") != "" {
-			t.Skip("Server does not support backend PID")
-		}
-		return nil
-	})
-	require.NoError(t, err)
-
 	c, err := pool.Acquire(ctx)
 	require.NoError(t, err)
 
@@ -764,14 +740,6 @@ func TestConnReleaseClosesConnInTransaction(t *testing.T) {
 	pool, err := pgxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
 	require.NoError(t, err)
 	defer pool.Close()
-
-	err = pool.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
-		if conn.Conn().PgConn().ParameterStatus("crdb_version") != "" {
-			t.Skip("Server does not support backend PID")
-		}
-		return nil
-	})
-	require.NoError(t, err)
 
 	c, err := pool.Acquire(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
I needed to track per-connection metadata (similar to what is described in https://github.com/jackc/pgx/issues/1097)

In order to clean up unneeded metadata after a connection has been closed, I added a `BeforeClose` hook, similar to the existing hooks. In the linked issue @jackc suggested that an `AfterClose` hook would be accepted - I went with a `BeforeClose` hook to ensure that there was no risk of connection data being cleared out during the lifetime of the hook.

I also un-skipped tests for cockroach that rely on backend PIDs, since cockroach returns PIDs now (as of v22.1).