### PR TITLE
Fix hstore NULL versus empty

### DIFF
--- a/pgtype/hstore.go
+++ b/pgtype/hstore.go
@@ -174,7 +174,7 @@ func (scanPlanBinaryHstoreToHstoreScanner) Scan(src []byte, dst any) error {
 	scanner := (dst).(HstoreScanner)
 
 	if src == nil {
-		return scanner.ScanHstore(Hstore{})
+		return scanner.ScanHstore(Hstore(nil))
 	}
 
 	rp := 0
@@ -234,7 +234,7 @@ func (scanPlanTextAnyToHstoreScanner) Scan(src []byte, dst any) error {
 	scanner := (dst).(HstoreScanner)
 
 	if src == nil {
-		return scanner.ScanHstore(Hstore{})
+		return scanner.ScanHstore(Hstore(nil))
 	}
 
 	keys, values, err := parseHstore(string(src))


### PR DESCRIPTION
When running queries with the hstore type registered, and with simple mode queries, the scan implementation does not correctly distinguish between NULL and empty. Fix the implementation and add a test to verify this.