### PR TITLE
Correctly handle bool type aliases

### DIFF
--- a/pgtype/convert.go
+++ b/pgtype/convert.go
@@ -64,6 +64,9 @@ func underlyingNumberType(val any) (any, bool) {
 	case reflect.String:
 		convVal := refVal.String()
 		return convVal, reflect.TypeOf(convVal) != refVal.Type()
+	case reflect.Bool:
+		convVal := refVal.Bool()
+		return convVal, reflect.TypeOf(convVal) != refVal.Type()
 	}
 
 	return nil, false

--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -666,6 +666,7 @@ var elemKindToPointerTypes map[reflect.Kind]reflect.Type = map[reflect.Kind]refl
 	reflect.Float32: reflect.TypeOf(new(float32)),
 	reflect.Float64: reflect.TypeOf(new(float64)),
 	reflect.String:  reflect.TypeOf(new(string)),
+	reflect.Bool:    reflect.TypeOf(new(bool)),
 }
 
 type underlyingTypeScanPlan struct {

--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -1519,6 +1519,7 @@ var kindToTypes map[reflect.Kind]reflect.Type = map[reflect.Kind]reflect.Type{
 	reflect.Float32: reflect.TypeOf(float32(0)),
 	reflect.Float64: reflect.TypeOf(float64(0)),
 	reflect.String:  reflect.TypeOf(""),
+	reflect.Bool:    reflect.TypeOf(false),
 }
 
 type underlyingTypeEncodePlan struct {

--- a/values_test.go
+++ b/values_test.go
@@ -881,6 +881,7 @@ func TestEncodeTypeRename(t *testing.T) {
 		conn.TypeMap().RegisterDefaultPgType(inUint32, "int8")
 		conn.TypeMap().RegisterDefaultPgType(inUint64, "int8")
 		conn.TypeMap().RegisterDefaultPgType(inString, "text")
+		conn.TypeMap().RegisterDefaultPgType(inBool, "bool")
 
 		err := conn.QueryRow(context.Background(), "select $1::int, $2::int, $3::int2, $4::int4, $5::int8, $6::int, $7::int, $8::int, $9::int, $10::int, $11::text, $12::bool",
 			inInt, inInt8, inInt16, inInt32, inInt64, inUint, inUint8, inUint16, inUint32, inUint64, inString, inBool,

--- a/values_test.go
+++ b/values_test.go
@@ -865,6 +865,10 @@ func TestEncodeTypeRename(t *testing.T) {
 		inString := _string("foo")
 		var outString _string
 
+		type _bool bool
+		inBool := _bool(true)
+		var outBool _bool
+
 		// pgx.QueryExecModeExec requires all types to be registered.
 		conn.TypeMap().RegisterDefaultPgType(inInt, "int8")
 		conn.TypeMap().RegisterDefaultPgType(inInt8, "int8")
@@ -878,9 +882,9 @@ func TestEncodeTypeRename(t *testing.T) {
 		conn.TypeMap().RegisterDefaultPgType(inUint64, "int8")
 		conn.TypeMap().RegisterDefaultPgType(inString, "text")
 
-		err := conn.QueryRow(context.Background(), "select $1::int, $2::int, $3::int2, $4::int4, $5::int8, $6::int, $7::int, $8::int, $9::int, $10::int, $11::text",
-			inInt, inInt8, inInt16, inInt32, inInt64, inUint, inUint8, inUint16, inUint32, inUint64, inString,
-		).Scan(&outInt, &outInt8, &outInt16, &outInt32, &outInt64, &outUint, &outUint8, &outUint16, &outUint32, &outUint64, &outString)
+		err := conn.QueryRow(context.Background(), "select $1::int, $2::int, $3::int2, $4::int4, $5::int8, $6::int, $7::int, $8::int, $9::int, $10::int, $11::text, $12::bool",
+			inInt, inInt8, inInt16, inInt32, inInt64, inUint, inUint8, inUint16, inUint32, inUint64, inString, inBool,
+		).Scan(&outInt, &outInt8, &outInt16, &outInt32, &outInt64, &outUint, &outUint8, &outUint16, &outUint32, &outUint64, &outString, &outBool)
 		if err != nil {
 			t.Fatalf("Failed with type rename: %v", err)
 		}
@@ -927,6 +931,10 @@ func TestEncodeTypeRename(t *testing.T) {
 
 		if inString != outString {
 			t.Errorf("string rename: expected %v, got %v", inString, outString)
+		}
+
+		if inBool != outBool {
+			t.Errorf("bool rename: expected %v, got %v", inBool, outBool)
 		}
 	})
 }


### PR DESCRIPTION
The bool type was missing in the `kindToTypes` map, which breaks handling of type aliases for bool.

fixes #1593