### PR TITLE
pgtype/hstore.go: Remove unused quoteHstore{Element,Replacer}

### DIFF
--- a/pgtype/hstore.go
+++ b/pgtype/hstore.go
@@ -271,12 +271,6 @@ func (c HstoreCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (
 	return hstore, nil
 }
 
-var quoteHstoreReplacer = strings.NewReplacer(`\`, `\\`, `"`, `\"`)
-
-func quoteHstoreElement(src string) string {
-	return `"` + quoteArrayReplacer.Replace(src) + `"`
-}
-
 func quoteHstoreElementIfNeeded(src string) string {
 	if src == "" || (len(src) == 4 && strings.ToLower(src) == "null") || strings.ContainsAny(src, ` {},"\=>`) {
 		return quoteArrayElement(src)


### PR DESCRIPTION
These are unused. The code uses quoteArrayElement instead.