### PR TITLE
pgtype.TestTextCodeACLItem: Use built-in role instead of postgres

### DIFF
--- a/pgtype/text_test.go
+++ b/pgtype/text_test.go
@@ -83,16 +83,18 @@ func TestTextCodecBPChar(t *testing.T) {
 // ACLItem is used for PostgreSQL's aclitem data type. A sample aclitem
 // might look like this:
 //
-//	postgres=arwdDxt/postgres
+//	pg_database_owner=arwdDxt/pg_database_owner
 //
 // Note, however, that because the user/role name part of an aclitem is
 // an identifier, it follows all the usual formatting rules for SQL
 // identifiers: if it contains spaces and other special characters,
 // it should appear in double-quotes:
 //
-//	postgres=arwdDxt/"role with spaces"
+//	pg_database_owner=arwdDxt/"role with spaces"
 //
 // It only supports the text format.
+//
+// Use the pg_database_owner in the test since it is a predefined role.
 func TestTextCodecACLItem(t *testing.T) {
 	ctr := defaultConnTestRunner
 	ctr.AfterConnect = func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
@@ -101,9 +103,9 @@ func TestTextCodecACLItem(t *testing.T) {
 
 	pgxtest.RunValueRoundTripTests(context.Background(), t, ctr, nil, "aclitem", []pgxtest.ValueRoundTripTest{
 		{
-			pgtype.Text{String: "postgres=arwdDxt/postgres", Valid: true},
+			pgtype.Text{String: "pg_database_owner=arwdDxt/pg_database_owner", Valid: true},
 			new(pgtype.Text),
-			isExpectedEq(pgtype.Text{String: "postgres=arwdDxt/postgres", Valid: true}),
+			isExpectedEq(pgtype.Text{String: "pg_database_owner=arwdDxt/pg_database_owner", Valid: true}),
 		},
 		{pgtype.Text{}, new(pgtype.Text), isExpectedEq(pgtype.Text{})},
 		{nil, new(pgtype.Text), isExpectedEq(pgtype.Text{})},


### PR DESCRIPTION
The role "postgres" is not guaranteed to exist. When creating a new database with initdb, the default is the current user's name. Most Linux distributions and many "production" Postgres installs will use the name "postgres", but it is not the default. The "pg_database_owner" role on the other hand is predefined and is guaranteed to exist:
https://www.postgresql.org/docs/current/predefined-roles.html

This should make the tests easier to run for some users (like me!)

See initdb documentation for the --username flag for details: https://www.postgresql.org/docs/current/app-initdb.html