### PR TITLE
pgtype: Change hstore tests to execute "create extension hstore"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,6 @@ Create and setup a test database:
 ```
 export PGDATABASE=pgx_test
 createdb
-psql -c 'create extension hstore;'
 psql -c 'create domain uint64 as numeric(20,0);'
 ```
 

--- a/testsetup/postgresql_setup.sql
+++ b/testsetup/postgresql_setup.sql
@@ -1,5 +1,4 @@
 -- Create extensions and types.
-create extension hstore;
 create domain uint64 as numeric(20,0);
 
 -- Create users for different types of connections and authentication.


### PR DESCRIPTION
The hstore extension can be loaded by any user with "create" priviledges. The test already queries for the hstore OID, so we might as well load the extension if it does not exist. This removes some required setup for running the tests, so should make it a bit easier for others to run them.