### PR TITLE
ParseConfig: default_query_exec_mode: Return arg in error

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -178,7 +178,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 		case "simple_protocol":
 			defaultQueryExecMode = QueryExecModeSimpleProtocol
 		default:
-			return nil, fmt.Errorf("invalid default_query_exec_mode: %v", err)
+			return nil, fmt.Errorf("invalid default_query_exec_mode: %s", s)
 		}
 	}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -197,6 +197,21 @@ func TestParseConfigExtractsDefaultQueryExecMode(t *testing.T) {
 	}
 }
 
+func TestParseConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		connString           string
+		expectedErrSubstring string
+	}{
+		{"default_query_exec_mode=does_not_exist", "does_not_exist"},
+	} {
+		config, err := pgx.ParseConfig(tt.connString)
+		require.Nil(t, config)
+		require.ErrorContains(t, err, tt.expectedErrSubstring)
+	}
+}
+
 func TestExec(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
If the default_query_exec_mode is unknown, the returned error previously was:

    invalid default_query_exec_mode: <nil>

This changes it to return the argument. Add a test that unknown modes fail to parse and include this string.