### PR TITLE
pgtype/hstore: Avoid Postgres Mac OS X parsing bug

### DIFF
--- a/pgtype/hstore.go
+++ b/pgtype/hstore.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -137,13 +136,20 @@ func (encodePlanHstoreCodecText) Encode(value any, buf []byte) (newBuf []byte, e
 			buf = append(buf, ',')
 		}
 
-		buf = append(buf, quoteHstoreElementIfNeeded(k)...)
+		// unconditionally quote hstore keys/values like Postgres does
+		// this avoids a Mac OS X Postgres hstore parsing bug:
+		// https://www.postgresql.org/message-id/CA%2BHWA9awUW0%2BRV_gO9r1ABZwGoZxPztcJxPy8vMFSTbTfi4jig%40mail.gmail.com
+		buf = append(buf, '"')
+		buf = append(buf, quoteArrayReplacer.Replace(k)...)
+		buf = append(buf, '"')
 		buf = append(buf, "=>"...)
 
 		if v == nil {
 			buf = append(buf, "NULL"...)
 		} else {
-			buf = append(buf, quoteHstoreElementIfNeeded(*v)...)
+			buf = append(buf, '"')
+			buf = append(buf, quoteArrayReplacer.Replace(*v)...)
+			buf = append(buf, '"')
 		}
 	}
 
@@ -269,19 +275,6 @@ func (c HstoreCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (
 		return nil, err
 	}
 	return hstore, nil
-}
-
-func quoteHstoreElementIfNeeded(src string) string {
-	// Double-quote keys and values that include whitespace, commas, =s or >s. To include a double
-	// quote or a backslash in a key or value, escape it with a backslash.
-	// From: https://www.postgresql.org/docs/current/hstore.html
-	// whitespace appears to be defined as the isspace() C function: \t\n\v\f\r\n and space
-	const quoteRequiredChars = `,"\=> ` + "\t\n\v\f\r"
-	if src == "" || (len(src) == 4 && strings.ToLower(src) == "null") || strings.ContainsAny(src, quoteRequiredChars) {
-		return quoteArrayElement(src)
-	}
-
-	return src
 }
 
 const (


### PR DESCRIPTION
Postgres on Mac OS X has a bug in how it parses hstore text values that causes it to misinterpret some Unicode values as spaces. This causes values sent by pgx to be misinterpreted. To avoid this, always quote hstore values, which is how Postgres serializes them itself. The test change fails on Mac OS X without this fix.

While I suspect this should not be performance critical for any application, I added a quick benchmark to test the performance of the encoding. This change actually makes encoding slightly faster on my M1 Pro. The output from the benchstat program on this banchmark is:

```
goos: darwin
goarch: arm64
pkg: github.com/jackc/pgx/v5/pgtype
                          │   orig.txt   │           new-quotes.txt            │
                          │    sec/op    │   sec/op     vs base                │
HstoreSerialize/text-10      207.1n ± 0%   142.3n ± 1%  -31.31% (p=0.000 n=10)
HstoreSerialize/binary-10   100.10n ± 0%   99.64n ± 1%   -0.45% (p=0.013 n=10)
```

I have also attempted to fix the Postgres bug, but it will take a long time for this fix to get upstream:

https://www.postgresql.org/message-id/CA%2BHWA9awUW0%2BRV_gO9r1ABZwGoZxPztcJxPy8vMFSTbTfi4jig%40mail.gmail.com