### PR TITLE
TestConnectWithFallback: increase timeout

### DIFF
--- a/copy_from_test.go
+++ b/copy_from_test.go
@@ -17,8 +17,6 @@ import (
 func TestConnCopyWithAllQueryExecModes(t *testing.T) {
 	for _, mode := range pgxtest.AllQueryExecModes {
 		t.Run(mode.String(), func(t *testing.T) {
-			t.Parallel()
-
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
@@ -81,8 +79,6 @@ func TestConnCopyWithKnownOIDQueryExecModes(t *testing.T) {
 
 	for _, mode := range pgxtest.KnownOIDQueryExecModes {
 		t.Run(mode.String(), func(t *testing.T) {
-			t.Parallel()
-
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -496,7 +496,7 @@ func TestConnectWithRuntimeParams(t *testing.T) {
 func TestConnectWithFallback(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	config, err := pgconn.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))

--- a/query_test.go
+++ b/query_test.go
@@ -1784,7 +1784,7 @@ func TestConnSimpleProtocol(t *testing.T) {
 	{
 		if conn.PgConn().ParameterStatus("crdb_version") == "" {
 			// CockroachDB doesn't support circle type.
-			expected := pgtype.Circle{P: pgtype.Vec2{1, 2}, R: 1.5, Valid: true}
+			expected := pgtype.Circle{P: pgtype.Vec2{X: 1, Y: 2}, R: 1.5, Valid: true}
 			actual := expected
 			err := conn.QueryRow(
 				context.Background(),


### PR DESCRIPTION
on Windows connecting on a closed port takes about 2 seconds. You can test with something like this

```
package main

import (
	"context"
	"fmt"
	"net"
	"time"
)

func main() {
	d := &net.Dialer{KeepAlive: 5 * time.Minute}
	start := time.Now()
	_, err := d.DialContext(context.Background(), "tcp", "127.0.0.1:1")
	fmt.Printf("finished, time %s, err: %v\n", time.Since(start), err)
}
```

This seems by design

https://groups.google.com/g/comp.os.ms-windows.programmer.win32/c/jV6kRVY3BqM

Generally `TestConnectWithFallback` takes about 8-9 seconds on Windows. Increase timeout to avoid random failures under load