### PR TITLE
pgtype array: Fix encoding of vtab \v

### DIFF
--- a/pgtype/array.go
+++ b/pgtype/array.go
@@ -363,12 +363,13 @@ func quoteArrayElement(src string) string {
 }
 
 func isSpace(ch byte) bool {
-	// see https://github.com/postgres/postgres/blob/REL_12_STABLE/src/backend/parser/scansup.c#L224
-	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f'
+	// see array_isspace:
+	// https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/arrayfuncs.c
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\v' || ch == '\f'
 }
 
 func quoteArrayElementIfNeeded(src string) string {
-	if src == "" || (len(src) == 4 && strings.ToLower(src) == "null") || isSpace(src[0]) || isSpace(src[len(src)-1]) || strings.ContainsAny(src, `{},"\`) {
+	if src == "" || (len(src) == 4 && strings.EqualFold(src, "null")) || isSpace(src[0]) || isSpace(src[len(src)-1]) || strings.ContainsAny(src, `{},"\`) {
 		return quoteArrayElement(src)
 	}
 	return src


### PR DESCRIPTION
Arrays with values that start or end with vtab ("\v") must be quoted. Postgres's array parser skips leading and trailing whitespace with the array_isspace() function, which is slightly different from the scanner_isspace() function that was previously linked. Add a test that reproduces this failure, and fix the definition of isSpace.

This also includes a change to use strings.EqualFold which should really not matter, but does not require copying the string.