### PR TITLE
 Enable failover efforts when pg_hba.conf disallows non-ssl connections

### DIFF
--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -174,7 +174,7 @@ func ConnectConfig(octx context.Context, config *Config) (pgConn *PgConn, err er
 			const ERRCODE_INVALID_CATALOG_NAME = "3D000"                // db does not exist
 			const ERRCODE_INSUFFICIENT_PRIVILEGE = "42501"              // missing connect privilege
 			if pgerr.Code == ERRCODE_INVALID_PASSWORD ||
-				pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION ||
+				pgerr.Code == ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION && fc.TLSConfig != nil ||
 				pgerr.Code == ERRCODE_INVALID_CATALOG_NAME ||
 				pgerr.Code == ERRCODE_INSUFFICIENT_PRIVILEGE {
 				break


### PR DESCRIPTION
Copy of https://github.com/jackc/pgconn/pull/133

This will more closely mirror libpq because the automatically added fallback configs for non-tls will not cause failures in subsequent fallbacks. 