### PR TITLE
README: Add kataras/pgx-golog to 3rd-party loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ These adapters can be used with the tracelog package.
 * [github.com/jackc/pgx-zap](https://github.com/jackc/pgx-zap)
 * [github.com/jackc/pgx-zerolog](https://github.com/jackc/pgx-zerolog)
 * [github.com/mcosta74/pgx-slog](https://github.com/mcosta74/pgx-slog)
+* [github.com/kataras/pgx-golog](https://github.com/kataras/pgx-golog)
 
 ## 3rd Party Libraries with PGX Support
 


### PR DESCRIPTION
As titled. Thanks @jackc 