### PR TITLE
Use bytes.Equal rather than bytes.Compare ==/!= 0

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -151,7 +151,7 @@ func BenchmarkMinimalPgConnPreparedSelect(b *testing.B) {
 
 		for rr.NextRow() {
 			for i := range rr.Values() {
-				if bytes.Compare(rr.Values()[0], encodedBytes) != 0 {
+				if !bytes.Equal(rr.Values()[0], encodedBytes) {
 					b.Fatalf("unexpected values: %s %s", rr.Values()[i], encodedBytes)
 				}
 			}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1242,7 +1242,7 @@ func TestRawValuesUnderlyingMemoryReused(t *testing.T) {
 			rows.Close()
 			require.NoError(t, rows.Err())
 
-			if bytes.Compare(original, buf) != 0 {
+			if !bytes.Equal(original, buf) {
 				return
 			}
 		}

--- a/pgproto3/chunkreader_test.go
+++ b/pgproto3/chunkreader_test.go
@@ -17,7 +17,7 @@ func TestChunkReaderNextDoesNotReadIfAlreadyBuffered(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(n1, src[0:2]) != 0 {
+	if !bytes.Equal(n1, src[0:2]) {
 		t.Fatalf("Expected read bytes to be %v, but they were %v", src[0:2], n1)
 	}
 
@@ -25,11 +25,11 @@ func TestChunkReaderNextDoesNotReadIfAlreadyBuffered(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(n2, src[2:4]) != 0 {
+	if !bytes.Equal(n2, src[2:4]) {
 		t.Fatalf("Expected read bytes to be %v, but they were %v", src[2:4], n2)
 	}
 
-	if bytes.Compare((*r.buf)[:len(src)], src) != 0 {
+	if !bytes.Equal((*r.buf)[:len(src)], src) {
 		t.Fatalf("Expected r.buf to be %v, but it was %v", src, r.buf)
 	}
 

--- a/pgtype/bits_test.go
+++ b/pgtype/bits_test.go
@@ -13,7 +13,7 @@ func isExpectedEqBits(a any) func(any) bool {
 	return func(v any) bool {
 		ab := a.(pgtype.Bits)
 		vb := v.(pgtype.Bits)
-		return bytes.Compare(ab.Bytes, vb.Bytes) == 0 && ab.Len == vb.Len && ab.Valid == vb.Valid
+		return bytes.Equal(ab.Bytes, vb.Bytes) && ab.Len == vb.Len && ab.Valid == vb.Valid
 	}
 }
 

--- a/pgtype/bytea_test.go
+++ b/pgtype/bytea_test.go
@@ -25,7 +25,7 @@ func isExpectedEqBytes(a any) func(any) bool {
 			return true
 		}
 
-		return bytes.Compare(ab, vb) == 0
+		return bytes.Equal(ab, vb)
 	}
 }
 
@@ -64,7 +64,7 @@ func TestDriverBytes(t *testing.T) {
 			rowCount++
 
 			// At some point the buffer should be reused and change.
-			if bytes.Compare(argBuf, resultBuf) != 0 {
+			if !bytes.Equal(argBuf, resultBuf) {
 				detectedResultMutation = true
 			}
 

--- a/pgtype/macaddr_test.go
+++ b/pgtype/macaddr_test.go
@@ -22,7 +22,7 @@ func isExpectedEqHardwareAddr(a any) func(any) bool {
 			return true
 		}
 
-		return bytes.Compare(aa, vv) == 0
+		return bytes.Equal(aa, vv)
 	}
 }
 

--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -241,11 +241,11 @@ func (n Numeric) MarshalJSON() ([]byte, error) {
 }
 
 func (n *Numeric) UnmarshalJSON(src []byte) error {
-	if bytes.Compare(src, []byte(`null`)) == 0 {
+	if bytes.Equal(src, []byte(`null`)) {
 		*n = Numeric{}
 		return nil
 	}
-	if bytes.Compare(src, []byte(`"NaN"`)) == 0 {
+	if bytes.Equal(src, []byte(`"NaN"`)) {
 		*n = Numeric{NaN: true, Valid: true}
 		return nil
 	}

--- a/pgtype/point.go
+++ b/pgtype/point.go
@@ -40,7 +40,7 @@ func (p Point) PointValue() (Point, error) {
 }
 
 func parsePoint(src []byte) (*Point, error) {
-	if src == nil || bytes.Compare(src, []byte("null")) == 0 {
+	if src == nil || bytes.Equal(src, []byte("null")) {
 		return &Point{}, nil
 	}
 

--- a/pgtype/range_test.go
+++ b/pgtype/range_test.go
@@ -166,11 +166,11 @@ func TestParseUntypedBinaryRange(t *testing.T) {
 			t.Errorf("%d. `%v`: expected result upper type %v, got %v", i, tt.src, string(tt.result.UpperType), string(r.UpperType))
 		}
 
-		if bytes.Compare(r.Lower, tt.result.Lower) != 0 {
+		if !bytes.Equal(r.Lower, tt.result.Lower) {
 			t.Errorf("%d. `%v`: expected result lower %v, got %v", i, tt.src, tt.result.Lower, r.Lower)
 		}
 
-		if bytes.Compare(r.Upper, tt.result.Upper) != 0 {
+		if !bytes.Equal(r.Upper, tt.result.Upper) {
 			t.Errorf("%d. `%v`: expected result upper %v, got %v", i, tt.src, tt.result.Upper, r.Upper)
 		}
 	}

--- a/pgtype/uuid.go
+++ b/pgtype/uuid.go
@@ -97,7 +97,7 @@ func (src UUID) MarshalJSON() ([]byte, error) {
 }
 
 func (dst *UUID) UnmarshalJSON(src []byte) error {
-	if bytes.Compare(src, []byte("null")) == 0 {
+	if bytes.Equal(src, []byte("null")) {
 		*dst = UUID{}
 		return nil
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -1518,7 +1518,7 @@ func TestConnSimpleProtocol(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if bytes.Compare(actual, expected) != 0 {
+		if !bytes.Equal(actual, expected) {
 			t.Errorf("expected %v got %v", expected, actual)
 		}
 	}
@@ -1825,7 +1825,7 @@ func TestConnSimpleProtocol(t *testing.T) {
 		if expectedBool != actualBool {
 			t.Errorf("expected %v got %v", expectedBool, actualBool)
 		}
-		if bytes.Compare(expectedBytes, actualBytes) != 0 {
+		if !bytes.Equal(expectedBytes, actualBytes) {
 			t.Errorf("expected %v got %v", expectedBytes, actualBytes)
 		}
 		if expectedString != actualString {

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -547,7 +547,7 @@ func TestConnQueryJSONIntoByteSlice(t *testing.T) {
 			t.Errorf("Unexpected failure: %v (sql -> %v)", err, sql)
 		}
 
-		if bytes.Compare(actual, expected) != 0 {
+		if !bytes.Equal(actual, expected) {
 			t.Errorf(`Expected "%v", got "%v" (sql -> %v)`, string(expected), string(actual), sql)
 		}
 
@@ -579,7 +579,7 @@ func TestConnExecInsertByteSliceIntoJSON(t *testing.T) {
 	err = db.QueryRow(`select body from docs`).Scan(&actual)
 	require.NoError(t, err)
 
-	if bytes.Compare(actual, expected) != 0 {
+	if !bytes.Equal(actual, expected) {
 		t.Errorf(`Expected "%v", got "%v"`, string(expected), string(actual))
 	}
 


### PR DESCRIPTION
This is a no-op change that I noticed when poking around the codebase to see how something else worked.

This change is recommended by go-staticcheck, but also might be a bit more efficient for the compiler to implement, since we don't care about which slice of bytes is greater than the other one.

https://www.sobyte.net/post/2022-01/go-bytes-compare-equal/