### PR TITLE
Add PgConn.SyncConn

### DIFF
--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -1732,6 +1732,7 @@ func (pgConn *PgConn) exitPotentialWriteReadDeadlock() {
 	// The state of the timer is not relevant upon exiting the potential slow write. It may both
 	// fire (due to a slow write), or not fire (due to a fast write).
 	_ = pgConn.slowWriteTimer.Stop()
+	pgConn.bgReader.Stop()
 }
 
 func (pgConn *PgConn) flushWithPotentialWriteReadDeadlock() error {

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -2319,6 +2319,9 @@ func TestHijackAndConstruct(t *testing.T) {
 	origConn, err := pgconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
 	require.NoError(t, err)
 
+	err = origConn.SyncConn(ctx)
+	require.NoError(t, err)
+
 	hc, err := origConn.Hijack()
 	require.NoError(t, err)
 

--- a/pgproto3/frontend.go
+++ b/pgproto3/frontend.go
@@ -361,3 +361,7 @@ func (f *Frontend) findAuthenticationMessageType(src []byte) (BackendMessage, er
 func (f *Frontend) GetAuthType() uint32 {
 	return f.authType
 }
+
+func (f *Frontend) ReadBufferLen() int {
+	return f.cr.wp - f.cr.rp
+}


### PR DESCRIPTION
This provides a way to ensure it is safe to directly read or write to the underlying net.Conn.

https://github.com/jackc/pgx/issues/1673

---

Unfortunately, I'm not sure of a good way to test this as I don't know of a sure way to cause the conditions that `SyncConn` removes.