### PR TITLE
Fixes #1684 QCharArrayOID being defined with the wrong OID

### DIFF
--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -44,7 +44,7 @@ const (
 	MacaddrOID             = 829
 	InetOID                = 869
 	BoolArrayOID           = 1000
-	QCharArrayOID          = 1003
+	QCharArrayOID          = 1002
 	NameArrayOID           = 1003
 	Int2ArrayOID           = 1005
 	Int4ArrayOID           = 1007


### PR DESCRIPTION
The currently defined OID for QCharArrayOID is 1003 (NameArrayOID) instead of 1002. Seems like a typo.