### PR TITLE
allow replace xid datatypes

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -742,7 +742,7 @@ func (r *Rows) Next(dest []driver.Value) error {
 					return d.Value()
 				}
 			case pgtype.XIDOID:
-				// there we get 32-xid or 64-xid
+				// here we get 32-xid or 64-xid datatype
 				d, _ := ci.DataTypeForOID(pgtype.XIDOID)
 				scanPlan := ci.PlanScan(dataTypeOID, format, &d)
 				r.valueFuncs[i] = func(src []byte) (driver.Value, error) {


### PR DESCRIPTION
PR from https://github.com/jackc/pgtype/issues/209

By default, we get a 32-bit XID with the data `type XID pguint32`. If we replace `pgtype.XIDOID`, we can use a custom data type instead.