### PR TITLE
use a non-cryptographic hash to generate unique statement names

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2,10 +2,9 @@ package pgx
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"strconv"
 	"strings"
 	"time"
@@ -318,8 +317,9 @@ func (c *Conn) Prepare(ctx context.Context, name, sql string) (sd *pgconn.Statem
 
 	var psName, psKey string
 	if name == sql {
-		digest := sha256.Sum256([]byte(sql))
-		psName = "stmt_" + hex.EncodeToString(digest[0:24])
+		h := fnv.New64a()
+		h.Write([]byte(sql))
+		psName = "stmt_" + strconv.FormatUint(h.Sum64(), 10)
 		psKey = sql
 	} else {
 		psName = name

--- a/conn_test.go
+++ b/conn_test.go
@@ -536,7 +536,7 @@ func TestPrepareWithDigestedName(t *testing.T) {
 		sql := "select $1::text"
 		sd, err := conn.Prepare(ctx, sql, sql)
 		require.NoError(t, err)
-		require.Equal(t, "stmt_2510cc7db17de3f42758a2a29c8b9ef8305d007b997ebdd6", sd.Name)
+		require.Equal(t, "stmt_12917919191120275379", sd.Name)
 
 		var s string
 		err = conn.QueryRow(ctx, sql, "hello").Scan(&s)

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/puddle/v2 v2.2.0 h1:RdcDk92EJBuBS55nQMMYFXTxwstHug4jkhT5pq8VxPk=
-github.com/jackc/puddle/v2 v2.2.0/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/stmtcache/stmtcache.go
+++ b/internal/stmtcache/stmtcache.go
@@ -2,8 +2,8 @@
 package stmtcache
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
+	"hash/fnv"
+	"strconv"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -11,8 +11,9 @@ import (
 // StatementName returns a statement name that will be stable for sql across multiple connections and program
 // executions.
 func StatementName(sql string) string {
-	digest := sha256.Sum256([]byte(sql))
-	return "stmtcache_" + hex.EncodeToString(digest[0:24])
+	h := fnv.New64a()
+	h.Write([]byte(sql))
+	return "stmtcache_" + strconv.FormatUint(h.Sum64(), 10)
 }
 
 // Cache caches statement descriptions.


### PR DESCRIPTION
you can benchmark like this

```
func hashSha256(sql string) string {
	digest := sha256.Sum256([]byte(sql))
	return "stmtcache_" + hex.EncodeToString(digest[0:24])
}

func hashFNV1(sql string) string {
	h := fnv.New64a()
	h.Write([]byte(sql))
	return "stmtcache_" + strconv.FormatUint(h.Sum64(), 10)
}

func hashXXHash(sql string) string {
	h := xxhash.New()
	h.Write([]byte(sql))
	return "stmtcache_" + strconv.FormatUint(h.Sum64(), 10)
}

func BenchmarkSha256(b *testing.B) {
	sql := `SELECT u.id,u.username,u.password,u.public_keys,u.home_dir,u.uid,u.gid,u.max_sessions,u.quota_size,u.quota_files,u.permissions,u.used_quota_size,u.used_quota_files,u.last_quota_update,u.upload_bandwidth,u.download_bandwidth,u.expiration_date,u.last_login,u.status,u.filters,u.filesystem,u.additional_info,u.description,u.email,u.created_at,u.updated_at,u.upload_data_transfer,u.download_data_transfer,u.total_data_transfer,u.used_upload_data_transfer,u.used_download_data_transfer,u.deleted_at,u.first_download,u.first_upload,r.name,u.last_password_change FROM users u LEFT JOIN roles r on r.id = u.role_id WHERE u.deleted_at = 0 ORDER BY u.username ASC LIMIT $1 OFFSET $2`
	for i := 0; i < b.N; i++ {
		hashSha256(sql)
	}
}

func BenchmarkFNV1(b *testing.B) {
	sql := `SELECT u.id,u.username,u.password,u.public_keys,u.home_dir,u.uid,u.gid,u.max_sessions,u.quota_size,u.quota_files,u.permissions,u.used_quota_size,u.used_quota_files,u.last_quota_update,u.upload_bandwidth,u.download_bandwidth,u.expiration_date,u.last_login,u.status,u.filters,u.filesystem,u.additional_info,u.description,u.email,u.created_at,u.updated_at,u.upload_data_transfer,u.download_data_transfer,u.total_data_transfer,u.used_upload_data_transfer,u.used_download_data_transfer,u.deleted_at,u.first_download,u.first_upload,r.name,u.last_password_change FROM users u LEFT JOIN roles r on r.id = u.role_id WHERE u.deleted_at = 0 ORDER BY u.username ASC LIMIT $1 OFFSET $2`
	for i := 0; i < b.N; i++ {
		hashFNV1(sql)
	}
}

func BenchmarkXXhash(b *testing.B) {
	sql := `SELECT u.id,u.username,u.password,u.public_keys,u.home_dir,u.uid,u.gid,u.max_sessions,u.quota_size,u.quota_files,u.permissions,u.used_quota_size,u.used_quota_files,u.last_quota_update,u.upload_bandwidth,u.download_bandwidth,u.expiration_date,u.last_login,u.status,u.filters,u.filesystem,u.additional_info,u.description,u.email,u.created_at,u.updated_at,u.upload_data_transfer,u.download_data_transfer,u.total_data_transfer,u.used_upload_data_transfer,u.used_download_data_transfer,u.deleted_at,u.first_download,u.first_upload,r.name,u.last_password_change FROM users u LEFT JOIN roles r on r.id = u.role_id WHERE u.deleted_at = 0 ORDER BY u.username ASC LIMIT $1 OFFSET $2`
	for i := 0; i < b.N; i++ {
		hashXXHash(sql)
	}
}
```

xxhash is faster but requires an external dependency. FNV-1 should be enough.

Results on my laptop:

```
BenchmarkFNV1-12    	  807478	      1304 ns/op	     760 B/op	       3 allocs/op
```

```
BenchmarkSha256-12    	  365073	      2831 ns/op	     864 B/op	       4 allocs/op
```

This is just a suggestion, even sha256 should be ok for general use. Thank you