### PR TITLE
Expose context to notice and notification handlers

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -250,8 +250,8 @@ func connect(ctx context.Context, config *ConnConfig) (c *Conn, err error) {
 	}
 
 	// Only install pgx notification system if no other callback handler is present.
-	if config.Config.OnNotification == nil {
-		config.Config.OnNotification = c.bufferNotifications
+	if config.Config.OnNotificationCtx == nil {
+		config.Config.OnNotificationCtx = c.bufferNotifications
 	}
 
 	c.pgConn, err = pgconn.ConnectConfig(ctx, &config.Config)
@@ -364,7 +364,7 @@ func (c *Conn) DeallocateAll(ctx context.Context) error {
 	return err
 }
 
-func (c *Conn) bufferNotifications(_ *pgconn.PgConn, n *pgconn.Notification) {
+func (c *Conn) bufferNotifications(_ context.Context, _ *pgconn.PgConn, n *pgconn.Notification) {
 	c.notifications = append(c.notifications, n)
 }
 

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -55,10 +55,16 @@ type Config struct {
 	AfterConnect AfterConnectFunc
 
 	// OnNotice is a callback function called when a notice response is received.
+	// Deprecated: use OnNoticeCtx instead
 	OnNotice NoticeHandler
 
+	OnNoticeCtx NoticeHandlerCtx
+
 	// OnNotification is a callback function called when a notification from the LISTEN/NOTIFY system is received.
+	// Deprecated: use OnNotificationCtx instead
 	OnNotification NotificationHandler
+
+	OnNotificationCtx NotificationHandlerCtx
 
 	createdByParseConfig bool // Used to enforce created by ParseConfig rule.
 }

--- a/pgconn/krb5.go
+++ b/pgconn/krb5.go
@@ -1,6 +1,7 @@
 package pgconn
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -33,7 +34,7 @@ type GSS interface {
 	Continue(inToken []byte) (done bool, outToken []byte, err error)
 }
 
-func (c *PgConn) gssAuth() error {
+func (c *PgConn) gssAuth(ctx context.Context) error {
 	if newGSS == nil {
 		return errors.New("kerberos error: no GSSAPI provider registered, see https://github.com/otan/gopgkrb5")
 	}
@@ -67,7 +68,7 @@ func (c *PgConn) gssAuth() error {
 		if err != nil {
 			return err
 		}
-		resp, err := c.rxGSSContinue()
+		resp, err := c.rxGSSContinue(ctx)
 		if err != nil {
 			return err
 		}
@@ -83,8 +84,8 @@ func (c *PgConn) gssAuth() error {
 	return nil
 }
 
-func (c *PgConn) rxGSSContinue() (*pgproto3.AuthenticationGSSContinue, error) {
-	msg, err := c.receiveMessage()
+func (c *PgConn) rxGSSContinue(ctx context.Context) (*pgproto3.AuthenticationGSSContinue, error) {
+	msg, err := c.receiveMessage(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -1505,7 +1505,7 @@ func TestConnOnNotification(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg string
-	config.OnNotification = func(c *pgconn.PgConn, n *pgconn.Notification) {
+	config.OnNotificationCtx = func(ctx context.Context, c *pgconn.PgConn, n *pgconn.Notification) {
 		msg = n.Payload
 	}
 
@@ -1544,7 +1544,7 @@ func TestConnWaitForNotification(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg string
-	config.OnNotification = func(c *pgconn.PgConn, n *pgconn.Notification) {
+	config.OnNotificationCtx = func(ctx context.Context, p *pgconn.PgConn, n *pgconn.Notification) {
 		msg = n.Payload
 	}
 


### PR DESCRIPTION
Add new handler types for notices and notifications. These are equivalent to the existing types, but receive a context as the first parameter. This allows for notices and notifications to use values typically stored in contexts, such as logging/tracing metadata.

The existing behavior is kept for backwards compatability, but the `OnNotice` and `OnNotifiation` fields of `pgconn.Config` are deprecated. 

--- 

What do you think of this @jackc? There are parts missing here: documentation and tests. If you think this is a good idea, I'll add those. 