### PR TITLE
Add Scan to pgtype.FlatArray

### DIFF
--- a/pgtype/array.go
+++ b/pgtype/array.go
@@ -458,3 +458,8 @@ func (a FlatArray[T]) ScanIndex(i int) any {
 func (a FlatArray[T]) ScanIndexType() any {
 	return new(T)
 }
+
+func (a *FlatArray[T]) Scan(src any) error {
+	scanner := &sqlScannerWrapper{m: defaultMap, v: (*[]T)(a)}
+	return scanner.Scan(src)
+}


### PR DESCRIPTION
Make `pgtype.FlatArray` respectful to `sql.Scanner` interface which makes sense when the standard `sql` package in use.

See https://github.com/jackc/pgx/issues/1779

