### PR TITLE
clean preparedStatements cache after successful deallocate

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -340,15 +340,18 @@ func (c *Conn) Prepare(ctx context.Context, name, sql string) (sd *pgconn.Statem
 
 // Deallocate releases a prepared statement.
 func (c *Conn) Deallocate(ctx context.Context, name string) error {
-	var psName string
+	psName := name
 	if sd, ok := c.preparedStatements[name]; ok {
-		delete(c.preparedStatements, name)
 		psName = sd.Name
-	} else {
-		psName = name
 	}
+
 	_, err := c.pgConn.Exec(ctx, "deallocate "+quoteIdentifier(psName)).ReadAll()
-	return err
+	if err != nil {
+		return err
+	}
+
+	delete(c.preparedStatements, name)
+	return nil
 }
 
 // DeallocateAll releases all previously prepared statements from the server and client, where it also resets the statement and description cache.


### PR DESCRIPTION
When trying to close a prepared statement on an aborted transaction, it's possible to clear the local prepared statement cache without actually deallocating the prepared statement in Postgres. So when trying to prepare the same statement a second time, this error occurs:

> ERROR: prepared statement "stmt_xxx" already exists (SQLSTATE 42P05)

It's an issue we have in our tests but I wasn't able to isolate it as a runnable example (we use sqlx with the stdlib adapter, nested transactions, etc.) but the gist of it is:

- start a transaction
- prepare a statement `stmt_xxx`
- defer Close/Deallocate it
- abort the transaction (eg. `SELECT 1/0)`
- the deallocate fails in DB but clears the `preparedStatements` cache
	- `ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)`
- start a new transaction
- prepare the same statement `stmt_xxx`
	- `ERROR: prepared statement "stmt_xxx" already exists (SQLSTATE 42P05)`