### PR TITLE
Use PostgreSQL protocol for deallocating prepared statements

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -341,14 +341,23 @@ func (c *Conn) Prepare(ctx context.Context, name, sql string) (sd *pgconn.Statem
 // Deallocate releases a prepared statement.
 func (c *Conn) Deallocate(ctx context.Context, name string) error {
 	var psName string
-	if sd, ok := c.preparedStatements[name]; ok {
-		delete(c.preparedStatements, name)
+	sd := c.preparedStatements[name]
+	if sd != nil {
 		psName = sd.Name
 	} else {
 		psName = name
 	}
+
 	err := c.pgConn.Deallocate(ctx, psName)
-	return err
+	if err != nil {
+		return err
+	}
+
+	if sd != nil {
+		delete(c.preparedStatements, name)
+	}
+
+	return nil
 }
 
 // DeallocateAll releases all previously prepared statements from the server and client, where it also resets the statement and description cache.

--- a/conn.go
+++ b/conn.go
@@ -338,7 +338,7 @@ func (c *Conn) Prepare(ctx context.Context, name, sql string) (sd *pgconn.Statem
 	return sd, nil
 }
 
-// Deallocate releases a prepared statement.
+// Deallocate releases a prepared statement. Calling Deallocate on a non-existent prepared statement will succeed.
 func (c *Conn) Deallocate(ctx context.Context, name string) error {
 	var psName string
 	sd := c.preparedStatements[name]

--- a/conn.go
+++ b/conn.go
@@ -347,7 +347,7 @@ func (c *Conn) Deallocate(ctx context.Context, name string) error {
 	} else {
 		psName = name
 	}
-	_, err := c.pgConn.Exec(ctx, "deallocate "+quoteIdentifier(psName)).ReadAll()
+	err := c.pgConn.Deallocate(ctx, psName)
 	return err
 }
 

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -875,7 +875,9 @@ readloop:
 // Deallocate deallocates a prepared statement.
 //
 // Deallocate does not send a DEALLOCATE statement to the server. It uses the PostgreSQL Close protocol message
-// directly. This has the implication that Deallocate can succeed in an aborted transaction.
+// directly. This has slightly different behavior than executing DEALLOCATE statement.
+//   - Deallocate can succeed in an aborted transaction.
+//   - Deallocating a non-existent prepared statement is not an error.
 func (pgConn *PgConn) Deallocate(ctx context.Context, name string) error {
 	if err := pgConn.lock(); err != nil {
 		return err

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -813,6 +813,9 @@ type StatementDescription struct {
 
 // Prepare creates a prepared statement. If the name is empty, the anonymous prepared statement will be used. This
 // allows Prepare to also to describe statements without creating a server-side prepared statement.
+//
+// Prepare does not send a PREPARE statement to the server. It uses the PostgreSQL Parse and Describe protocol messages
+// directly.
 func (pgConn *PgConn) Prepare(ctx context.Context, name, sql string, paramOIDs []uint32) (*StatementDescription, error) {
 	if err := pgConn.lock(); err != nil {
 		return nil, err

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -728,6 +728,22 @@ func TestConnDeallocateSucceedsInAbortedTransaction(t *testing.T) {
 	ensureConnValid(t, pgConn)
 }
 
+func TestConnDeallocateNonExistantStatementSucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgConn, err := pgconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	defer closeConn(t, pgConn)
+
+	err = pgConn.Deallocate(ctx, "ps1")
+	require.NoError(t, err)
+
+	ensureConnValid(t, pgConn)
+}
+
 func TestConnExec(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This allows Deallocate to succeed even inside of an aborted transaction.

It also only removes the connection's record of a prepared statement if the deallocation succeeds.

This should resolve the issue identified in #1795 and may also resolve #1791.