### PR TITLE
Fix usage of logger in stdlib docs

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -31,7 +31,7 @@
 // with sql.Open.
 //
 //	connConfig, _ := pgx.ParseConfig(os.Getenv("DATABASE_URL"))
-//	connConfig.Logger = myLogger
+//	connConfig.Tracer = &tracelog.TraceLog{Logger: myLogger, LogLevel: tracelog.LogLevelInfo}
 //	connStr := stdlib.RegisterConnConfig(connConfig)
 //	db, _ := sql.Open("pgx", connStr)
 //


### PR DESCRIPTION
The documentation previously showed the old way of logging and not the newer tracer adapter. This is a minor patch updates the example to build correctly with pgx/v5.