### PR TITLE
support scientific notation big floats

### DIFF
--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -762,7 +762,7 @@ func (scanPlanTextAnyToNumericScanner) Scan(src []byte, dst any) error {
 	if strings.ContainsAny(string(src), "eE") {
 		if bigF, ok := new(big.Float).SetString(string(src)); ok {
 			smallF, _ := bigF.Float64()
-			src = []byte(strconv.FormatFloat(smallF, 'f', -1, int(bigF.Prec())))
+			src = []byte(strconv.FormatFloat(smallF, 'f', -1, 64))
 		}
 	}
 

--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -762,7 +762,6 @@ func (scanPlanTextAnyToNumericScanner) Scan(src []byte, dst any) error {
 	if strings.ContainsAny(string(src), "eE") {
 		if bigF, ok := new(big.Float).SetString(string(src)); ok {
 			smallF, _ := bigF.Float64()
-
 			src = []byte(strconv.FormatFloat(smallF, 'f', -1, int(bigF.Prec())))
 		}
 	}

--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -759,6 +759,14 @@ func (scanPlanTextAnyToNumericScanner) Scan(src []byte, dst any) error {
 		return scanner.ScanNumeric(Numeric{InfinityModifier: NegativeInfinity, Valid: true})
 	}
 
+	if strings.ContainsAny(string(src), "eE") {
+		if bigF, ok := new(big.Float).SetString(string(src)); ok {
+			smallF, _ := bigF.Float64()
+
+			src = []byte(strconv.FormatFloat(smallF, 'f', -1, int(bigF.Prec())))
+		}
+	}
+
 	num, exp, err := parseNumericString(string(src))
 	if err != nil {
 		return err

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -241,46 +241,58 @@ func TestNumericUnmarshalJSON(t *testing.T) {
 		src     []byte
 		wantErr bool
 	}{
+		// {
+		// 	name:    "null",
+		// 	want:    &pgtype.Numeric{},
+		// 	src:     []byte(`null`),
+		// 	wantErr: false,
+		// },
+		// {
+		// 	name:    "NaN",
+		// 	want:    &pgtype.Numeric{Valid: true, NaN: true},
+		// 	src:     []byte(`"NaN"`),
+		// 	wantErr: false,
+		// },
+		// {
+		// 	name:    "0",
+		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(0)},
+		// 	src:     []byte("0"),
+		// 	wantErr: false,
+		// },
+		// {
+		// 	name:    "1",
+		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1)},
+		// 	src:     []byte("1"),
+		// 	wantErr: false,
+		// },
+		// {
+		// 	name:    "-1",
+		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(-1)},
+		// 	src:     []byte("-1"),
+		// 	wantErr: false,
+		// },
+		// {
+		// 	name:    "bigInt",
+		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1), Exp: 30},
+		// 	src:     []byte("1000000000000000000000000000000"),
+		// 	wantErr: false,
+		// },
+		// {
+		// 	name:    "float: 1234.56789",
+		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(123456789), Exp: -5},
+		// 	src:     []byte("1234.56789"),
+		// 	wantErr: false,
+		// },
 		{
-			name:    "null",
-			want:    &pgtype.Numeric{},
-			src:     []byte(`null`),
+			name:    "float: 1e10",
+			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1), Exp: 10},
+			src:     []byte("1e10"),
 			wantErr: false,
 		},
 		{
-			name:    "NaN",
-			want:    &pgtype.Numeric{Valid: true, NaN: true},
-			src:     []byte(`"NaN"`),
-			wantErr: false,
-		},
-		{
-			name:    "0",
-			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(0)},
-			src:     []byte("0"),
-			wantErr: false,
-		},
-		{
-			name:    "1",
-			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1)},
-			src:     []byte("1"),
-			wantErr: false,
-		},
-		{
-			name:    "-1",
-			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(-1)},
-			src:     []byte("-1"),
-			wantErr: false,
-		},
-		{
-			name:    "bigInt",
-			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1), Exp: 30},
-			src:     []byte("1000000000000000000000000000000"),
-			wantErr: false,
-		},
-		{
-			name:    "float: 1234.56789",
-			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(123456789), Exp: -5},
-			src:     []byte("1234.56789"),
+			name:    "float: 1.000101231014e10",
+			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1000101231014), Exp: -2},
+			src:     []byte("1.000101231014e10"),
 			wantErr: false,
 		},
 		{

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -284,18 +284,6 @@ func TestNumericUnmarshalJSON(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "float: 1e10",
-			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1), Exp: 10},
-			src:     []byte("1e10"),
-			wantErr: false,
-		},
-		{
-			name:    "float: 1.000101231014e10",
-			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1000101231014), Exp: -2},
-			src:     []byte("1.000101231014e10"),
-			wantErr: false,
-		},
-		{
 			name:    "invalid value",
 			want:    &pgtype.Numeric{},
 			src:     []byte("0xffff"),

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -241,48 +241,48 @@ func TestNumericUnmarshalJSON(t *testing.T) {
 		src     []byte
 		wantErr bool
 	}{
-		// {
-		// 	name:    "null",
-		// 	want:    &pgtype.Numeric{},
-		// 	src:     []byte(`null`),
-		// 	wantErr: false,
-		// },
-		// {
-		// 	name:    "NaN",
-		// 	want:    &pgtype.Numeric{Valid: true, NaN: true},
-		// 	src:     []byte(`"NaN"`),
-		// 	wantErr: false,
-		// },
-		// {
-		// 	name:    "0",
-		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(0)},
-		// 	src:     []byte("0"),
-		// 	wantErr: false,
-		// },
-		// {
-		// 	name:    "1",
-		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1)},
-		// 	src:     []byte("1"),
-		// 	wantErr: false,
-		// },
-		// {
-		// 	name:    "-1",
-		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(-1)},
-		// 	src:     []byte("-1"),
-		// 	wantErr: false,
-		// },
-		// {
-		// 	name:    "bigInt",
-		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1), Exp: 30},
-		// 	src:     []byte("1000000000000000000000000000000"),
-		// 	wantErr: false,
-		// },
-		// {
-		// 	name:    "float: 1234.56789",
-		// 	want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(123456789), Exp: -5},
-		// 	src:     []byte("1234.56789"),
-		// 	wantErr: false,
-		// },
+		{
+			name:    "null",
+			want:    &pgtype.Numeric{},
+			src:     []byte(`null`),
+			wantErr: false,
+		},
+		{
+			name:    "NaN",
+			want:    &pgtype.Numeric{Valid: true, NaN: true},
+			src:     []byte(`"NaN"`),
+			wantErr: false,
+		},
+		{
+			name:    "0",
+			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(0)},
+			src:     []byte("0"),
+			wantErr: false,
+		},
+		{
+			name:    "1",
+			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1)},
+			src:     []byte("1"),
+			wantErr: false,
+		},
+		{
+			name:    "-1",
+			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(-1)},
+			src:     []byte("-1"),
+			wantErr: false,
+		},
+		{
+			name:    "bigInt",
+			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1), Exp: 30},
+			src:     []byte("1000000000000000000000000000000"),
+			wantErr: false,
+		},
+		{
+			name:    "float: 1234.56789",
+			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(123456789), Exp: -5},
+			src:     []byte("1234.56789"),
+			wantErr: false,
+		},
 		{
 			name:    "float: 1e10",
 			want:    &pgtype.Numeric{Valid: true, Int: big.NewInt(1), Exp: 10},


### PR DESCRIPTION
Adds some support following discovery of https://github.com/jackc/pgx/issues/1758 by
1. detecting scientific notation
2. scan into big/Float
3. replace original string with a true numeric string
4. ensure using minimal significant figures after the decimal