### PR TITLE
Batch.Queue: document always uses the conn's DefaultQueryExecMode

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -61,6 +61,8 @@ type Batch struct {
 }
 
 // Queue queues a query to batch b. query can be an SQL query or the name of a prepared statement.
+// The only pgx option argument that is supported is QueryRewriter. Queries are executed using the
+// connection's DefaultQueryExecMode.
 func (b *Batch) Queue(query string, arguments ...any) *QueuedQuery {
 	qq := &QueuedQuery{
 		query:     query,

--- a/conn.go
+++ b/conn.go
@@ -902,8 +902,6 @@ func (c *Conn) SendBatch(ctx context.Context, b *Batch) (br BatchResults) {
 		return &batchResults{ctx: ctx, conn: c, err: err}
 	}
 
-	mode := c.config.DefaultQueryExecMode
-
 	for _, bi := range b.queuedQueries {
 		var queryRewriter QueryRewriter
 		sql := bi.query
@@ -911,6 +909,7 @@ func (c *Conn) SendBatch(ctx context.Context, b *Batch) (br BatchResults) {
 
 	optionLoop:
 		for len(arguments) > 0 {
+			// Update Batch.Queue function comment when additional options are implemented
 			switch arg := arguments[0].(type) {
 			case QueryRewriter:
 				queryRewriter = arg
@@ -932,6 +931,8 @@ func (c *Conn) SendBatch(ctx context.Context, b *Batch) (br BatchResults) {
 		bi.arguments = arguments
 	}
 
+	// TODO: changing mode per batch? Update Batch.Queue function comment when implemented
+	mode := c.config.DefaultQueryExecMode
 	if mode == QueryExecModeSimpleProtocol {
 		return c.sendBatchQueryExecModeSimpleProtocol(ctx, b)
 	}


### PR DESCRIPTION
The only way to change the query mode used by Batch.Queue and SendBatch is to use a connection with a different
DefaultQueryExecMode. Add this to the function documentation.

Conn.SendBatch: Move where mode is defined to make this clearer in the code. I spent time looking for the option that does not exist.