### PR TITLE
pgconn: normalize more connection errors

### DIFF
--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -107,14 +107,15 @@ func (e *parseConfigError) Unwrap() error {
 }
 
 func normalizeTimeoutError(ctx context.Context, err error) error {
-	if err, ok := err.(net.Error); ok && err.Timeout() {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
 		if ctx.Err() == context.Canceled {
 			// Since the timeout was caused by a context cancellation, the actual error is context.Canceled not the timeout error.
 			return context.Canceled
 		} else if ctx.Err() == context.DeadlineExceeded {
 			return &errTimeout{err: ctx.Err()}
 		} else {
-			return &errTimeout{err: err}
+			return &errTimeout{err: netErr}
 		}
 	}
 	return err

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -289,7 +289,7 @@ func connect(ctx context.Context, config *Config, fallbackConfig *FallbackConfig
 		pgConn.contextWatcher.Unwatch() // Always unwatch `netConn` after TLS.
 		if err != nil {
 			netConn.Close()
-			return nil, &connectError{config: config, msg: "tls error", err: err}
+			return nil, &connectError{config: config, msg: "tls error", err: normalizeTimeoutError(ctx, err)}
 		}
 
 		pgConn.conn = nbTLSConn


### PR DESCRIPTION
Normalize the error that is returned by startTLS in pgconn.connect. This makes it possible to determine if the error was a context error. Before this change the returned error for a context that is canceled or hits the deadline would be `tls error (read tcp 127.0.0.1:55914->127.0.0.1:5432: i/o timeout)`.

This change also uses errors.As to unwrap errors in normalizeTimeoutError. This allows the function to handle the `writeError` type that shows up as `failed to write startup message (read tcp 127.0.0.1:55914->127.0.0.1:5432: i/o timeout)`.