### PR TITLE
Fix panic in Pipeline when PgConn is busy or closed

### DIFF
--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -2053,6 +2053,13 @@ func (p *Pipeline) Flush() error {
 
 // Sync establishes a synchronization point and flushes the queued requests.
 func (p *Pipeline) Sync() error {
+	if p.closed {
+		if p.err != nil {
+			return p.err
+		}
+		return errors.New("pipeline closed")
+	}
+
 	p.conn.frontend.SendSync(&pgproto3.Sync{})
 	err := p.Flush()
 	if err != nil {


### PR DESCRIPTION
Fixes #1827

In the current implementation, if a `Pipeline` is [created with an error](https://github.com/jackc/pgx/blob/v5.5.1/pgconn/pgconn.go#L1948-L1953) due to the connection being busy/closed, calling `Sync` on that `Pipeline` will result in a nil dereference panic. An example of where this behaviour can be seen is [here](https://github.com/jackc/pgx/blob/v5.5.1/conn.go#L1365-L1373).

This PR adds a check to the start of the `Sync` method to return an error if the `Pipeline` is "closed".