### PR TITLE
Fix possible typo in the OpenDBFromPool example

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -21,10 +21,7 @@
 //	  return err
 //	}
 //
-//	db, err := stdlib.OpenDBFromPool(pool)
-//	if err != nil {
-//	  return err
-//	}
+//	db := stdlib.OpenDBFromPool(pool)
 //
 // Or a pgx.ConnConfig can be used to set configuration not accessible via connection string. In this case the
 // pgx.ConnConfig must first be registered with the driver. This registration returns a connection string which is used


### PR DESCRIPTION
Hi there! I ran into a build error when trying out the stdlib compatibility package today:
```
assignment mismatch: 2 variables but stdlib.OpenDBFromPool returns 1 value
```

It looks like the example documentation assumes that `OpenDBFromPool` returns `(*sql.DB, error)`, but the implementation returns just a `*sql.DB`. This PR updates the example to use the single return value.