### PR TITLE
feat: fast encodeUUID

### DIFF
--- a/pgtype/uuid.go
+++ b/pgtype/uuid.go
@@ -52,7 +52,19 @@ func parseUUID(src string) (dst [16]byte, err error) {
 
 // encodeUUID converts a uuid byte array to UUID standard string form.
 func encodeUUID(src [16]byte) string {
-	return fmt.Sprintf("%x-%x-%x-%x-%x", src[0:4], src[4:6], src[6:8], src[8:10], src[10:16])
+	var buf [36]byte
+
+	hex.Encode(buf[0:8], src[:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], src[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], src[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], src[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:], src[10:])
+
+	return string(buf[:])
 }
 
 // Scan implements the database/sql Scanner interface.


### PR DESCRIPTION
Hello @jackc! 

The benchmark speaks for itself
```
goos: windows
goarch: amd64
pkg: test
cpu: 12th Gen Intel(R) Core(TM) i9-12900K
Benchmark_encodeUUID
Benchmark_encodeUUID-16                  1312166               900.1 ns/op
             736 B/op         28 allocs/op
Benchmark_fastEncodeUUID
Benchmark_fastEncodeUUID-16           10241485               109.3 ns/op
             192 B/op          4 allocs/op
PASS
```

This change has significantly reduced the number of allocations in my queries
```
goos: windows
goarch: amd64
pkg: test
cpu: 12th Gen Intel(R) Core(TM) i9-12900K
BenchmarkSelect_encodeUUID
BenchmarkSelect_encodeUUID-16          1455            993028 ns/op           95501 B/op
            2593 allocs/op
BenchmarkSelect_fastEncodeUUID
BenchmarkSelect_fastEncodeUUID-16          1486            820928 ns/op          112806 B/op
            1357 allocs/op
PASS
```