### PR TITLE
Add `AppendRows` helper

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -417,11 +417,9 @@ type CollectableRow interface {
 // RowToFunc is a function that scans or otherwise converts row to a T.
 type RowToFunc[T any] func(row CollectableRow) (T, error)
 
-// CollectRows iterates through rows, calling fn for each row, and collecting the results into a slice of T.
-func CollectRows[T any](rows Rows, fn RowToFunc[T]) ([]T, error) {
+// AppendRows iterates through rows, calling fn for each row, and appending the results into a slice of T.
+func AppendRows[T any, S ~[]T](slice S, rows Rows, fn RowToFunc[T]) (S, error) {
 	defer rows.Close()
-
-	slice := []T{}
 
 	for rows.Next() {
 		value, err := fn(rows)
@@ -436,6 +434,11 @@ func CollectRows[T any](rows Rows, fn RowToFunc[T]) ([]T, error) {
 	}
 
 	return slice, nil
+}
+
+// CollectRows iterates through rows, calling fn for each row, and collecting the results into a slice of T.
+func CollectRows[T any](rows Rows, fn RowToFunc[T]) ([]T, error) {
+	return AppendRows([]T(nil), rows, fn)
 }
 
 // CollectOneRow calls fn for the first row in rows and returns the result. If no rows are found returns an error where errors.Is(ErrNoRows) is true.


### PR DESCRIPTION
I found myself using `CollectRows` and appending the results immediately into a different slice, and I thought that a small tweak to the helper function to make it append to an existing slice would make it more useful in general.