### PR TITLE
make properties of QueuedQuery and Batch public, closes #1878

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -10,8 +10,8 @@ import (
 
 // QueuedQuery is a query that has been queued for execution via a Batch.
 type QueuedQuery struct {
-	query     string
-	arguments []any
+	SQL       string
+	Arguments []any
 	fn        batchItemFunc
 	sd        *pgconn.StatementDescription
 }
@@ -57,7 +57,7 @@ func (qq *QueuedQuery) Exec(fn func(ct pgconn.CommandTag) error) {
 // Batch queries are a way of bundling multiple queries together to avoid
 // unnecessary network round trips. A Batch must only be sent once.
 type Batch struct {
-	queuedQueries []*QueuedQuery
+	QueuedQueries []*QueuedQuery
 }
 
 // Queue queues a query to batch b. query can be an SQL query or the name of a prepared statement.
@@ -65,16 +65,16 @@ type Batch struct {
 // connection's DefaultQueryExecMode.
 func (b *Batch) Queue(query string, arguments ...any) *QueuedQuery {
 	qq := &QueuedQuery{
-		query:     query,
-		arguments: arguments,
+		SQL:       query,
+		Arguments: arguments,
 	}
-	b.queuedQueries = append(b.queuedQueries, qq)
+	b.QueuedQueries = append(b.QueuedQueries, qq)
 	return qq
 }
 
 // Len returns number of queries that have been queued so far.
 func (b *Batch) Len() int {
-	return len(b.queuedQueries)
+	return len(b.QueuedQueries)
 }
 
 type BatchResults interface {
@@ -227,9 +227,9 @@ func (br *batchResults) Close() error {
 	}
 
 	// Read and run fn for all remaining items
-	for br.err == nil && !br.closed && br.b != nil && br.qqIdx < len(br.b.queuedQueries) {
-		if br.b.queuedQueries[br.qqIdx].fn != nil {
-			err := br.b.queuedQueries[br.qqIdx].fn(br)
+	for br.err == nil && !br.closed && br.b != nil && br.qqIdx < len(br.b.QueuedQueries) {
+		if br.b.QueuedQueries[br.qqIdx].fn != nil {
+			err := br.b.QueuedQueries[br.qqIdx].fn(br)
 			if err != nil {
 				br.err = err
 			}
@@ -253,10 +253,10 @@ func (br *batchResults) earlyError() error {
 }
 
 func (br *batchResults) nextQueryAndArgs() (query string, args []any, ok bool) {
-	if br.b != nil && br.qqIdx < len(br.b.queuedQueries) {
-		bi := br.b.queuedQueries[br.qqIdx]
-		query = bi.query
-		args = bi.arguments
+	if br.b != nil && br.qqIdx < len(br.b.QueuedQueries) {
+		bi := br.b.QueuedQueries[br.qqIdx]
+		query = bi.SQL
+		args = bi.Arguments
 		ok = true
 		br.qqIdx++
 	}
@@ -396,9 +396,9 @@ func (br *pipelineBatchResults) Close() error {
 	}
 
 	// Read and run fn for all remaining items
-	for br.err == nil && !br.closed && br.b != nil && br.qqIdx < len(br.b.queuedQueries) {
-		if br.b.queuedQueries[br.qqIdx].fn != nil {
-			err := br.b.queuedQueries[br.qqIdx].fn(br)
+	for br.err == nil && !br.closed && br.b != nil && br.qqIdx < len(br.b.QueuedQueries) {
+		if br.b.QueuedQueries[br.qqIdx].fn != nil {
+			err := br.b.QueuedQueries[br.qqIdx].fn(br)
 			if err != nil {
 				br.err = err
 			}
@@ -422,10 +422,10 @@ func (br *pipelineBatchResults) earlyError() error {
 }
 
 func (br *pipelineBatchResults) nextQueryAndArgs() (query string, args []any, ok bool) {
-	if br.b != nil && br.qqIdx < len(br.b.queuedQueries) {
-		bi := br.b.queuedQueries[br.qqIdx]
-		query = bi.query
-		args = bi.arguments
+	if br.b != nil && br.qqIdx < len(br.b.QueuedQueries) {
+		bi := br.b.QueuedQueries[br.qqIdx]
+		query = bi.SQL
+		args = bi.Arguments
 		ok = true
 		br.qqIdx++
 	}


### PR DESCRIPTION
As discussed previously this PR changes publicity of structs properties in `batch.go`.

`QueuedQuery.query` replaced with `QueuedQuery.SQL` because of naming conflict with existing method