### PR TITLE
Add link to github.com/twpayne/pgx-geos

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ pgerrcode contains constants for the PostgreSQL error codes.
 
 * [github.com/jackc/pgx-gofrs-uuid](https://github.com/jackc/pgx-gofrs-uuid)
 * [github.com/jackc/pgx-shopspring-decimal](https://github.com/jackc/pgx-shopspring-decimal)
+* [github.com/twpayne/pgx-geos](https://github.com/twpayne/pgx-geos) ([PostGIS](https://postgis.net/) and [GEOS](https://libgeos.org/) via [go-geos](https://github.com/twpayne/go-geos))
 * [github.com/vgarvardt/pgx-google-uuid](https://github.com/vgarvardt/pgx-google-uuid)
 
 


### PR DESCRIPTION
Thank you for your review of #1892!

This PR adds a link to github.com/twpayne/pgx-geos to the list of adapters for 3rd party types. Specifically, this adds reasonably good support for PostGIS geometry types to jackc/pgx.