### PR TITLE
Correct host in ConnectError

### DIFF
--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -59,14 +59,15 @@ func (pe *PgError) SQLState() string {
 
 // ConnectError is the error returned when a connection attempt fails.
 type ConnectError struct {
-	Config *Config // The configuration that was used in the connection attempt.
-	msg    string
-	err    error
+	Config         *Config // The configuration that was used in the connection attempt.
+	fallbackConfig *FallbackConfig
+	msg            string
+	err            error
 }
 
 func (e *ConnectError) Error() string {
 	sb := &strings.Builder{}
-	fmt.Fprintf(sb, "failed to connect to `host=%s user=%s database=%s`: %s", e.Config.Host, e.Config.User, e.Config.Database, e.msg)
+	fmt.Fprintf(sb, "failed to connect to `host=%s user=%s database=%s`: %s", e.fallbackConfig.Host, e.Config.User, e.Config.Database, e.msg)
 	if e.err != nil {
 		fmt.Fprintf(sb, " (%s)", e.err.Error())
 	}
@@ -230,3 +231,18 @@ func (e *NotPreferredError) SafeToRetry() bool {
 func (e *NotPreferredError) Unwrap() error {
 	return e.err
 }
+
+type lookupError struct {
+	err            error
+	fallbackConfig *FallbackConfig
+}
+
+func (e *lookupError) Error() string {
+	return e.err.Error()
+}
+
+func (e *lookupError) Unwrap() error {
+	return e.err
+}
+
+var errIPAddrNotFound = errors.New("ip address not found")

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -379,6 +379,22 @@ func TestConnectWithConnectionRefused(t *testing.T) {
 	}
 }
 
+func TestConnectErrorHasCorrectHost(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Presumably nothing is listening on 127.0.0.1:1 and 127.0.0.1:2
+	conn, err := pgconn.Connect(ctx, "postgresql://user:password@localhost:1,127.0.0.1:2/database")
+	if err == nil {
+		conn.Close(ctx)
+		t.Fatal("Expected error establishing connection to bad port")
+	}
+	require.ErrorContains(t, err, "host=127.0.0.1")
+	require.ErrorContains(t, err, "dial tcp 127.0.0.1:2")
+}
+
 func TestConnectCustomDialer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Added `*fallbackConfig` to `ConnectError` to have the correct host in the error message.
See https://github.com/jackc/pgx/issues/1929