### PR TITLE
Expose host address when timeout exceeded

### DIFF
--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -117,6 +117,8 @@ func normalizeTimeoutError(ctx context.Context, err error) error {
 		if ctx.Err() == context.Canceled {
 			// Since the timeout was caused by a context cancellation, the actual error is context.Canceled not the timeout error.
 			return context.Canceled
+		} else if ctx.Err() == context.DeadlineExceeded {
+			return &errTimeout{err: fmt.Errorf("%s: %w", netErr.Error(), ctx.Err())}
 		} else {
 			return &errTimeout{err: netErr}
 		}

--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -117,8 +117,6 @@ func normalizeTimeoutError(ctx context.Context, err error) error {
 		if ctx.Err() == context.Canceled {
 			// Since the timeout was caused by a context cancellation, the actual error is context.Canceled not the timeout error.
 			return context.Canceled
-		} else if ctx.Err() == context.DeadlineExceeded {
-			return &errTimeout{err: ctx.Err()}
 		} else {
 			return &errTimeout{err: netErr}
 		}

--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -117,8 +117,8 @@ func normalizeTimeoutError(ctx context.Context, err error) error {
 		if ctx.Err() == context.Canceled {
 			// Since the timeout was caused by a context cancellation, the actual error is context.Canceled not the timeout error.
 			return context.Canceled
-		} else if ctx.Err() == context.DeadlineExceeded {
-			return &errTimeout{err: fmt.Errorf("%s: %w", netErr.Error(), ctx.Err())}
+		} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return &errTimeout{err: fmt.Errorf("%s: %w", netErr.Error(), context.DeadlineExceeded)}
 		} else {
 			return &errTimeout{err: netErr}
 		}

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -177,6 +177,7 @@ func ConnectConfig(octx context.Context, config *Config) (pgConn *PgConn, err er
 		pgConn, fberr = connect(ctx, config, fc, false)
 		if fberr == nil {
 			foundBestServer = true
+			err = nil
 			break
 		} else if pgerr, ok := fberr.(*PgError); ok {
 			err = &ConnectError{Config: config, msg: "server error", err: pgerr}

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -193,6 +193,10 @@ func ConnectConfig(octx context.Context, config *Config) (pgConn *PgConn, err er
 			if _, ok := cerr.err.(*NotPreferredError); ok {
 				fallbackConfig = fc
 			}
+			if _, ok := cerr.err.(*errTimeout); ok {
+				// once we reach timeout it's useless to check other fallbacks
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes: #1942

Once we face a timeout we should expose address, it can be for example ipv6 or ipv4 and knowing what exact address we took for resolver extreamly helpful for triaging a networking issue.

This issue is also fixed in pgx/v4, see: https://github.com/jackc/pgconn/issues/139