### PR TITLE
Add support for macaddr8 type

### DIFF
--- a/pgtype/macaddr_test.go
+++ b/pgtype/macaddr_test.go
@@ -46,6 +46,20 @@ func TestMacaddrCodec(t *testing.T) {
 			new(string),
 			isExpectedEq("01:23:45:67:89:ab"),
 		},
+		{nil, new(*net.HardwareAddr), isExpectedEq((*net.HardwareAddr)(nil))},
+	})
+
+	pgxtest.RunValueRoundTripTests(context.Background(), t, defaultConnTestRunner, pgxtest.KnownOIDQueryExecModes, "macaddr8", []pgxtest.ValueRoundTripTest{
+		{
+			mustParseMacaddr(t, "01:23:45:67:89:ab:01:08"),
+			new(net.HardwareAddr),
+			isExpectedEqHardwareAddr(mustParseMacaddr(t, "01:23:45:67:89:ab:01:08")),
+		},
+		{
+			"01:23:45:67:89:ab:01:08",
+			new(net.HardwareAddr),
+			isExpectedEqHardwareAddr(mustParseMacaddr(t, "01:23:45:67:89:ab:01:08")),
+		},
 		{
 			mustParseMacaddr(t, "01:23:45:67:89:ab:01:08"),
 			new(string),

--- a/pgtype/macaddr_test.go
+++ b/pgtype/macaddr_test.go
@@ -46,6 +46,11 @@ func TestMacaddrCodec(t *testing.T) {
 			new(string),
 			isExpectedEq("01:23:45:67:89:ab"),
 		},
+		{
+			mustParseMacaddr(t, "01:23:45:67:89:ab:01:08"),
+			new(string),
+			isExpectedEq("01:23:45:67:89:ab:01:08"),
+		},
 		{nil, new(*net.HardwareAddr), isExpectedEq((*net.HardwareAddr)(nil))},
 	})
 }

--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -41,6 +41,7 @@ const (
 	CircleOID              = 718
 	CircleArrayOID         = 719
 	UnknownOID             = 705
+	Macaddr8OID            = 774
 	MacaddrOID             = 829
 	InetOID                = 869
 	BoolArrayOID           = 1000

--- a/pgtype/pgtype_default.go
+++ b/pgtype/pgtype_default.go
@@ -70,6 +70,7 @@ func initDefaultMap() {
 	defaultMap.RegisterType(&Type{Name: "jsonpath", OID: JSONPathOID, Codec: &TextFormatOnlyCodec{TextCodec{}}})
 	defaultMap.RegisterType(&Type{Name: "line", OID: LineOID, Codec: LineCodec{}})
 	defaultMap.RegisterType(&Type{Name: "lseg", OID: LsegOID, Codec: LsegCodec{}})
+	defaultMap.RegisterType(&Type{Name: "macaddr8", OID: Macaddr8OID, Codec: MacaddrCodec{}})
 	defaultMap.RegisterType(&Type{Name: "macaddr", OID: MacaddrOID, Codec: MacaddrCodec{}})
 	defaultMap.RegisterType(&Type{Name: "name", OID: NameOID, Codec: TextCodec{}})
 	defaultMap.RegisterType(&Type{Name: "numeric", OID: NumericOID, Codec: NumericCodec{}})


### PR DESCRIPTION
Postgres also has a `macaddr8` type, this PR adds support for it, using the same codec as `macaddr`