### PR TITLE
Remove unnecessary Rows.Close()

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -461,7 +461,6 @@ func CollectOneRow[T any](rows Rows, fn RowToFunc[T]) (T, error) {
 		return value, err
 	}
 
-	rows.Close()
 	return value, rows.Err()
 }
 


### PR DESCRIPTION
Hi, I frequently use the `CollectOneRow` function and noticed that Close() is redundantly called. There's no issue if it's already closed, but please remove it for cleaner code.