### PR TITLE
Create NextE function to allow application to know when connection is…

### DIFF
--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -1536,20 +1536,25 @@ func (rr *ResultReader) Read() *Result {
 
 // NextRow advances the ResultReader to the next row and returns true if a row is available.
 func (rr *ResultReader) NextRow() bool {
+	next, _ := rr.NextRowE()
+	return next
+}
+
+func (rr *ResultReader) NextRowE() (bool, error) {
 	for !rr.commandConcluded {
 		msg, err := rr.receiveMessage()
 		if err != nil {
-			return false
+			return false, err
 		}
 
 		switch msg := msg.(type) {
 		case *pgproto3.DataRow:
 			rr.rowValues = msg.Values
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // FieldDescriptions returns the field descriptions for the current result set. The returned slice is only valid until


### PR DESCRIPTION
Hi, When running a long live job at midnight, We found that when the connection can be terminated by some factor like maintenance, terminated by the admin. 
the logger for this driver shows this error. 
```
"err":{
      "Severity":"FATAL",
      "Code":"57P01",
      "Message":"terminating connection due to administrator command",
      "Detail":"",
      "Hint":"",
      "Position":0,
      "InternalPosition":0,
      "InternalQuery":"",
      "Where":"",
      "SchemaName":"",
      "TableName":"",
      "ColumnName":"",
      "DataTypeName":"",
      "ConstraintName":"",
      "File":"postgres.c",
      "Line":3114,
      "Routine":"ProcessInterrupts"
   },
   ```
   After checking we saw that on Next function there is no way to distinguish between data is completed fetch or there are error when fetch data. 
   So i want to introduce a new function called NextE to return both (bool, error) to reader
