### PR TITLE
Fix typos in doc comments

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -624,7 +624,7 @@ const (
 	// to execute. It does not use named prepared statements. But it does use the unnamed prepared statement to get the
 	// statement description on the first round trip and then uses it to execute the query on the second round trip. This
 	// may cause problems with connection poolers that switch the underlying connection between round trips. It is safe
-	// even when the the database schema is modified concurrently.
+	// even when the database schema is modified concurrently.
 	QueryExecModeDescribeExec
 
 	// Assume the PostgreSQL query parameter types based on the Go type of the arguments. This uses the extended protocol

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -70,7 +70,7 @@ type Config struct {
 
 // ParseConfigOptions contains options that control how a config is built such as GetSSLPassword.
 type ParseConfigOptions struct {
-	// GetSSLPassword gets the password to decrypt a SSL client certificate. This is analogous to the the libpq function
+	// GetSSLPassword gets the password to decrypt a SSL client certificate. This is analogous to the libpq function
 	// PQsetSSLKeyPassHook_OpenSSL.
 	GetSSLPassword GetSSLPasswordFunc
 }

--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -18,7 +18,7 @@ func SafeToRetry(err error) bool {
 	return false
 }
 
-// Timeout checks if err was was caused by a timeout. To be specific, it is true if err was caused within pgconn by a
+// Timeout checks if err was caused by a timeout. To be specific, it is true if err was caused within pgconn by a
 // context.DeadlineExceeded or an implementer of net.Error where Timeout() is true.
 func Timeout(err error) bool {
 	var timeoutErr *errTimeout

--- a/pgconn/errors_test.go
+++ b/pgconn/errors_test.go
@@ -30,7 +30,7 @@ func TestConfigError(t *testing.T) {
 		},
 		{
 			name:        "weird url",
-			err:         pgconn.NewParseConfigError("postgresql://foo::pasword@host:1:", "msg", nil),
+			err:         pgconn.NewParseConfigError("postgresql://foo::password@host:1:", "msg", nil),
 			expectedMsg: "cannot parse `postgresql://foo:xxxxx@host:1:`: msg",
 		},
 		{

--- a/pgproto3/pgproto3.go
+++ b/pgproto3/pgproto3.go
@@ -99,7 +99,7 @@ func getValueFromJSON(v map[string]string) ([]byte, error) {
 	return nil, errors.New("unknown protocol representation")
 }
 
-// beginMessage begines a new message of type t. It appends the message type and a placeholder for the message length to
+// beginMessage begins a new message of type t. It appends the message type and a placeholder for the message length to
 // dst. It returns the new buffer and the position of the message length placeholder.
 func beginMessage(dst []byte, t byte) ([]byte, int) {
 	dst = append(dst, t)

--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -1331,7 +1331,7 @@ func (plan *derefPointerEncodePlan) Encode(value any, buf []byte) (newBuf []byte
 }
 
 // TryWrapDerefPointerEncodePlan tries to dereference a pointer. e.g. If value was of type *string then a wrapper plan
-// would be returned that derefences the value.
+// would be returned that dereferences the value.
 func TryWrapDerefPointerEncodePlan(value any) (plan WrappedEncodePlanNextSetter, nextValue any, ok bool) {
 	if _, ok := value.(driver.Valuer); ok {
 		return nil, nil, false

--- a/values_test.go
+++ b/values_test.go
@@ -216,7 +216,7 @@ func testJSONInt16ArrayFailureDueToOverflow(t *testing.T, conn *pgx.Conn, typena
 	var output []int16
 	err := conn.QueryRow(context.Background(), "select $1::"+typename, input).Scan(&output)
 	if err == nil || err.Error() != "can't scan into dest[0]: json: cannot unmarshal number 234432 into Go value of type int16" {
-		t.Errorf("%s: Expected *json.UnmarkalTypeError, but got %v", typename, err)
+		t.Errorf("%s: Expected *json.UnmarshalTypeError, but got %v", typename, err)
 	}
 }
 


### PR DESCRIPTION
The PR corrects spelling mistakes in comments and the test assertion message.