### PR TITLE
remove keepalive and rely on GOLANG default (since go 1.13 default is 15s)

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -800,7 +800,8 @@ func parsePort(s string) (uint16, error) {
 }
 
 func makeDefaultDialer() *net.Dialer {
-	return &net.Dialer{KeepAlive: 5 * time.Minute}
+	// rely on GOLANG KeepAlive settings
+	return &net.Dialer{}
 }
 
 func makeDefaultResolver() *net.Resolver {


### PR DESCRIPTION
set keepalive to appropiate value (since go 1.13 default is 15s).

5 minute for initial keepalive checks are way to high, we should orient us here according to go defaults

https://www.reddit.com/r/golang/comments/d7v7dn/psa_go_113_introduces_15_sec_server_tcp/