### PR TITLE
Fix test asserts: reverse expected-actual params

### DIFF
--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -2714,7 +2714,7 @@ func TestPipelinePrepare(t *testing.T) {
 	sd, ok := results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "a")
+	require.Equal(t, "a", string(sd.Fields[0].Name))
 	require.Equal(t, []uint32{pgtype.Int8OID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2722,7 +2722,7 @@ func TestPipelinePrepare(t *testing.T) {
 	sd, ok = results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "b")
+	require.Equal(t, "b", string(sd.Fields[0].Name))
 	require.Equal(t, []uint32{pgtype.TextOID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2730,7 +2730,7 @@ func TestPipelinePrepare(t *testing.T) {
 	sd, ok = results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "c")
+	require.Equal(t, "c", string(sd.Fields[0].Name))
 	require.Equal(t, []uint32{}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2784,7 +2784,7 @@ func TestPipelinePrepareError(t *testing.T) {
 	sd, ok := results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "a")
+	require.Equal(t, "a", string(sd.Fields[0].Name))
 	require.Equal(t, []uint32{pgtype.Int8OID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2828,7 +2828,7 @@ func TestPipelinePrepareAndDeallocate(t *testing.T) {
 	sd, ok := results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "a")
+	require.Equal(t, "a", string(sd.Fields[0].Name))
 	require.Equal(t, []uint32{pgtype.Int8OID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -2965,7 +2965,7 @@ func TestPipelinePrepareQuery(t *testing.T) {
 	sd, ok := results.(*pgconn.StatementDescription)
 	require.Truef(t, ok, "expected StatementDescription, got: %#v", results)
 	require.Len(t, sd.Fields, 1)
-	require.Equal(t, string(sd.Fields[0].Name), "msg")
+	require.Equal(t, "msg", string(sd.Fields[0].Name))
 	require.Equal(t, []uint32{pgtype.TextOID}, sd.ParamOIDs)
 
 	results, err = pipeline.GetResults()
@@ -3427,9 +3427,9 @@ func TestSNISupport(t *testing.T) {
 			select {
 			case sniHost := <-serverSNINameChan:
 				if tt.sni_set {
-					require.Equal(t, sniHost, "localhost")
+					require.Equal(t, "localhost", sniHost)
 				} else {
-					require.Equal(t, sniHost, "")
+					require.Equal(t, "", sniHost)
 				}
 			case err = <-serverErrChan:
 				t.Fatalf("server failed with error: %+v", err)

--- a/pgtype/bytea_test.go
+++ b/pgtype/bytea_test.go
@@ -92,7 +92,7 @@ func TestPreallocBytes(t *testing.T) {
 
 		require.Len(t, buf, 2)
 		require.Equal(t, 4, cap(buf))
-		require.Equal(t, buf, []byte{1, 2})
+		require.Equal(t, []byte{1, 2}, buf)
 
 		require.Equal(t, []byte{1, 2, 7, 8}, origBuf)
 
@@ -112,7 +112,7 @@ func TestUndecodedBytes(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, buf, 4)
-		require.Equal(t, buf, []byte{0, 0, 0, 1})
+		require.Equal(t, []byte{0, 0, 0, 1}, buf)
 	})
 }
 
@@ -132,6 +132,6 @@ func TestByteaCodecDecodeDatabaseSQLValue(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, buf, 4)
-		require.Equal(t, buf, []byte{0xa1, 0xb2, 0xc3, 0xd4})
+		require.Equal(t, []byte{0xa1, 0xb2, 0xc3, 0xd4}, buf)
 	})
 }

--- a/pgtype/enum_codec_test.go
+++ b/pgtype/enum_codec_test.go
@@ -64,6 +64,6 @@ create type enum_test as enum ('foo', 'bar', 'baz');`)
 		require.True(t, rows.Next())
 		values, err := rows.Values()
 		require.NoError(t, err)
-		require.Equal(t, values, []any{"foo"})
+		require.Equal(t, []any{"foo"}, values)
 	})
 }

--- a/pgtype/pgtype_test.go
+++ b/pgtype/pgtype_test.go
@@ -309,7 +309,7 @@ func TestPointerPointerStructScan(t *testing.T) {
 	plan := m.PlanScan(pgt.OID, pgtype.TextFormatCode, &c)
 	err := plan.Scan([]byte("(1)"), &c)
 	require.NoError(t, err)
-	require.Equal(t, c.ID, 1)
+	require.Equal(t, 1, c.ID)
 }
 
 // https://github.com/jackc/pgx/issues/1263


### PR DESCRIPTION
This PR fixes tests by reversing passed parameters to the [require.Equal](https://pkg.go.dev/github.com/stretchr/testify@v1.8.1/require#Equal) according to the signature (`actual` after `expected`):

```
func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool
```
