### PR TITLE
Add ltree extension requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ Create and setup a test database:
 export PGDATABASE=pgx_test
 createdb
 psql -c 'create extension hstore;'
+psql -c 'create extension ltree;'
 psql -c 'create domain uint64 as numeric(20,0);'
 ```
 


### PR DESCRIPTION
Otherwise tests fail for me locally.

They still fail for me with:

```
--- FAIL: TestConnCopyWithAllQueryExecModes (0.13s)
    --- FAIL: TestConnCopyWithAllQueryExecModes/exec (0.02s)
        copy_from_test.go:70: Input rows and output rows do not equal: [[0 1 2 abc 2010-02-03 04:05:06 +0100 CET] [<nil> <nil> <nil> <nil> <nil>]] -> [[0 1 2 abc 2010-02-03 03:05:06 +0000 +0000] [<nil> <nil> <nil> <nil> <nil>]]
    --- FAIL: TestConnCopyWithAllQueryExecModes/simple_protocol (0.03s)
        copy_from_test.go:70: Input rows and output rows do not equal: [[0 1 2 abc 2010-02-03 04:05:06 +0100 CET] [<nil> <nil> <nil> <nil> <nil>]] -> [[0 1 2 abc 2010-02-03 03:05:06 +0000 +0000] [<nil> <nil> <nil> <nil> <nil>]]
FAIL
FAIL	github.com/jackc/pgx/v5	30.333s
```

But I do not know how to fix that. It might be something wrong with my local setup.

I run tests with:

```
$ docker run --name pgsql --rm -d -p 5432:5432 -e LOG_TO_STDOUT=1 -e PGSQL_ROLE_1_USERNAME=test -e PGSQL_ROLE_1_PASSWORD=test -e PGSQL_DB_1_NAME=test -e PGSQL_DB_1_OWNER=test registry.gitlab.com/tozd/docker/postgresql:16
$ docker exec -t -i pgsql bash
$ psql -h localhost -U test -W
test (password)
create extension hstore;
create extension ltree;
create domain uint64 as numeric(20,0);
^d
$ export PGX_TEST_DATABASE=postgres://test:test@localhost:5432/test
$ go test ./...
````