### PR TITLE
Add Scan and Value to pgtype.FlatArray, pgtype.Array, pgtype.Range, and pgtype.Multirange

### DIFF
--- a/pgtype/multirange.go
+++ b/pgtype/multirange.go
@@ -441,3 +441,50 @@ func (r Multirange[T]) ScanIndex(i int) any {
 func (r Multirange[T]) ScanIndexType() any {
 	return new(T)
 }
+
+// Scan implements the database/sql Scanner interface.
+//
+// Range needs a *Map to decode the range elements. Unfortunately, the the Go type system does not support attaching
+// data to a type and the Scanner interface does not have an argument that can be used to pass extra data to the Scan
+// method. To work around this limitation, Scan uses a default *Map. This means Scan may only work properly with types
+// that are supported by a default *Map. from a Map or Codec.
+func (r *Multirange[T]) Scan(v any) error {
+	if v == nil {
+		*r = nil
+		return nil
+	}
+
+	m := databaseSQLMapPool.Get().(*Map)
+	defer databaseSQLMapPool.Put(m)
+
+	switch v := v.(type) {
+	case string:
+		return m.Scan(0, 0, []byte(v), r)
+	case []byte:
+		return m.Scan(0, 0, v, r)
+	default:
+		return fmt.Errorf("unsupported type: %T", v)
+	}
+}
+
+// Value implements the database/sql/driver Valuer interface.
+//
+// Range needs a *Map to encode the range elements. Unfortunately, the the Go type system does not support attaching
+// data to a type and the Valuer interface does not have an argument that can be used to pass extra data to the Value
+// method. To work around this limitation, Value uses a default *Map. This means Value may only work properly with types
+// that are supported by a default *Map. from a Map or Codec.
+func (src Multirange[T]) Value() (driver.Value, error) {
+	if src == nil {
+		return nil, nil
+	}
+
+	m := databaseSQLMapPool.Get().(*Map)
+	defer databaseSQLMapPool.Put(m)
+
+	buf, err := m.Encode(0, TextFormatCode, src, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return string(buf), nil
+}

--- a/stdlib/bench_test.go
+++ b/stdlib/bench_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func getSelectRowsCounts(b *testing.B) []int64 {
@@ -105,5 +107,54 @@ func BenchmarkSelectRowsScanNull(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+func BenchmarkFlatArrayEncodeArgument(b *testing.B) {
+	db := openDB(b)
+	defer closeDB(b, db)
+
+	input := make(pgtype.FlatArray[string], 10)
+	for i := range input {
+		input[i] = fmt.Sprintf("String %d", i)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var n int64
+		err := db.QueryRow("select cardinality($1::text[])", input).Scan(&n)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if n != int64(len(input)) {
+			b.Fatalf("Expected %d, got %d", len(input), n)
+		}
+	}
+}
+
+func BenchmarkFlatArrayScanResult(b *testing.B) {
+	db := openDB(b)
+	defer closeDB(b, db)
+
+	var input string
+	for i := 0; i < 10; i++ {
+		if i > 0 {
+			input += ","
+		}
+		input += fmt.Sprintf(`'String %d'`, i)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var result pgtype.FlatArray[string]
+		err := db.QueryRow(fmt.Sprintf("select array[%s]::text[]", input)).Scan(&result)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(result) != 10 {
+			b.Fatalf("Expected %d, got %d", len(result), 10)
+		}
 	}
 }

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -589,6 +589,7 @@ func TestConnQueryPGTypeRange(t *testing.T) {
 func TestConnQueryPGTypeMultirange(t *testing.T) {
 	testWithAllQueryExecModes(t, func(t *testing.T, db *sql.DB) {
 		skipCockroachDB(t, db, "Server does not support int4range")
+		skipPostgreSQLVersionLessThan(t, db, 14)
 
 		var r pgtype.Multirange[pgtype.Range[pgtype.Int4]]
 		err := db.QueryRow("select int4multirange(int4range(1, 5), int4range(7,9))").Scan(&r)

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -530,6 +530,8 @@ func TestPGTypeFlatArray(t *testing.T) {
 
 func TestPGTypeArray(t *testing.T) {
 	testWithAllQueryExecModes(t, func(t *testing.T, db *sql.DB) {
+		skipCockroachDB(t, db, "Server does not support nested arrays")
+
 		var matrix pgtype.Array[int64]
 
 		err := db.QueryRow("select '{{1,2,3},{4,5,6}}'::bigint[]").Scan(&matrix)

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -555,14 +555,12 @@ func TestPGTypeArray(t *testing.T) {
 	})
 }
 
-func TestConnQueryScanRange(t *testing.T) {
+func TestConnQueryPGTypeRange(t *testing.T) {
 	testWithAllQueryExecModes(t, func(t *testing.T, db *sql.DB) {
 		skipCockroachDB(t, db, "Server does not support int4range")
 
-		m := pgtype.NewMap()
-
 		var r pgtype.Range[pgtype.Int4]
-		err := db.QueryRow("select int4range(1, 5)").Scan(m.SQLScanner(&r))
+		err := db.QueryRow("select int4range(1, 5)").Scan(&r)
 		require.NoError(t, err)
 		assert.Equal(
 			t,
@@ -574,6 +572,15 @@ func TestConnQueryScanRange(t *testing.T) {
 				Valid:     true,
 			},
 			r)
+
+		var equal bool
+		err = db.QueryRow("select int4range(1, 5) = $1::int4range", r).Scan(&equal)
+		require.NoError(t, err)
+		require.Equal(t, true, equal)
+
+		err = db.QueryRow("select null::int4range").Scan(&r)
+		require.NoError(t, err)
+		assert.Equal(t, pgtype.Range[pgtype.Int4]{}, r)
 	})
 }
 


### PR DESCRIPTION
This allows using the types directly without `*Map.SQLScanner`.

These methods were previously not implemented because they all require a `*Map` to encode or decode their underlying elements. The new implementations use an internal default `*Map`.  This means that they may not be able to directly support custom types, but normal types like `pgtype.FlatArray[string]` will work as expected.