### PR TITLE
Add support for PG 17 interval infinity values

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
-github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=
-github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=

--- a/pgtype/date.go
+++ b/pgtype/date.go
@@ -80,10 +80,8 @@ func (src Date) MarshalJSON() ([]byte, error) {
 	switch src.InfinityModifier {
 	case Finite:
 		s = src.Time.Format("2006-01-02")
-	case Infinity:
-		s = "infinity"
-	case NegativeInfinity:
-		s = "-infinity"
+	case Infinity, NegativeInfinity:
+		s = src.InfinityModifier.String()
 	}
 
 	return json.Marshal(s)
@@ -213,10 +211,8 @@ func (encodePlanDateCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 		if bc {
 			buf = append(buf, " BC"...)
 		}
-	case Infinity:
-		buf = append(buf, "infinity"...)
-	case NegativeInfinity:
-		buf = append(buf, "-infinity"...)
+	case Infinity, NegativeInfinity:
+		buf = append(buf, date.InfinityModifier.String()...)
 	}
 
 	return buf, nil

--- a/pgtype/interval_test.go
+++ b/pgtype/interval_test.go
@@ -127,6 +127,16 @@ func TestIntervalCodec(t *testing.T) {
 			new(pgtype.Interval),
 			isExpectedEq(pgtype.Interval{Months: -13, Valid: true}),
 		},
+		{
+			"infinity",
+			new(pgtype.Interval),
+			isExpectedEq(pgtype.Interval{InfinityModifier: pgtype.Infinity, Valid: true}),
+		},
+		{
+			"-infinity",
+			new(pgtype.Interval),
+			isExpectedEq(pgtype.Interval{InfinityModifier: pgtype.NegativeInfinity, Valid: true}),
+		},
 		{time.Hour, new(time.Duration), isExpectedEq(time.Hour)},
 		{
 			pgtype.Interval{Months: 1, Days: 1, Valid: true},
@@ -149,6 +159,8 @@ func TestIntervalTextEncode(t *testing.T) {
 		{source: pgtype.Interval{Months: 0, Days: 0, Microseconds: 0, Valid: true}, result: "00:00:00"},
 		{source: pgtype.Interval{Months: 0, Days: 0, Microseconds: 6 * 60 * 1000000, Valid: true}, result: "00:06:00"},
 		{source: pgtype.Interval{Months: 0, Days: 1, Microseconds: 6*60*1000000 + 30, Valid: true}, result: "1 day 00:06:00.000030"},
+		{source: pgtype.Interval{InfinityModifier: pgtype.Infinity, Valid: true}, result: "infinity"},
+		{source: pgtype.Interval{InfinityModifier: pgtype.NegativeInfinity, Valid: true}, result: "-infinity"},
 	}
 	for i, tt := range successfulTests {
 		buf, err := m.Encode(pgtype.DateOID, pgtype.TextFormatCode, tt.source, nil)

--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -77,10 +77,8 @@ func (ts Timestamp) MarshalJSON() ([]byte, error) {
 	switch ts.InfinityModifier {
 	case Finite:
 		s = ts.Time.Format(time.RFC3339Nano)
-	case Infinity:
-		s = "infinity"
-	case NegativeInfinity:
-		s = "-infinity"
+	case Infinity, NegativeInfinity:
+		s = ts.InfinityModifier.String()
 	}
 
 	return json.Marshal(s)
@@ -205,10 +203,8 @@ func (encodePlanTimestampCodecText) Encode(value any, buf []byte) (newBuf []byte
 		if bc {
 			s = s + " BC"
 		}
-	case Infinity:
-		s = "infinity"
-	case NegativeInfinity:
-		s = "-infinity"
+	case Infinity, NegativeInfinity:
+		s = ts.InfinityModifier.String()
 	}
 
 	buf = append(buf, s...)

--- a/pgtype/timestamptz.go
+++ b/pgtype/timestamptz.go
@@ -85,10 +85,8 @@ func (tstz Timestamptz) MarshalJSON() ([]byte, error) {
 	switch tstz.InfinityModifier {
 	case Finite:
 		s = tstz.Time.Format(time.RFC3339Nano)
-	case Infinity:
-		s = "infinity"
-	case NegativeInfinity:
-		s = "-infinity"
+	case Infinity, NegativeInfinity:
+		s = tstz.InfinityModifier.String()
 	}
 
 	return json.Marshal(s)
@@ -213,10 +211,8 @@ func (encodePlanTimestamptzCodecText) Encode(value any, buf []byte) (newBuf []by
 		if bc {
 			s = s + " BC"
 		}
-	case Infinity:
-		s = "infinity"
-	case NegativeInfinity:
-		s = "-infinity"
+	case Infinity, NegativeInfinity:
+		s = ts.InfinityModifier.String()
 	}
 
 	buf = append(buf, s...)


### PR DESCRIPTION
Although Postgres 17 is still in beta, I thought it might make sense to get ahead of one of the changes being made.

Added in this commit: https://github.com/postgres/postgres/commit/519fc1bd9
Upstream release notes: https://www.postgresql.org/docs/17/release-17.html#RELEASE-17-DATATYPES

The wire format for infinity/-infinity adds no breaking changes- it is just the various values set to either minimum or maximum possible int64/int32 values.

I attempted to match how InfinityModifier works in other types, such as date and timestamptz.

Please let me know what, if anything, I forgot to update here, and any other feedback is definitely welcome.

It feels like this is relatively safe and backward compatible with older versions, since you can just choose not to use infinity values with older versions, and since there were no wire format changes. However, I'm happy to make changes or documentation updates if that is necessary.