### PR TITLE
prevent double close in CopyFrom

### DIFF
--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -1356,9 +1356,11 @@ func (pgConn *PgConn) CopyFrom(ctx context.Context, r io.Reader, sql string) (Co
 			// the goroutine. So instead check pgConn.bufferingReceiveErr which will have been set by the signalMessage. If an
 			// error is found then forcibly close the connection without sending the Terminate message.
 			if err := pgConn.bufferingReceiveErr; err != nil {
-				pgConn.status = connStatusClosed
-				pgConn.conn.Close()
-				close(pgConn.cleanupDone)
+				if pgConn.status != connStatusClosed {
+					pgConn.status = connStatusClosed
+					pgConn.conn.Close()
+					close(pgConn.cleanupDone)
+				}
 				return CommandTag{}, normalizeTimeoutError(ctx, err)
 			}
 			msg, _ := pgConn.receiveMessage()


### PR DESCRIPTION
```
/go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:75 +0x98
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 173068306

/go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:78 +0x58
golang.org/x/sync/errgroup.(*Group).Go.func1()

/root/flow/activities/flowable_core.go:191 +0x27c
github.com/PeerDB-io/peer-flow/activities.syncCore[...].func3()

/root/flow/connectors/postgres/postgres.go:429 +0x34
github.com/PeerDB-io/peer-flow/connectors/postgres.(*PostgresConnector).SyncRecords(0x68?, {0x3950860?, 0x400be6e550?}, 0x2959298?)

/root/flow/connectors/postgres/postgres.go:538 +0x45c
github.com/PeerDB-io/peer-flow/connectors/postgres.syncRecordsCore[...]({0x3950860, 0x400be6e550}, 0x40055f8700, 0x4002759960)

/go/pkg/mod/github.com/jackc/pgx/v5@v5.5.5/tx.go:256 +0x60
github.com/jackc/pgx/v5.(*dbTx).CopyFrom(0x40030de360?, {0x3950860?, 0x400be6e550?}, {0x4004cfb160?, 0x0?, 0x0?}, {0x400137f280?, 0x0?, 0x0?}, {0x3946ee0?, ...})

/go/pkg/mod/github.com/jackc/pgx/v5@v5.5.5/copy_from.go:275 +0x108
github.com/jackc/pgx/v5.(*Conn).CopyFrom(0x40030de360, {0x3950860, 0x400be6e550}, {0x4004cfb160, 0x2, 0x2}, {0x400137f280, 0x8, 0x8}, {0x3946ee0, ...})

/go/pkg/mod/github.com/jackc/pgx/v5@v5.5.5/copy_from.go:202 +0x44c
github.com/jackc/pgx/v5.(*copyFrom).run(0x4001939bc0, {0x3950860?, 0x400be6e550?})

/go/pkg/mod/github.com/jackc/pgx/v5@v5.5.5/pgconn/pgconn.go:1340 +0x808
github.com/jackc/pgx/v5/pgconn.(*PgConn).CopyFrom(0x4008e8a008, {0x3950860, 0x400be6e550}, {0x391f3e0, 0x4002167140}, {0x40045e9d40, 0x114})

goroutine 173071566 [running]:
panic: close of closed channel

error while rolling back transaction
```