### PR TITLE
Fix bug relating to reuse of types

### DIFF
--- a/derived_types.go
+++ b/derived_types.go
@@ -235,7 +235,9 @@ func (c *Conn) LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Typ
 		if type_ != nil {
 			m.RegisterType(type_)
 			if ti.NspName != "" {
-				m.RegisterType(&pgtype.Type{Name: ti.NspName + "." + type_.Name, OID: type_.OID, Codec: type_.Codec})
+				nspType := &pgtype.Type{Name: ti.NspName + "." + type_.Name, OID: type_.OID, Codec: type_.Codec}
+				m.RegisterType(nspType)
+				result = append(result, nspType)
 			}
 			result = append(result, type_)
 		}

--- a/derived_types_test.go
+++ b/derived_types_test.go
@@ -29,9 +29,12 @@ create type dtype_test as (
 
 		types, err := conn.LoadTypes(ctx, []string{"dtype_test"})
 		require.NoError(t, err)
-		require.Len(t, types, 3)
-		require.Equal(t, types[0].Name, "anotheruint64")
-		require.Equal(t, types[1].Name, "_anotheruint64")
-		require.Equal(t, types[2].Name, "dtype_test")
+		require.Len(t, types, 6)
+		require.Equal(t, types[0].Name, "public.anotheruint64")
+		require.Equal(t, types[1].Name, "anotheruint64")
+		require.Equal(t, types[2].Name, "public._anotheruint64")
+		require.Equal(t, types[3].Name, "_anotheruint64")
+		require.Equal(t, types[4].Name, "public.dtype_test")
+		require.Equal(t, types[5].Name, "dtype_test")
 	})
 }

--- a/pgtype/derived_types_test.go
+++ b/pgtype/derived_types_test.go
@@ -28,10 +28,13 @@ create type dt_test as (
 		defer conn.Exec(ctx, "drop type dt_test")
 
 		dtypes, err := conn.LoadTypes(ctx, []string{"dt_test"})
-		require.Len(t, dtypes, 3)
-		require.Equal(t, dtypes[0].Name, "dt_uint64")
-		require.Equal(t, dtypes[1].Name, "_dt_uint64")
-		require.Equal(t, dtypes[2].Name, "dt_test")
+		require.Len(t, dtypes, 6)
+		require.Equal(t, dtypes[0].Name, "public.dt_uint64")
+		require.Equal(t, dtypes[1].Name, "dt_uint64")
+		require.Equal(t, dtypes[2].Name, "public._dt_uint64")
+		require.Equal(t, dtypes[3].Name, "_dt_uint64")
+		require.Equal(t, dtypes[4].Name, "public.dt_test")
+		require.Equal(t, dtypes[5].Name, "dt_test")
 		require.NoError(t, err)
 		conn.TypeMap().RegisterTypes(dtypes)
 


### PR DESCRIPTION
When `LoadTypes` is being called, it does not include the namespace-qualified types in its result. While these namespaces are visible to `LoadTypes` itself, `RegisterTypes` will not recognise this form of the types, only allowing them to be used if they are on the schema path, and referred to without their namespace component.