### PR TITLE
don't print URL when url.Parse returns an error

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -472,7 +472,7 @@ func parseURLSettings(connString string) (map[string]string, error) {
 		if urlErr := new(url.Error); errors.As(err, &urlErr) {
 			return nil, urlErr.Err
 		}
-		return nil, errors.New("failed to parse URL")
+		return nil, err
 	}
 
 	if parsedURL.User != nil {


### PR DESCRIPTION
When `pgx.Connect`or `pgx.ParseConfig` is used, it indirectly calls url.Parse which by default returns the URL as part of its error type in case it failed to parse it. This leads to the error message from pgx leaking the unredacted URL in any logs.

Fixed by typecasting to `url.Error` and then returning only the appropriate bit of the error, needed to change a variable name along with this.

## Minimal Reproduction

```
package main

import (
	"context"
	"fmt"
	"os"

	"github.com/jackc/pgx/v5"
)

func main() {
	conn, err := pgx.Connect(context.Background(), "postgres://postgres:password@ localhost:5432/postgres")
	if err != nil {
		fmt.Fprintf(os.Stderr, "Unable to connect to database: %v\n", err)
		os.Exit(1)
	}
	defer conn.Close(context.Background())
}
```

### Without the change
```
Unable to connect to database: cannot parse `postgres://postgres:xxxxxx@ localhost:5432/postgres`: failed to parse as URL (parse "postgres://postgres:password@ localhost:5432/postgres": invalid character " " in host name)
```

### With the change
```
Unable to connect to database: cannot parse `postgres://postgres:xxxxxx@ localhost:5432/postgres`: failed to parse as URL (invalid character " " in host name)
```