### PR TITLE
Lock EnumCodec.membersMap during reads and writes

### DIFF
--- a/pgtype/enum_codec.go
+++ b/pgtype/enum_codec.go
@@ -3,24 +3,26 @@ package pgtype
 import (
 	"database/sql/driver"
 	"fmt"
+	"sync"
 )
 
 // EnumCodec is a codec that caches the strings it decodes. If the same string is read multiple times only one copy is
 // allocated. These strings are only garbage collected when the EnumCodec is garbage collected. EnumCodec can be used
 // for any text type not only enums, but it should only be used when there are a small number of possible values.
 type EnumCodec struct {
-	membersMap map[string]string // map to quickly lookup member and reuse string instead of allocating
+	membersMap   map[string]string // map to quickly lookup member and reuse string instead of allocating
+	membersMutex sync.RWMutex
 }
 
-func (EnumCodec) FormatSupported(format int16) bool {
+func (*EnumCodec) FormatSupported(format int16) bool {
 	return format == TextFormatCode || format == BinaryFormatCode
 }
 
-func (EnumCodec) PreferredFormat() int16 {
+func (*EnumCodec) PreferredFormat() int16 {
 	return TextFormatCode
 }
 
-func (EnumCodec) PlanEncode(m *Map, oid uint32, format int16, value any) EncodePlan {
+func (*EnumCodec) PlanEncode(m *Map, oid uint32, format int16, value any) EncodePlan {
 	switch format {
 	case TextFormatCode, BinaryFormatCode:
 		switch value.(type) {
@@ -67,15 +69,26 @@ func (c *EnumCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (a
 // lookupAndCacheString looks for src in the members map. If it is not found it is added to the map.
 func (c *EnumCodec) lookupAndCacheString(src []byte) string {
 	if c.membersMap == nil {
-		c.membersMap = make(map[string]string)
+		c.membersMutex.Lock()
+		// Re-do the nil check in case it's changed while we were waiting on
+		// the lock
+		if c.membersMap == nil {
+			c.membersMap = make(map[string]string)
+		}
+		c.membersMutex.Unlock()
 	}
 
+	c.membersMutex.RLock()
 	if s, found := c.membersMap[string(src)]; found {
+		c.membersMutex.RUnlock()
 		return s
 	}
+	c.membersMutex.RUnlock()
 
 	s := string(src)
+	c.membersMutex.Lock()
 	c.membersMap[s] = s
+	c.membersMutex.Unlock()
 	return s
 }
 


### PR DESCRIPTION
We've been seeing a nondeterministic `fatal error: concurrent map writes` error while using PGX. I traced it to the `c.membersMap[s] = s` line, and I think that this is a true issue - there doesn't appear to be anything preventing concurrent access to this map.

This PR adds a `sync.RWMutex` to `EnumCodec` and calls the appropriate `RLock` or `Lock` methods around read or write access.