### PR TITLE
add byte length check to uint32

### DIFF
--- a/pgtype/uint32.go
+++ b/pgtype/uint32.go
@@ -296,6 +296,10 @@ func (scanPlanBinaryUint32ToTextScanner) Scan(src []byte, dst any) error {
 		return s.ScanText(Text{})
 	}
 
+	if len(src) != 4 {
+		return fmt.Errorf("invalid length for uint32: %v", len(src))
+	}
+
 	n := uint64(binary.BigEndian.Uint32(src))
 	return s.ScanText(Text{String: strconv.FormatUint(n, 10), Valid: true})
 }


### PR DESCRIPTION
I thought this check was not needed, but I was wrong. It should be checking the byte length.