### PR TITLE
Use sql.ErrNoRows as value for pgx.ErrNoRows

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -3,6 +3,7 @@ package pgx_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"os"
 	"strings"
 	"sync"
@@ -1407,4 +1408,14 @@ func TestConnDeallocateInvalidatedCachedStatementsInTransactionWithBatch(t *test
 	require.NoError(t, err)
 
 	ensureConnValid(t, conn)
+}
+
+func TestErrNoRows(t *testing.T) {
+	t.Parallel()
+
+	// ensure we preserve old error message
+	require.Equal(t, "no rows in result set", pgx.ErrNoRows.Error())
+
+	require.ErrorIs(t, pgx.ErrNoRows, sql.ErrNoRows, "pgx.ErrNowRows must match sql.ErrNoRows")
+	require.ErrorIs(t, pgx.ErrNoRows, pgx.ErrNoRows, "sql.ErrNowRows must match pgx.ErrNoRows")
 }


### PR DESCRIPTION
Remaking pgx.ErrNoRows as wrapper over sql.ErrNoRows

**Why not just `var ErrNoRows = sql.ErrNoRows`?** 
I want to preserve the original error message in case any tools (log analyzers, for example) depend on the exact string value

Corresponding issue
https://github.com/jackc/pgx/issues/1931