### PR TITLE
Reduce SQL sanitizer allocations 

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1417,5 +1417,4 @@ func TestErrNoRows(t *testing.T) {
 	require.Equal(t, "no rows in result set", pgx.ErrNoRows.Error())
 
 	require.ErrorIs(t, pgx.ErrNoRows, sql.ErrNoRows, "pgx.ErrNowRows must match sql.ErrNoRows")
-	require.ErrorIs(t, pgx.ErrNoRows, pgx.ErrNoRows, "sql.ErrNowRows must match pgx.ErrNoRows")
 }

--- a/internal/sanitize/benchmmark.sh
+++ b/internal/sanitize/benchmmark.sh
@@ -43,7 +43,7 @@ for i in "${!commits[@]}"; do
     }
 
     # Sanitized commmit message
-    commit_message=$(git log -1 --pretty=format:"%s" | tr ' ' '_')
+    commit_message=$(git log -1 --pretty=format:"%s" | tr -c '[:alnum:]-_' '_')
 
     # Benchmark data will go there
     bench_file="${benchmarks_dir}/${i}_${commit_message}.bench"
@@ -56,4 +56,5 @@ for i in "${!commits[@]}"; do
     bench_files+=("$bench_file")
 done
 
+# go install golang.org/x/perf/cmd/benchstat[@latest]
 benchstat "${bench_files[@]}"

--- a/internal/sanitize/benchmmark.sh
+++ b/internal/sanitize/benchmmark.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" == "HEAD" ]; then
+    current_branch=$(git rev-parse HEAD)
+fi
+
+restore_branch() {
+    echo "Restoring original branch/commit: $current_branch"
+    git checkout "$current_branch"
+}
+trap restore_branch EXIT
+
+# Check if there are uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "There are uncommitted changes. Please commit or stash them before running this script."
+    exit 1
+fi
+
+# Ensure that at least one commit argument is passed
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <commit1> <commit2> ... <commitN>"
+    exit 1
+fi
+
+commits=("$@")
+benchmarks_dir=benchmarks
+
+if ! mkdir -p "${benchmarks_dir}"; then
+    echo "Unable to create dir for benchmarks data"
+    exit 1
+fi
+
+# Benchmark results
+bench_files=()
+
+# Run benchmark for each listed commit
+for i in "${!commits[@]}"; do
+    commit="${commits[i]}"
+    git checkout "$commit" || {
+        echo "Failed to checkout $commit"
+        exit 1
+    }
+
+    # Sanitized commmit message
+    commit_message=$(git log -1 --pretty=format:"%s" | tr ' ' '_')
+
+    # Benchmark data will go there
+    bench_file="${benchmarks_dir}/${i}_${commit_message}.bench"
+
+    if ! go test -bench=. -count=25 >"$bench_file"; then
+        echo "Benchmarking failed for commit $commit"
+        exit 1
+    fi
+
+    bench_files+=("$bench_file")
+done
+
+benchstat "${bench_files[@]}"

--- a/internal/sanitize/benchmmark.sh
+++ b/internal/sanitize/benchmmark.sh
@@ -48,7 +48,7 @@ for i in "${!commits[@]}"; do
     # Benchmark data will go there
     bench_file="${benchmarks_dir}/${i}_${commit_message}.bench"
 
-    if ! go test -bench=. -count=25 >"$bench_file"; then
+    if ! go test -bench=. -count=10 >"$bench_file"; then
         echo "Benchmarking failed for commit $commit"
         exit 1
     fi

--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -70,9 +70,9 @@ func (q *Query) Sanitize(args ...any) (string, error) {
 			case bool:
 				p = strconv.AppendBool(buf.AvailableBuffer(), arg)
 			case []byte:
-				p = quoteBytes(buf.AvailableBuffer(), arg)
+				p = QuoteBytes(buf.AvailableBuffer(), arg)
 			case string:
-				p = quoteString(buf.AvailableBuffer(), arg)
+				p = QuoteString(buf.AvailableBuffer(), arg)
 			case time.Time:
 				p = arg.Truncate(time.Microsecond).
 					AppendFormat(buf.AvailableBuffer(), "'2006-01-02 15:04:05.999999999Z07:00:00'")
@@ -135,11 +135,7 @@ func (q *Query) init(sql string) {
 	q.Parts = l.parts
 }
 
-func QuoteString(str string) string {
-	return string(quoteString(nil, str))
-}
-
-func quoteString(dst []byte, str string) []byte {
+func QuoteString(dst []byte, str string) []byte {
 	const quote = "'"
 
 	n := strings.Count(str, quote)
@@ -166,11 +162,7 @@ func quoteString(dst []byte, str string) []byte {
 	return dst
 }
 
-func QuoteBytes(buf []byte) string {
-	return string(quoteBytes(nil, buf))
-}
-
-func quoteBytes(dst, buf []byte) []byte {
+func QuoteBytes(dst, buf []byte) []byte {
 	dst = append(dst, `'\x`...)
 
 	n := hex.EncodedLen(len(buf))

--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -151,7 +151,7 @@ func QuoteString(dst []byte, str string) []byte {
 
 	dst = append(dst, quote...)
 
-	p := slices.Grow(dst[len(dst):], len(str)+2*n)
+	p := slices.Grow(dst[len(dst):], 2*len(quote)+len(str)+2*n)
 
 	for len(str) > 0 {
 		i := strings.Index(str, quote)

--- a/internal/sanitize/sanitize_bench_test.go
+++ b/internal/sanitize/sanitize_bench_test.go
@@ -1,0 +1,62 @@
+// sanitize_benchmark_test.go
+package sanitize_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/internal/sanitize"
+)
+
+var benchmarkSanitizeResult string
+
+const benchmarkQuery = "" +
+	`SELECT * 
+   FROM "water_containers" 
+   WHERE NOT "id" = $1			-- int64
+   AND "tags" NOT IN $2         -- nil
+   AND "volume" > $3            -- float64
+   AND "transportable" = $4     -- bool
+   AND position($5 IN "sign")   -- bytes
+   AND "label" LIKE $6          -- string
+   AND "created_at" > $7;       -- time.Time`
+
+var benchmarkArgs = []any{
+	int64(12345),
+	nil,
+	float64(500),
+	true,
+	[]byte("8BADF00D"),
+	"kombucha's han'dy awokowa",
+	time.Date(2015, 10, 1, 0, 0, 0, 0, time.UTC),
+}
+
+func BenchmarkSanitize(b *testing.B) {
+	query, err := sanitize.NewQuery(benchmarkQuery)
+	if err != nil {
+		b.Fatalf("failed to create query: %v", err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		benchmarkSanitizeResult, err = query.Sanitize(benchmarkArgs...)
+		if err != nil {
+			b.Fatalf("failed to sanitize query: %v", err)
+		}
+	}
+}
+
+var benchmarkNewSQLResult string
+
+func BenchmarkSanitizeSQL(b *testing.B) {
+	b.ReportAllocs()
+	var err error
+	for i := 0; i < b.N; i++ {
+		benchmarkNewSQLResult, err = sanitize.SanitizeSQL(benchmarkQuery, benchmarkArgs...)
+		if err != nil {
+			b.Fatalf("failed to sanitize SQL: %v", err)
+		}
+	}
+}

--- a/internal/sanitize/sanitize_fuzz_test.go
+++ b/internal/sanitize/sanitize_fuzz_test.go
@@ -7,17 +7,22 @@ import (
 )
 
 func FuzzQuoteString(f *testing.F) {
-	f.Add("")
-	f.Add("\n")
+	const prefix = "prefix"
+	f.Add("new\nline")
 	f.Add("sample text")
 	f.Add("sample q'u'o't'e's")
 	f.Add("select 'quoted $42', $1")
 
 	f.Fuzz(func(t *testing.T, input string) {
-		got := sanitize.QuoteString(nil, input)
+		got := string(sanitize.QuoteString([]byte(prefix), input))
 		want := oldQuoteString(input)
 
-		if want != string(got) {
+		quoted, ok := strings.CutPrefix(got, prefix)
+		if !ok {
+			t.Fatalf("result has no prefix")
+		}
+
+		if want != quoted {
 			t.Errorf("got  %q", got)
 			t.Fatalf("want %q", want)
 		}
@@ -25,6 +30,7 @@ func FuzzQuoteString(f *testing.F) {
 }
 
 func FuzzQuoteBytes(f *testing.F) {
+	const prefix = "prefix"
 	f.Add([]byte(nil))
 	f.Add([]byte("\n"))
 	f.Add([]byte("sample text"))
@@ -32,10 +38,15 @@ func FuzzQuoteBytes(f *testing.F) {
 	f.Add([]byte("select 'quoted $42', $1"))
 
 	f.Fuzz(func(t *testing.T, input []byte) {
-		got := sanitize.QuoteBytes(nil, input)
+		got := string(sanitize.QuoteBytes([]byte(prefix), input))
 		want := oldQuoteBytes(input)
 
-		if want != string(got) {
+		quoted, ok := strings.CutPrefix(got, prefix)
+		if !ok {
+			t.Fatalf("result has no prefix")
+		}
+
+		if want != quoted {
 			t.Errorf("got  %q", got)
 			t.Fatalf("want %q", want)
 		}

--- a/internal/sanitize/sanitize_fuzz_test.go
+++ b/internal/sanitize/sanitize_fuzz_test.go
@@ -1,0 +1,43 @@
+package sanitize_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/internal/sanitize"
+)
+
+func FuzzQuoteString(f *testing.F) {
+	f.Add("")
+	f.Add("\n")
+	f.Add("sample text")
+	f.Add("sample q'u'o't'e's")
+	f.Add("select 'quoted $42', $1")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		got := sanitize.QuoteString(input)
+		want := oldQuoteString(input)
+
+		if want != got {
+			t.Errorf("got  %q", got)
+			t.Fatalf("want %q", want)
+		}
+	})
+}
+
+func FuzzQuoteBytes(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add([]byte("\n"))
+	f.Add([]byte("sample text"))
+	f.Add([]byte("sample q'u'o't'e's"))
+	f.Add([]byte("select 'quoted $42', $1"))
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		got := sanitize.QuoteBytes(input)
+		want := oldQuoteBytes(input)
+
+		if want != got {
+			t.Errorf("got  %q", got)
+			t.Fatalf("want %q", want)
+		}
+	})
+}

--- a/internal/sanitize/sanitize_fuzz_test.go
+++ b/internal/sanitize/sanitize_fuzz_test.go
@@ -1,6 +1,7 @@
 package sanitize_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/internal/sanitize"

--- a/internal/sanitize/sanitize_fuzz_test.go
+++ b/internal/sanitize/sanitize_fuzz_test.go
@@ -14,10 +14,10 @@ func FuzzQuoteString(f *testing.F) {
 	f.Add("select 'quoted $42', $1")
 
 	f.Fuzz(func(t *testing.T, input string) {
-		got := sanitize.QuoteString(input)
+		got := sanitize.QuoteString(nil, input)
 		want := oldQuoteString(input)
 
-		if want != got {
+		if want != string(got) {
 			t.Errorf("got  %q", got)
 			t.Fatalf("want %q", want)
 		}
@@ -32,10 +32,10 @@ func FuzzQuoteBytes(f *testing.F) {
 	f.Add([]byte("select 'quoted $42', $1"))
 
 	f.Fuzz(func(t *testing.T, input []byte) {
-		got := sanitize.QuoteBytes(input)
+		got := sanitize.QuoteBytes(nil, input)
 		want := oldQuoteBytes(input)
 
-		if want != got {
+		if want != string(got) {
 			t.Errorf("got  %q", got)
 			t.Fatalf("want %q", want)
 		}

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -235,7 +235,7 @@ func TestQuoteString(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := sanitize.QuoteString(input)
+			got := string(sanitize.QuoteString(nil, input))
 			want := oldQuoteString(input)
 
 			if got != want {
@@ -259,7 +259,7 @@ func TestQuoteBytes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := sanitize.QuoteBytes(input)
+			got := string(sanitize.QuoteBytes(nil, input))
 			want := oldQuoteBytes(input)
 
 			if got != want {

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -250,6 +250,8 @@ func TestQuoteString(t *testing.T) {
 	tc("with quotes", `one's hat is always a cat`)
 }
 
+// This function was used before optimizations.
+// You should keep for testing purposes - we want to ensure there are no breaking changes.
 func oldQuoteString(str string) string {
 	return "'" + strings.ReplaceAll(str, "'", "''") + "'"
 }
@@ -274,6 +276,8 @@ func TestQuoteBytes(t *testing.T) {
 	tc("text", []byte("abcd"))
 }
 
+// This function was used before optimizations.
+// You should keep for testing purposes - we want to ensure there are no breaking changes.
 func oldQuoteBytes(buf []byte) string {
 	return `'\x` + hex.EncodeToString(buf) + "'"
 }

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -1,6 +1,7 @@
 package sanitize_test
 
 import (
+	"encoding/hex"
 	"testing"
 	"time"
 
@@ -226,4 +227,28 @@ func TestQuerySanitize(t *testing.T) {
 			t.Errorf("%d. expected error %v, got %v", i, tt.expected, err)
 		}
 	}
+}
+
+func TestQuoteBytes(t *testing.T) {
+	tc := func(name string, input []byte) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := sanitize.QuoteBytes(input)
+			want := oldQuoteBytes(input)
+
+			if got != want {
+				t.Errorf("got:  %s", got)
+				t.Fatalf("want: %s", want)
+			}
+		})
+	}
+
+	tc("nil", nil)
+	tc("empty", []byte{})
+	tc("text", []byte("abcd"))
+}
+
+func oldQuoteBytes(buf []byte) string {
+	return `'\x` + hex.EncodeToString(buf) + "'"
 }

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -2,6 +2,7 @@ package sanitize_test
 
 import (
 	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 
@@ -227,6 +228,30 @@ func TestQuerySanitize(t *testing.T) {
 			t.Errorf("%d. expected error %v, got %v", i, tt.expected, err)
 		}
 	}
+}
+
+func TestQuoteString(t *testing.T) {
+	tc := func(name, input string) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := sanitize.QuoteString(input)
+			want := oldQuoteString(input)
+
+			if got != want {
+				t.Errorf("got:  %s", got)
+				t.Fatalf("want: %s", want)
+			}
+		})
+	}
+
+	tc("empty", "")
+	tc("text", "abcd")
+	tc("with quotes", `one's hat is always a cat`)
+}
+
+func oldQuoteString(str string) string {
+	return "'" + strings.ReplaceAll(str, "'", "''") + "'"
 }
 
 func TestQuoteBytes(t *testing.T) {


### PR DESCRIPTION
https://github.com/jackc/pgx/issues/2124

Result:
<img width="863" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/c3919d9f-47d9-4bd0-9207-0bad21cc3924">

Main optimizations:
- extensive usage of `sync.Pool` for byte buffers, lexers and parsed query structs
- append-style string formatters for `int64`, `float64` and `time.Time` + `bytes.Buffer.AvailableBuffer`
- rework of `QuoteString` and `QuoteBytes` to append-style (with tests for backwards compatibility) 

Misc changes:
- benchmarks for `Query.Sanitize` and `SanitizeSQL` functions
- a tiny script for generation of benchmark reports for selected commits and diff (using [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat))
- fuzzing of `QuoteString` and `QuoteBytes` (I did'n find any problems for 1h of fuzzing, but you can never be sure for 100%)

Since optimization is an extremely hard problem, I think it's worth checking some more benchmarks.  

I would be very grateful for your opinion on this and recommendations/advice, @jackc @vtolstov 
