### PR TITLE
handling double pointer on sql.Scanner interface when scanning rows

### DIFF
--- a/pgtype/json.go
+++ b/pgtype/json.go
@@ -143,16 +143,32 @@ func (c *JSONCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanP
 	case BytesScanner:
 		return scanPlanBinaryBytesToBytesScanner{}
 
+	}
+
 	// Cannot rely on sql.Scanner being handled later because scanPlanJSONToJSONUnmarshal will take precedence.
 	//
 	// https://github.com/jackc/pgx/issues/1418
-	case sql.Scanner:
+	if isSQLScanner(target) {
 		return &scanPlanSQLScanner{formatCode: format}
 	}
 
 	return &scanPlanJSONToJSONUnmarshal{
 		unmarshal: c.Unmarshal,
 	}
+}
+
+// we need to check if the target is a pointer to a sql.Scanner (or any of the pointer ref tree implements a sql.Scanner).
+//
+// https://github.com/jackc/pgx/issues/2146
+func isSQLScanner(v any) bool {
+	val := reflect.ValueOf(v)
+	for val.Kind() == reflect.Ptr {
+		if _, ok := val.Interface().(sql.Scanner); ok {
+			return true
+		}
+		val = val.Elem()
+	}
+	return false
 }
 
 type scanPlanAnyToString struct{}

--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -396,7 +396,12 @@ type scanPlanSQLScanner struct {
 }
 
 func (plan *scanPlanSQLScanner) Scan(src []byte, dst any) error {
-	scanner := dst.(sql.Scanner)
+	scanner := getSQLScanner(dst)
+
+	if scanner == nil {
+		return fmt.Errorf("cannot scan into %T", dst)
+	}
+
 	if src == nil {
 		// This is necessary because interface value []byte:nil does not equal nil:nil for the binary format path and the
 		// text format path would be converted to empty string.
@@ -406,6 +411,21 @@ func (plan *scanPlanSQLScanner) Scan(src []byte, dst any) error {
 	} else {
 		return scanner.Scan(string(src))
 	}
+}
+
+// we don't know if the target is a sql.Scanner or a pointer on a sql.Scanner, so we need to check recursively
+func getSQLScanner(target any) sql.Scanner {
+	val := reflect.ValueOf(target)
+	for val.Kind() == reflect.Ptr {
+		if _, ok := val.Interface().(sql.Scanner); ok {
+			if val.IsNil() {
+				val.Set(reflect.New(val.Type().Elem()))
+			}
+			return val.Interface().(sql.Scanner)
+		}
+		val = val.Elem()
+	}
+	return nil
 }
 
 type scanPlanString struct{}

--- a/pgtype/pgtype_test.go
+++ b/pgtype/pgtype_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 	"regexp"
 	"strconv"
 	"testing"
@@ -629,5 +630,12 @@ func BenchmarkScanPlanScanInt4IntoGoInt32(b *testing.B) {
 func isExpectedEq(a any) func(any) bool {
 	return func(v any) bool {
 		return a == v
+	}
+}
+
+func isPtrExpectedEq(a any) func(any) bool {
+	return func(v any) bool {
+		val := reflect.ValueOf(v)
+		return a == val.Elem().Interface()
 	}
 }


### PR DESCRIPTION
fix #2146 

This PR handle the case of double pointer on sql.Scanning by reversing the pointer three until we found a sql.Scanner interface

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)
