### PR TITLE
feat: add dedicated method to extract error from errRow

### DIFF
--- a/pgxpool/rows.go
+++ b/pgxpool/rows.go
@@ -24,6 +24,7 @@ type errRow struct {
 }
 
 func (e errRow) Scan(dest ...any) error { return e.err }
+func (e errRow) Err() error             { return e.err }
 
 type poolRows struct {
 	r   pgx.Rows


### PR DESCRIPTION
Add a dedicated method to extract error from `errRow`. This is already present for `errRows`. This allows the use case to extract the error to retry if necessary. 

```
type errRow interface {
	pgx.Row
	Err() error
}

func (r *RetriableDBTX) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
	row := r.dbtx.QueryRow(ctx, sql, args...)
	if er, ok := row.(errRow); ok {
		// Custom logic to retry
	}

	return row
}
```
