### PR TITLE
Update TimestampCodec  to be equal to TextCodec for pointer reference

### DIFF
--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -122,15 +122,15 @@ type TimestampCodec struct {
 	ScanLocation *time.Location
 }
 
-func (*TimestampCodec) FormatSupported(format int16) bool {
+func (TimestampCodec) FormatSupported(format int16) bool {
 	return format == TextFormatCode || format == BinaryFormatCode
 }
 
-func (*TimestampCodec) PreferredFormat() int16 {
+func (TimestampCodec) PreferredFormat() int16 {
 	return BinaryFormatCode
 }
 
-func (*TimestampCodec) PlanEncode(m *Map, oid uint32, format int16, value any) EncodePlan {
+func (TimestampCodec) PlanEncode(m *Map, oid uint32, format int16, value any) EncodePlan {
 	if _, ok := value.(TimestampValuer); !ok {
 		return nil
 	}
@@ -224,7 +224,7 @@ func discardTimeZone(t time.Time) time.Time {
 	return t
 }
 
-func (c *TimestampCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
+func (c TimestampCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {
@@ -318,7 +318,7 @@ func (plan *scanPlanTextTimestampToTimestampScanner) Scan(src []byte, dst any) e
 	return scanner.ScanTimestamp(ts)
 }
 
-func (c *TimestampCodec) DecodeDatabaseSQLValue(m *Map, oid uint32, format int16, src []byte) (driver.Value, error) {
+func (c TimestampCodec) DecodeDatabaseSQLValue(m *Map, oid uint32, format int16, src []byte) (driver.Value, error) {
 	if src == nil {
 		return nil, nil
 	}
@@ -336,7 +336,7 @@ func (c *TimestampCodec) DecodeDatabaseSQLValue(m *Map, oid uint32, format int16
 	return ts.Time, nil
 }
 
-func (c *TimestampCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (any, error) {
+func (c TimestampCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (any, error) {
 	if src == nil {
 		return nil, nil
 	}

--- a/pgtype/timestamptz.go
+++ b/pgtype/timestamptz.go
@@ -130,15 +130,15 @@ type TimestamptzCodec struct {
 	ScanLocation *time.Location
 }
 
-func (*TimestamptzCodec) FormatSupported(format int16) bool {
+func (TimestamptzCodec) FormatSupported(format int16) bool {
 	return format == TextFormatCode || format == BinaryFormatCode
 }
 
-func (*TimestamptzCodec) PreferredFormat() int16 {
+func (TimestamptzCodec) PreferredFormat() int16 {
 	return BinaryFormatCode
 }
 
-func (*TimestamptzCodec) PlanEncode(m *Map, oid uint32, format int16, value any) EncodePlan {
+func (TimestamptzCodec) PlanEncode(m *Map, oid uint32, format int16, value any) EncodePlan {
 	if _, ok := value.(TimestamptzValuer); !ok {
 		return nil
 	}
@@ -224,7 +224,7 @@ func (encodePlanTimestamptzCodecText) Encode(value any, buf []byte) (newBuf []by
 	return buf, nil
 }
 
-func (c *TimestamptzCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
+func (c TimestamptzCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 
 	switch format {
 	case BinaryFormatCode:
@@ -329,7 +329,7 @@ func (plan *scanPlanTextTimestamptzToTimestamptzScanner) Scan(src []byte, dst an
 	return scanner.ScanTimestamptz(tstz)
 }
 
-func (c *TimestamptzCodec) DecodeDatabaseSQLValue(m *Map, oid uint32, format int16, src []byte) (driver.Value, error) {
+func (c TimestamptzCodec) DecodeDatabaseSQLValue(m *Map, oid uint32, format int16, src []byte) (driver.Value, error) {
 	if src == nil {
 		return nil, nil
 	}
@@ -347,7 +347,7 @@ func (c *TimestamptzCodec) DecodeDatabaseSQLValue(m *Map, oid uint32, format int
 	return tstz.Time, nil
 }
 
-func (c *TimestamptzCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (any, error) {
+func (c TimestamptzCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (any, error) {
 	if src == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
working with 
https://github.com/manniwood/pgx-protobuf-timestamp i receive  
`cannot use TimestampCodec{} (value of type TimestampCodec) as pgtype.Codec value in struct literal: TimestampCodec does not implement pgtype.Codec (method DecodeDatabaseSQLValue has pointer receiver)`

and i found that is because of timestamp have pointers where textecodec(athat works) dont have, this is to normalize the both

sems that is introduced in https://github.com/jackc/pgx/commit/8649231bb3bc00b4b9c180ce557a54ae41c28ce2
idk if its the better approach, but it need to be fixed for 

```
type TextCodec struct {
	pgtype.TextCodec
}


...

// TimestampCodec embeds pgtype.TimestampCodec, which implements pgtype.Codec interface
type TimestampCodec struct {
	pgtype.TimestampCodec
}


// Register registers the github.com/gofrs/uuid integration with a pgtype.Map.
func Register(tm *pgtype.Map) {
	tm.TryWrapEncodePlanFuncs = append(
		[]pgtype.TryWrapEncodePlanFunc{TryWrapTimestampEncodePlan},
		tm.TryWrapEncodePlanFuncs...)
	tm.TryWrapScanPlanFuncs = append(
		[]pgtype.TryWrapScanPlanFunc{TryWrapTimestampScanPlan},
		tm.TryWrapScanPlanFuncs...)

	tm.RegisterType(&pgtype.Type{
		Name:  "timestamp",
		OID:   pgtype.TimestampOID,
		Codec: TimestampCodec{},
	})
}
```

to work

i believe that i can overwrite some functions to make work in my side, but i think we need to set this here