### PR TITLE
Update comments in generated code to align with Go standards

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "erb"
 
 rule '.go' => '.go.erb' do |task|
   erb = ERB.new(File.read(task.source))
-  File.write(task.name, "// Do not edit. Generated from #{task.source}\n" + erb.result(binding))
+  File.write(task.name, "// Code generated from #{task.source}. DO NOT EDIT.\n\n" + erb.result(binding))
   sh "goimports", "-w", task.name
 end
 

--- a/pgtype/int.go
+++ b/pgtype/int.go
@@ -1,4 +1,5 @@
-// Do not edit. Generated from pgtype/int.go.erb
+// Code generated from pgtype/int.go.erb. DO NOT EDIT.
+
 package pgtype
 
 import (

--- a/pgtype/int_test.go
+++ b/pgtype/int_test.go
@@ -1,4 +1,5 @@
-// Do not edit. Generated from pgtype/int_test.go.erb
+// Code generated from pgtype/int_test.go.erb. DO NOT EDIT.
+
 package pgtype_test
 
 import (

--- a/pgtype/integration_benchmark_test.go
+++ b/pgtype/integration_benchmark_test.go
@@ -1,3 +1,5 @@
+// Code generated from pgtype/integration_benchmark_test.go.erb. DO NOT EDIT.
+
 package pgtype_test
 
 import (

--- a/pgtype/zeronull/int.go
+++ b/pgtype/zeronull/int.go
@@ -1,4 +1,5 @@
-// Do not edit. Generated from pgtype/zeronull/int.go.erb
+// Code generated from pgtype/zeronull/int.go.erb. DO NOT EDIT.
+
 package zeronull
 
 import (

--- a/pgtype/zeronull/int_test.go
+++ b/pgtype/zeronull/int_test.go
@@ -1,4 +1,5 @@
-// Do not edit. Generated from pgtype/zeronull/int_test.go.erb
+// Code generated from pgtype/zeronull/int_test.go.erb. DO NOT EDIT.
+
 package zeronull_test
 
 import (


### PR DESCRIPTION
This PR updates the comments in generated files to match the standard Go regular expression:

```
^// Code generated .* DO NOT EDIT\.$
```

For more information, refer to golang/go#13560 and https://go.dev/s/generatedcode.