### PR TITLE
Handle errors  in generate_certs

### DIFF
--- a/testsetup/generate_certs.go
+++ b/testsetup/generate_certs.go
@@ -106,12 +106,12 @@ func main() {
 		panic(err)
 	}
 
-	writeEncryptedPrivateKey("pgx_sslcert.key", clientCertPrivKey, "certpw")
+	err = writeEncryptedPrivateKey("pgx_sslcert.key", clientCertPrivKey, "certpw")
 	if err != nil {
 		panic(err)
 	}
 
-	writeCertificate("pgx_sslcert.crt", clientBytes)
+	err = writeCertificate("pgx_sslcert.crt", clientBytes)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR fixes handling errors from `writeEncryptedPrivateKey` and `writeCertificate` functions in `testsetup/generate_certs.go`.