### PR TITLE
Refactor Conn.LoadTypes by removing redundant check

### DIFF
--- a/derived_types.go
+++ b/derived_types.go
@@ -161,7 +161,7 @@ type derivedTypeInfo struct {
 // The result of this call can be passed into RegisterTypes to complete the process.
 func (c *Conn) LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Type, error) {
 	m := c.TypeMap()
-	if typeNames == nil || len(typeNames) == 0 {
+	if len(typeNames) == 0 {
 		return nil, fmt.Errorf("No type names were supplied.")
 	}
 
@@ -169,13 +169,7 @@ func (c *Conn) LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Typ
 	// the SQL not support recent structures such as multirange
 	serverVersion, _ := serverVersion(c)
 	sql := buildLoadDerivedTypesSQL(serverVersion, typeNames)
-	var rows Rows
-	var err error
-	if typeNames == nil {
-		rows, err = c.Query(ctx, sql, QueryExecModeSimpleProtocol)
-	} else {
-		rows, err = c.Query(ctx, sql, QueryExecModeSimpleProtocol, typeNames)
-	}
+	rows, err := c.Query(ctx, sql, QueryExecModeSimpleProtocol, typeNames)
 	if err != nil {
 		return nil, fmt.Errorf("While generating load types query: %w", err)
 	}


### PR DESCRIPTION
This PR simplifies the `Conn.LoadTypes` function:

- Omits the `typeNames == nil` check because `len(typeNames)` will be `0` for a slice if `typeNames` is `nil`.
- Omits the entire `if typeNames == nil {}` block because it is always `false` due to the check above.