### PR TITLE
Fixes for Method Comment and Typo in Test Function Name

### DIFF
--- a/pgconn/ctxwatch/context_watcher_test.go
+++ b/pgconn/ctxwatch/context_watcher_test.go
@@ -49,7 +49,7 @@ func TestContextWatcherContextCancelled(t *testing.T) {
 	require.True(t, cleanupCalled, "Cleanup func was not called")
 }
 
-func TestContextWatcherUnwatchdBeforeContextCancelled(t *testing.T) {
+func TestContextWatcherUnwatchedBeforeContextCancelled(t *testing.T) {
 	cw := ctxwatch.NewContextWatcher(&testHandler{
 		handleCancel: func(context.Context) {
 			t.Error("cancel func should not have been called")

--- a/pgproto3/password_message.go
+++ b/pgproto3/password_message.go
@@ -12,7 +12,7 @@ type PasswordMessage struct {
 // Frontend identifies this message as sendable by a PostgreSQL frontend.
 func (*PasswordMessage) Frontend() {}
 
-// Frontend identifies this message as an authentication response.
+// InitialResponse identifies this message as an authentication response.
 func (*PasswordMessage) InitialResponse() {}
 
 // Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message


### PR DESCRIPTION
This PR includes two minor fixes:

Corrects a method comment in PasswordMessage to accurately reflect its purpose.

Fixes a typo in a test function name in context_watcher_test.go.