### PR TITLE
Timestamp incorrectly adds 'Z' when serializing from JSON to indicate GMT, fixes bug #2215

### DIFF
--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -104,8 +104,13 @@ func (ts *Timestamp) UnmarshalJSON(b []byte) error {
 	case "-infinity":
 		*ts = Timestamp{Valid: true, InfinityModifier: -Infinity}
 	default:
+		tss := *s
 		// PostgreSQL uses ISO 8601 wihout timezone for to_json function and casting from a string to timestampt
-		tim, err := time.Parse(time.RFC3339Nano, *s+"Z")
+		if !strings.HasSuffix(tss, "Z") {
+			tss = tss + "Z"
+		}
+
+		tim, err := time.Parse(time.RFC3339Nano, tss)
 		if err != nil {
 			return err
 		}

--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -105,19 +105,23 @@ func (ts *Timestamp) UnmarshalJSON(b []byte) error {
 	case "-infinity":
 		*ts = Timestamp{Valid: true, InfinityModifier: -Infinity}
 	default:
+		// Parse time with or without timezonr
 		tss := *s
 		//		PostgreSQL uses ISO 8601 without timezone for to_json function and casting from a string to timestampt
-
 		tim, err := time.Parse(time.RFC3339Nano, tss)
 		if err == nil {
 			*ts = Timestamp{Time: tim, Valid: true}
+			return nil
 		}
 		tim, err = time.ParseInLocation(jsonISO8601, tss, time.UTC)
 		if err == nil {
 			*ts = Timestamp{Time: tim, Valid: true}
+			return nil
 		}
+		ts.Valid = false
+		return fmt.Errorf("cannot unmarshal %s to timestamp with layout %s or %s (%w)",
+			*s, time.RFC3339Nano, jsonISO8601, err)
 	}
-
 	return nil
 }
 

--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -105,7 +105,7 @@ func (ts *Timestamp) UnmarshalJSON(b []byte) error {
 		*ts = Timestamp{Valid: true, InfinityModifier: -Infinity}
 	default:
 		tss := *s
-		// PostgreSQL uses ISO 8601 wihout timezone for to_json function and casting from a string to timestampt
+		//		PostgreSQL uses ISO 8601 without timezone for to_json function and casting from a string to timestampt
 		if !strings.HasSuffix(tss, "Z") {
 			tss = tss + "Z"
 		}

--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -112,7 +112,7 @@ func (ts *Timestamp) UnmarshalJSON(b []byte) error {
 		if err == nil {
 			*ts = Timestamp{Time: tim, Valid: true}
 		}
-		tim, err = time.Parse(jsonISO8601, tss)
+		tim, err = time.ParseInLocation(jsonISO8601, tss, time.UTC)
 		if err == nil {
 			*ts = Timestamp{Time: tim, Valid: true}
 		}

--- a/pgtype/timestamp_test.go
+++ b/pgtype/timestamp_test.go
@@ -116,9 +116,9 @@ func TestTimestampMarshalJSON(t *testing.T) {
 		result string
 	}{
 		{source: pgtype.Timestamp{}, result: "null"},
-		{source: pgtype.Timestamp{Time: tm, Valid: true}, result: "\"2012-03-29T10:05:45Z\""},
-		{source: pgt, result: "\"2012-03-29T10:05:45Z\""},
-		{source: pgtype.Timestamp{Time: time.Date(2012, 3, 29, 10, 5, 45, 555*1000*1000, time.UTC), Valid: true}, result: "\"2012-03-29T10:05:45.555Z\""},
+		{source: pgtype.Timestamp{Time: tm, Valid: true}, result: `"2012-03-29T10:05:45"`},
+		{source: pgt, result: `"2012-03-29T10:05:45"`},
+		{source: pgtype.Timestamp{Time: time.Date(2012, 3, 29, 10, 5, 45, 555*1000*1000, time.UTC), Valid: true}, result: `"2012-03-29T10:05:45.555"`},
 		{source: pgtype.Timestamp{InfinityModifier: pgtype.Infinity, Valid: true}, result: "\"infinity\""},
 		{source: pgtype.Timestamp{InfinityModifier: pgtype.NegativeInfinity, Valid: true}, result: "\"-infinity\""},
 	}
@@ -137,6 +137,7 @@ func TestTimestampMarshalJSON(t *testing.T) {
 		t2 := tsStruct
 		err = json.Unmarshal(b, &t2)
 		assert.NoErrorf(t, err, "failed to unmarshal %v with %s", tt.source, err)
+		assert.True(t, tsStruct.TS.Time.Unix() == t2.TS.Time.Unix())
 	}
 }
 

--- a/pgtype/timestamp_test.go
+++ b/pgtype/timestamp_test.go
@@ -141,6 +141,18 @@ func TestTimestampMarshalJSON(t *testing.T) {
 	}
 }
 
+func TestTimestampUnmarshalJSONErrors(t *testing.T) {
+	tsStruct := struct {
+		TS pgtype.Timestamp `json:"ts"`
+	}{}
+	goodJson1 := []byte(`{"ts":"2012-03-29T10:05:45"}`)
+	assert.NoError(t, json.Unmarshal(goodJson1, &tsStruct))
+	goodJson2 := []byte(`{"ts":"2012-03-29T10:05:45Z"}`)
+	assert.NoError(t, json.Unmarshal(goodJson2, &tsStruct))
+	badJson := []byte(`{"ts":"2012-03-29"}`)
+	assert.Error(t, json.Unmarshal(badJson, &tsStruct))
+}
+
 func TestTimestampUnmarshalJSON(t *testing.T) {
 	successfulTests := []struct {
 		source string


### PR DESCRIPTION
Fixes https://github.com/jackc/pgx/issues/2215