### PR TITLE
Include the field name in error messages when scanning structs

### DIFF
--- a/pgtype/jsonb_test.go
+++ b/pgtype/jsonb_test.go
@@ -66,11 +66,11 @@ func TestJSONBCodecUnmarshalSQLNull(t *testing.T) {
 		// A string cannot scan a NULL.
 		str := "foobar"
 		err = conn.QueryRow(ctx, "select null::jsonb").Scan(&str)
-		require.EqualError(t, err, "can't scan into dest[0]: cannot scan NULL into *string")
+		require.EqualError(t, err, "can't scan into dest[0] (col: jsonb): cannot scan NULL into *string")
 
 		// A non-string cannot scan a NULL.
 		err = conn.QueryRow(ctx, "select null::jsonb").Scan(&n)
-		require.EqualError(t, err, "can't scan into dest[0]: cannot scan NULL into *int")
+		require.EqualError(t, err, "can't scan into dest[0] (col: jsonb): cannot scan NULL into *int")
 	})
 }
 

--- a/pgtype/xml_test.go
+++ b/pgtype/xml_test.go
@@ -79,7 +79,7 @@ func TestXMLCodecUnmarshalSQLNull(t *testing.T) {
 		// A string cannot scan a NULL.
 		str := "foobar"
 		err = conn.QueryRow(ctx, "select null::xml").Scan(&str)
-		assert.EqualError(t, err, "can't scan into dest[0]: cannot scan NULL into *string")
+		assert.EqualError(t, err, "can't scan into dest[0] (col: xml): cannot scan NULL into *string")
 	})
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -420,7 +420,7 @@ func TestConnQueryReadWrongTypeError(t *testing.T) {
 		t.Fatal("Expected Rows to have an error after an improper read but it didn't")
 	}
 
-	if rows.Err().Error() != "can't scan into dest[0]: cannot scan int4 (OID 23) in binary format into *time.Time" {
+	if rows.Err().Error() != "can't scan into dest[0] (col: n): cannot scan int4 (OID 23) in binary format into *time.Time" {
 		t.Fatalf("Expected different Rows.Err(): %v", rows.Err())
 	}
 


### PR DESCRIPTION
This is helpful when the order of the columns in the row is unknown (e.g. when issuing a `select *` query).