### PR TITLE
XMLCodec: fix DecodeValue to return a []byte

### DIFF
--- a/pgtype/pgtype_default.go
+++ b/pgtype/pgtype_default.go
@@ -91,7 +91,25 @@ func initDefaultMap() {
 	defaultMap.RegisterType(&Type{Name: "varchar", OID: VarcharOID, Codec: TextCodec{}})
 	defaultMap.RegisterType(&Type{Name: "xid", OID: XIDOID, Codec: Uint32Codec{}})
 	defaultMap.RegisterType(&Type{Name: "xid8", OID: XID8OID, Codec: Uint64Codec{}})
-	defaultMap.RegisterType(&Type{Name: "xml", OID: XMLOID, Codec: &XMLCodec{Marshal: xml.Marshal, Unmarshal: xml.Unmarshal}})
+	defaultMap.RegisterType(&Type{Name: "xml", OID: XMLOID, Codec: &XMLCodec{
+		Marshal: xml.Marshal,
+		// xml.Unmarshal does not support unmarshalling into *any. However, XMLCodec.DecodeValue calls Unmarshal with a
+		// *any. Wrap xml.Marshal with a function that copies the data into a new byte slice in this case. Not implementing
+		// directly in XMLCodec.DecodeValue to allow for the unlikely possibility that someone uses an alternative XML
+		// unmarshaler that does support unmarshalling into *any.
+		//
+		// https://github.com/jackc/pgx/issues/2227
+		// https://github.com/jackc/pgx/pull/2228
+		Unmarshal: func(data []byte, v any) error {
+			if v, ok := v.(*any); ok {
+				dstBuf := make([]byte, len(data))
+				copy(dstBuf, data)
+				*v = dstBuf
+				return nil
+			}
+			return xml.Unmarshal(data, v)
+		},
+	}})
 
 	// Range types
 	defaultMap.RegisterType(&Type{Name: "daterange", OID: DaterangeOID, Codec: &RangeCodec{ElementType: defaultMap.oidToType[DateOID]}})

--- a/pgtype/xml.go
+++ b/pgtype/xml.go
@@ -192,7 +192,7 @@ func (c *XMLCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (an
 		return nil, nil
 	}
 
-	dstBuf := make([]byte, len(src))
-	copy(dstBuf, src)
-	return dstBuf, nil
+	var dst any
+	err := c.Unmarshal(src, &dst)
+	return dst, err
 }

--- a/pgtype/xml.go
+++ b/pgtype/xml.go
@@ -192,7 +192,7 @@ func (c *XMLCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (an
 		return nil, nil
 	}
 
-	var dst any
-	err := c.Unmarshal(src, &dst)
-	return dst, err
+	dstBuf := make([]byte, len(src))
+	copy(dstBuf, src)
+	return dstBuf, nil
 }


### PR DESCRIPTION
Previously, DecodeValue would always return nil with the default Unmarshal function.

fixes https://github.com/jackc/pgx/issues/2227