### PR TITLE
added BatchExec and BatchExecTx func

### DIFF
--- a/batch_exec.go
+++ b/batch_exec.go
@@ -1,0 +1,88 @@
+package pgx
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	ErrNoSupportTxInBatchExecTx = errors.New("no support tx in batch exec transaction")
+)
+
+// BatchExec Executes queries using pgx.Batch without using an explicit transaction
+// Example:
+//
+//	pgx.BatchExec(ctx, conn, func (b *pgx.Batch){
+//		batcher.Queue("INSERT INTO users (name, email) VALUES ($1, $2)", "Alice", "alice@example.com")
+//		batcher.Queue("INSERT INTO users (name, email) VALUES ($1, $2)", "Bob", "bob@example.com")
+//	})
+//
+// OR:
+//
+//	tx, err := conn.Begin(ctx)
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	pgx.BatchExec(ctx, tx, func (b *pgx.Batch){
+//		batcher.Queue("INSERT INTO users (name, email) VALUES ($1, $2)", "Alice", "alice@example.com")
+//		batcher.Queue("INSERT INTO users (name, email) VALUES ($1, $2)", "Bob", "bob@example.com")
+//	})
+//
+//	tx.Commit() // or tx.Rollback(ctx)
+func BatchExec(
+	ctx context.Context,
+	batcher interface {
+		SendBatch(ctx context.Context, b *Batch) BatchResults
+	},
+	enrich func(b *Batch),
+) error {
+	b := &Batch{}
+
+	enrich(b)
+
+	results := batcher.SendBatch(ctx, b)
+	defer results.Close()
+
+	// Each query is checked for errors one after another.
+	// Therefore, all queries in the loop are checked.
+	// TODO: >= 1.23 use: `for range b.Len()`
+	for i := 0; i < b.Len(); i++ {
+		if _, err := results.Exec(); err != nil {
+			return err
+		}
+	}
+
+	return results.Close()
+}
+
+// BatchExecTx Executes requests with pgx.Batch using an explicit transaction.
+// The transaction is executed using `BEGIN` and `COMMIT` to use a single network request.
+//
+// CAUTION: Using pgx.Tx will not produce the expected execution result,
+// nothing will happen when tx.Rollback() is requested.
+// If pgx.Tx is passed to the function as a batcher, an ErrNoSupportTxInBatchExecTx error will be returned.
+// Example:
+//
+//	pgx.BatchExecTx(ctx, conn, func (b *pgx.Batch){
+//		batcher.Queue("INSERT INTO users (name, email) VALUES ($1, $2)", "Alice", "alice@example.com")
+//		batcher.Queue("INSERT INTO users (name, email) VALUES ($1, $2)", "Bob", "bob@example.com")
+//	})
+func BatchExecTx(
+	ctx context.Context,
+	batcher interface {
+		SendBatch(ctx context.Context, b *Batch) BatchResults
+	},
+	enrich func(b *Batch),
+) error {
+	switch batcher.(type) {
+	case Tx:
+		return ErrNoSupportTxInBatchExecTx
+	default:
+		return BatchExec(ctx, batcher, func(b *Batch) {
+			b.Queue("BEGIN;")
+			enrich(b)
+			b.Queue("COMMIT;")
+		})
+	}
+}

--- a/batch_exec_test.go
+++ b/batch_exec_test.go
@@ -1,0 +1,180 @@
+package pgx_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxtest"
+)
+
+func TestBatchExec(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		pgxtest.SkipCockroachDB(t, conn, "Server serial type is incompatible with test")
+
+		sql := `CREATE TEMPORARY TABLE ledger(
+	  id serial PRIMARY KEY,
+	  description varchar NOT NULL,
+	  amount int NOT NULL
+	);`
+		mustExec(t, conn, sql)
+
+		var (
+			batch *pgx.Batch
+			err   error
+		)
+
+		err = pgx.BatchExec(ctx, conn, func(b *pgx.Batch) {
+			b.Queue("INSERT INTO ledger(description, amount) VALUES($1, $2)", "q1", 1)
+			b.Queue("INSERT INTO ledger(description, amount) VALUES($1, $2)", "q2", 2)
+			b.Queue("INSERT INTO ledger(description, amount) VALUES($1, $2)", "q3", 3)
+
+			batch = b // For checks
+		})
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if batch.Len() != 3 {
+			t.Errorf("batch.Len()size equal %v, want %v", batch.Len(), 3)
+		}
+
+		selectFromLedgerExpectedRows := []struct {
+			id          int32
+			description string
+			amount      int32
+		}{
+			{1, "q1", 1},
+			{2, "q2", 2},
+			{3, "q3", 3},
+		}
+
+		rows, err := conn.Query(ctx, "SELECT id, description, amount FROM ledger ORDER BY id")
+		if err != nil {
+			t.Error(err)
+		}
+
+		var id int32
+		var description string
+		var amount int32
+		rowCount := 0
+
+		for rows.Next() {
+			if rowCount >= len(selectFromLedgerExpectedRows) {
+				t.Fatalf("got too many rows: %d", rowCount)
+			}
+
+			if err := rows.Scan(&id, &description, &amount); err != nil {
+				t.Fatalf("row %d: %v", rowCount, err)
+			}
+
+			if id != selectFromLedgerExpectedRows[rowCount].id {
+				t.Errorf("id => %v, want %v", id, selectFromLedgerExpectedRows[rowCount].id)
+			}
+			if description != selectFromLedgerExpectedRows[rowCount].description {
+				t.Errorf("description => %v, want %v", description, selectFromLedgerExpectedRows[rowCount].description)
+			}
+			if amount != selectFromLedgerExpectedRows[rowCount].amount {
+				t.Errorf("amount => %v, want %v", amount, selectFromLedgerExpectedRows[rowCount].amount)
+			}
+
+			rowCount++
+		}
+
+		if rows.Err() != nil {
+			t.Fatal(rows.Err())
+		}
+	})
+}
+
+func TestBatchExecTx(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		pgxtest.SkipCockroachDB(t, conn, "Server serial type is incompatible with test")
+
+		sql := `CREATE TEMPORARY TABLE ledger(
+	  id serial PRIMARY KEY,
+	  description varchar NOT NULL,
+	  amount int NOT NULL
+	);`
+		mustExec(t, conn, sql)
+
+		var (
+			batch *pgx.Batch
+			err   error
+		)
+
+		err = pgx.BatchExecTx(ctx, conn, func(b *pgx.Batch) {
+			b.Queue("INSERT INTO ledger(description, amount) VALUES($1, $2)", "q1", 1)
+			b.Queue("INSERT INTO ledger(description, amount) VALUES($1, $2)", "q2", 2)
+			b.Queue("INSERT INTO ledger(description, amount) VALUES($1, $2)", "q3", 3)
+
+			batch = b // For checks
+		})
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if batch.Len() != 3 {
+			t.Errorf("batch.Len()size equal %v, want %v", batch.Len(), 3)
+		}
+
+		selectFromLedgerExpectedRows := []struct {
+			id          int32
+			description string
+			amount      int32
+		}{
+			{1, "q1", 1},
+			{2, "q2", 2},
+			{3, "q3", 3},
+		}
+
+		rows, err := conn.Query(ctx, "SELECT id, description, amount FROM ledger ORDER BY id")
+		if err != nil {
+			t.Error(err)
+		}
+
+		var id int32
+		var description string
+		var amount int32
+		rowCount := 0
+
+		for rows.Next() {
+			if rowCount >= len(selectFromLedgerExpectedRows) {
+				t.Fatalf("got too many rows: %d", rowCount)
+			}
+
+			if err := rows.Scan(&id, &description, &amount); err != nil {
+				t.Fatalf("row %d: %v", rowCount, err)
+			}
+
+			if id != selectFromLedgerExpectedRows[rowCount].id {
+				t.Errorf("id => %v, want %v", id, selectFromLedgerExpectedRows[rowCount].id)
+			}
+			if description != selectFromLedgerExpectedRows[rowCount].description {
+				t.Errorf("description => %v, want %v", description, selectFromLedgerExpectedRows[rowCount].description)
+			}
+			if amount != selectFromLedgerExpectedRows[rowCount].amount {
+				t.Errorf("amount => %v, want %v", amount, selectFromLedgerExpectedRows[rowCount].amount)
+			}
+
+			rowCount++
+		}
+
+		if rows.Err() != nil {
+			t.Fatal(rows.Err())
+		}
+	})
+}


### PR DESCRIPTION
Hey, everybody!
I decided to add 2 new functions to simplify working with pgx.Batch{}. 
One can be executed with both pgx.Conn and pgx.Tx. The second one is executed only with pgx.Conn, but specifies the transaction explicitly.