### PR TITLE
Fix args memory leak in rows.Close()

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -188,6 +188,8 @@ func (rows *baseRows) Close() {
 	} else if rows.queryTracer != nil {
 		rows.queryTracer.TraceQueryEnd(rows.ctx, rows.conn, TraceQueryEndData{rows.commandTag, rows.err})
 	}
+
+	rows.args = nil
 }
 
 func (rows *baseRows) CommandTag() pgconn.CommandTag {


### PR DESCRIPTION
Hello,
I have found the memory leak in rows.Close() method. Please check it out.

The code for reproduction is available here: https://github.com/hrubymar10/pgx-memory-leak-test/tree/master

heap pprof before fix:
<img width="1454" alt="Screenshot 2025-03-04 at 11 28 20" src="https://github.com/user-attachments/assets/fde25853-45c7-47ca-a3bf-22c5872cd06f" />

heap pprof after fix:
<img width="1454" alt="Screenshot 2025-03-04 at 11 36 50" src="https://github.com/user-attachments/assets/acb05f62-11bf-4ad8-aa8d-7eed02f3dd3b" />

pprof files:
[heap.pb.zip](https://github.com/user-attachments/files/19068991/heap.pb.zip)
[heap_fixed.pb.zip](https://github.com/user-attachments/files/19068989/heap_fixed.pb.zip)