### PR TITLE
feat: add support for direct sslnegotiation

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	KerberosSpn     string
 	Fallbacks       []*FallbackConfig
 
-	Sslnegotiation string // sslnegotiation=postgres or sslnegotiation=direct
+	SSLnegotiation string // sslnegotiation=postgres or sslnegotiation=direct
 
 	// ValidateConnect is called during a connection attempt after a successful authentication with the PostgreSQL server.
 	// It can be used to validate that the server is acceptable. If this returns an error the connection is closed and the next
@@ -389,7 +389,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 	config.Port = fallbacks[0].Port
 	config.TLSConfig = fallbacks[0].TLSConfig
 	config.Fallbacks = fallbacks[1:]
-	config.Sslnegotiation = settings["sslnegotiation"]
+	config.SSLnegotiation = settings["sslnegotiation"]
 
 	passfile, err := pgpassfile.ReadPassfile(settings["passfile"])
 	if err == nil {

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -51,6 +51,8 @@ type Config struct {
 	KerberosSpn     string
 	Fallbacks       []*FallbackConfig
 
+	Sslnegotiation string // sslnegotiation=postgres or sslnegotiation=direct
+
 	// ValidateConnect is called during a connection attempt after a successful authentication with the PostgreSQL server.
 	// It can be used to validate that the server is acceptable. If this returns an error the connection is closed and the next
 	// fallback config is tried. This allows implementing high availability behavior such as libpq does with target_session_attrs.
@@ -318,6 +320,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 		"sslkey":               {},
 		"sslcert":              {},
 		"sslrootcert":          {},
+		"sslnegotiation":       {},
 		"sslpassword":          {},
 		"sslsni":               {},
 		"krbspn":               {},
@@ -386,6 +389,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 	config.Port = fallbacks[0].Port
 	config.TLSConfig = fallbacks[0].TLSConfig
 	config.Fallbacks = fallbacks[1:]
+	config.Sslnegotiation = settings["sslnegotiation"]
 
 	passfile, err := pgpassfile.ReadPassfile(settings["passfile"])
 	if err == nil {
@@ -449,6 +453,7 @@ func parseEnvSettings() map[string]string {
 		"PGSSLSNI":             "sslsni",
 		"PGSSLROOTCERT":        "sslrootcert",
 		"PGSSLPASSWORD":        "sslpassword",
+		"PGSSLNEGOTIATION":     "sslnegotiation",
 		"PGTARGETSESSIONATTRS": "target_session_attrs",
 		"PGSERVICE":            "service",
 		"PGSERVICEFILE":        "servicefile",
@@ -646,6 +651,7 @@ func configTLS(settings map[string]string, thisHost string, parseConfigOptions P
 	sslkey := settings["sslkey"]
 	sslpassword := settings["sslpassword"]
 	sslsni := settings["sslsni"]
+	sslnegotiation := settings["sslnegotiation"]
 
 	// Match libpq default behavior
 	if sslmode == "" {
@@ -656,6 +662,11 @@ func configTLS(settings map[string]string, thisHost string, parseConfigOptions P
 	}
 
 	tlsConfig := &tls.Config{}
+
+	if sslnegotiation == "direct" {
+		tlsConfig.NextProtos = []string{"postgresql"}
+		sslmode = "require"
+	}
 
 	if sslrootcert != "" {
 		var caCertPool *x509.CertPool

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -665,7 +665,9 @@ func configTLS(settings map[string]string, thisHost string, parseConfigOptions P
 
 	if sslnegotiation == "direct" {
 		tlsConfig.NextProtos = []string{"postgresql"}
-		sslmode = "require"
+		if sslmode == "prefer" {
+			sslmode = "require"
+		}
 	}
 
 	if sslrootcert != "" {

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	KerberosSpn     string
 	Fallbacks       []*FallbackConfig
 
-	SSLnegotiation string // sslnegotiation=postgres or sslnegotiation=direct
+	SSLNegotiation string // sslnegotiation=postgres or sslnegotiation=direct
 
 	// ValidateConnect is called during a connection attempt after a successful authentication with the PostgreSQL server.
 	// It can be used to validate that the server is acceptable. If this returns an error the connection is closed and the next
@@ -389,7 +389,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 	config.Port = fallbacks[0].Port
 	config.TLSConfig = fallbacks[0].TLSConfig
 	config.Fallbacks = fallbacks[1:]
-	config.SSLnegotiation = settings["sslnegotiation"]
+	config.SSLNegotiation = settings["sslnegotiation"]
 
 	passfile, err := pgpassfile.ReadPassfile(settings["passfile"])
 	if err == nil {

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -325,7 +325,15 @@ func connectOne(ctx context.Context, config *Config, connectConfig *connectOneCo
 	if connectConfig.tlsConfig != nil {
 		pgConn.contextWatcher = ctxwatch.NewContextWatcher(&DeadlineContextWatcherHandler{Conn: pgConn.conn})
 		pgConn.contextWatcher.Watch(ctx)
-		tlsConn, err := startTLS(pgConn.conn, connectConfig.tlsConfig)
+		var (
+			tlsConn net.Conn
+			err     error
+		)
+		if config.Sslnegotiation == "direct" {
+			tlsConn = tls.Client(pgConn.conn, connectConfig.tlsConfig)
+		} else {
+			tlsConn, err = startTLS(pgConn.conn, connectConfig.tlsConfig)
+		}
 		pgConn.contextWatcher.Unwatch() // Always unwatch `netConn` after TLS.
 		if err != nil {
 			pgConn.conn.Close()

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -329,7 +329,7 @@ func connectOne(ctx context.Context, config *Config, connectConfig *connectOneCo
 			tlsConn net.Conn
 			err     error
 		)
-		if config.Sslnegotiation == "direct" {
+		if config.SSLnegotiation == "direct" {
 			tlsConn = tls.Client(pgConn.conn, connectConfig.tlsConfig)
 		} else {
 			tlsConn, err = startTLS(pgConn.conn, connectConfig.tlsConfig)

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -329,7 +329,7 @@ func connectOne(ctx context.Context, config *Config, connectConfig *connectOneCo
 			tlsConn net.Conn
 			err     error
 		)
-		if config.SSLnegotiation == "direct" {
+		if config.SSLNegotiation == "direct" {
 			tlsConn = tls.Client(pgConn.conn, connectConfig.tlsConfig)
 		} else {
 			tlsConn, err = startTLS(pgConn.conn, connectConfig.tlsConfig)


### PR DESCRIPTION
Add support for direct ssl negotiation which was introduced in postgres 17.

https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION

