### PR TITLE
Implement AcquireTracer and ReleaseTracer for TraceLog

### DIFF
--- a/tracelog/tracelog.go
+++ b/tracelog/tracelog.go
@@ -375,16 +375,16 @@ func (tl *TraceLog) TraceAcquireEnd(ctx context.Context, _ *pgxpool.Pool, data p
 	}
 
 	if data.Conn != nil {
-		if tl.shouldLog(LogLevelInfo) {
-			tl.log(ctx, data.Conn, LogLevelInfo, "Acquire", map[string]any{tl.Config.TimeKey: interval})
+		if tl.shouldLog(LogLevelDebug) {
+			tl.log(ctx, data.Conn, LogLevelDebug, "Acquire", map[string]any{tl.Config.TimeKey: interval})
 		}
 	}
 }
 
 func (tl *TraceLog) TraceRelease(_ *pgxpool.Pool, data pgxpool.TraceReleaseData) {
-	if tl.shouldLog(LogLevelInfo) {
+	if tl.shouldLog(LogLevelDebug) {
 		// there is no context on the TraceRelease callback
-		tl.log(context.Background(), data.Conn, LogLevelInfo, "Release", map[string]any{})
+		tl.log(context.Background(), data.Conn, LogLevelDebug, "Release", map[string]any{})
 	}
 }
 

--- a/tracelog/tracelog.go
+++ b/tracelog/tracelog.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // LogLevel represents the pgx logging level. See LogLevel* constants for
@@ -103,7 +104,7 @@ func logQueryArgs(args []any) []any {
 			}
 		case string:
 			if len(v) > 64 {
-				var l int = 0
+				var l = 0
 				for w := 0; l < 64; l += w {
 					_, w = utf8.DecodeRuneInString(v[l:])
 				}
@@ -130,8 +131,9 @@ func DefaultTraceLogConfig() *TraceLogConfig {
 	}
 }
 
-// TraceLog implements pgx.QueryTracer, pgx.BatchTracer, pgx.ConnectTracer, and pgx.CopyFromTracer. Logger and LogLevel
-// are required. Config will be automatically initialized on first use if nil.
+// TraceLog implements pgx.QueryTracer, pgx.BatchTracer, pgx.ConnectTracer, pgx.CopyFromTracer, pgxpool.AcquireTracer,
+// and pgxpool.ReleaseTracer. Logger and LogLevel are required. Config will be automatically initialized on the
+// first use if nil.
 type TraceLog struct {
 	Logger   Logger
 	LogLevel LogLevel
@@ -160,6 +162,7 @@ const (
 	tracelogCopyFromCtxKey
 	tracelogConnectCtxKey
 	tracelogPrepareCtxKey
+	tracelogAcquireCtxKey
 )
 
 type traceQueryData struct {
@@ -344,6 +347,44 @@ func (tl *TraceLog) TracePrepareEnd(ctx context.Context, conn *pgx.Conn, data pg
 
 	if tl.shouldLog(LogLevelInfo) {
 		tl.log(ctx, conn, LogLevelInfo, "Prepare", map[string]any{"name": prepareData.name, "sql": prepareData.sql, tl.Config.TimeKey: interval, "alreadyPrepared": data.AlreadyPrepared})
+	}
+}
+
+type traceAcquireData struct {
+	startTime time.Time
+}
+
+func (tl *TraceLog) TraceAcquireStart(ctx context.Context, _ *pgxpool.Pool, _ pgxpool.TraceAcquireStartData) context.Context {
+	return context.WithValue(ctx, tracelogAcquireCtxKey, &traceAcquireData{
+		startTime: time.Now(),
+	})
+}
+
+func (tl *TraceLog) TraceAcquireEnd(ctx context.Context, _ *pgxpool.Pool, data pgxpool.TraceAcquireEndData) {
+	tl.ensureConfig()
+	acquireData := ctx.Value(tracelogAcquireCtxKey).(*traceAcquireData)
+
+	endTime := time.Now()
+	interval := endTime.Sub(acquireData.startTime)
+
+	if data.Err != nil {
+		if tl.shouldLog(LogLevelError) {
+			tl.Logger.Log(ctx, LogLevelError, "Acquire", map[string]any{"err": data.Err, tl.Config.TimeKey: interval})
+		}
+		return
+	}
+
+	if data.Conn != nil {
+		if tl.shouldLog(LogLevelInfo) {
+			tl.log(ctx, data.Conn, LogLevelInfo, "Acquire", map[string]any{tl.Config.TimeKey: interval})
+		}
+	}
+}
+
+func (tl *TraceLog) TraceRelease(_ *pgxpool.Pool, data pgxpool.TraceReleaseData) {
+	if tl.shouldLog(LogLevelInfo) {
+		// there is no context on the TraceRelease callback
+		tl.log(context.Background(), data.Conn, LogLevelInfo, "Release", map[string]any{})
 	}
 }
 

--- a/tracelog/tracelog_test.go
+++ b/tracelog/tracelog_test.go
@@ -433,7 +433,7 @@ func TestLogAcquire(t *testing.T) {
 	defer conn1.Release()
 	require.Len(t, logger.logs, 2) // Has both the Connect and Acquire logs
 	require.Equal(t, "Acquire", logger.logs[1].msg)
-	require.Equal(t, tracelog.LogLevelInfo, logger.logs[1].lvl)
+	require.Equal(t, tracelog.LogLevelDebug, logger.logs[1].lvl)
 
 	logger.Clear()
 
@@ -484,7 +484,7 @@ func TestLogRelease(t *testing.T) {
 	conn1.Release()
 	require.Len(t, logger.logs, 1)
 	require.Equal(t, "Release", logger.logs[0].msg)
-	require.Equal(t, tracelog.LogLevelInfo, logger.logs[0].lvl)
+	require.Equal(t, tracelog.LogLevelDebug, logger.logs[0].lvl)
 }
 
 func TestLogPrepare(t *testing.T) {

--- a/tracelog/tracelog_test.go
+++ b/tracelog/tracelog_test.go
@@ -405,6 +405,88 @@ func TestLogBatchStatementsOnBatchResultClose(t *testing.T) {
 	})
 }
 
+func TestLogAcquire(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	logger := &testLogger{}
+	tracer := &tracelog.TraceLog{
+		Logger:   logger,
+		LogLevel: tracelog.LogLevelTrace,
+	}
+
+	config := defaultConnTestRunner.CreateConfig(ctx, t)
+	config.Tracer = tracer
+
+	poolConfig, err := pgxpool.ParseConfig(config.ConnString())
+	require.NoError(t, err)
+
+	poolConfig.ConnConfig = config
+	pool1, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	require.NoError(t, err)
+	defer pool1.Close()
+
+	conn1, err := pool1.Acquire(ctx)
+	require.NoError(t, err)
+	defer conn1.Release()
+	require.Len(t, logger.logs, 2) // Has both the Connect and Acquire logs
+	require.Equal(t, "Acquire", logger.logs[1].msg)
+	require.Equal(t, tracelog.LogLevelInfo, logger.logs[1].lvl)
+
+	logger.Clear()
+
+	// create a 2nd pool with a bad host to verify the error handling
+	poolConfig, err = pgxpool.ParseConfig("host=/invalid")
+	require.NoError(t, err)
+	poolConfig.ConnConfig.Tracer = tracer
+
+	pool2, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	require.NoError(t, err)
+	defer pool2.Close()
+
+	conn2, err := pool2.Acquire(ctx)
+	require.Error(t, err)
+	require.Nil(t, conn2)
+	require.Len(t, logger.logs, 2)
+	require.Equal(t, "Acquire", logger.logs[1].msg)
+	require.Equal(t, tracelog.LogLevelError, logger.logs[1].lvl)
+}
+
+func TestLogRelease(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	logger := &testLogger{}
+	tracer := &tracelog.TraceLog{
+		Logger:   logger,
+		LogLevel: tracelog.LogLevelTrace,
+	}
+
+	config := defaultConnTestRunner.CreateConfig(ctx, t)
+	config.Tracer = tracer
+
+	poolConfig, err := pgxpool.ParseConfig(config.ConnString())
+	require.NoError(t, err)
+
+	poolConfig.ConnConfig = config
+	pool1, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	require.NoError(t, err)
+	defer pool1.Close()
+
+	conn1, err := pool1.Acquire(ctx)
+	require.NoError(t, err)
+
+	logger.Clear()
+	conn1.Release()
+	require.Len(t, logger.logs, 1)
+	require.Equal(t, "Release", logger.logs[0].msg)
+	require.Equal(t, tracelog.LogLevelInfo, logger.logs[0].lvl)
+}
+
 func TestLogPrepare(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- `TraceLog` now implements the `pgxpool.AcquireTracer` and `pgxpool.ReleaseTracer` interfaces to log connection pool interactions.