### PR TITLE
Use `ParseConfigError` in `pgx.ParseConfig` and `pgxpool.ParseConfig`

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -172,7 +172,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 		delete(config.RuntimeParams, "statement_cache_capacity")
 		n, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse statement_cache_capacity: %w", err)
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse statement_cache_capacity", err)
 		}
 		statementCacheCapacity = int(n)
 	}
@@ -182,7 +182,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 		delete(config.RuntimeParams, "description_cache_capacity")
 		n, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse description_cache_capacity: %w", err)
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse description_cache_capacity", err)
 		}
 		descriptionCacheCapacity = int(n)
 	}
@@ -202,7 +202,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 		case "simple_protocol":
 			defaultQueryExecMode = QueryExecModeSimpleProtocol
 		default:
-			return nil, fmt.Errorf("invalid default_query_exec_mode: %s", s)
+			return nil, pgconn.NewParseConfigError(connString, "invalid default_query_exec_mode", err)
 		}
 	}
 

--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -112,6 +112,14 @@ type ParseConfigError struct {
 	err        error
 }
 
+func NewParseConfigError(conn, msg string, err error) error {
+	return &ParseConfigError{
+		ConnString: conn,
+		msg:        msg,
+		err:        err,
+	}
+}
+
 func (e *ParseConfigError) Error() string {
 	// Now that ParseConfigError is public and ConnString is available to the developer, perhaps it would be better only
 	// return a static string. That would ensure that the error message cannot leak a password. The ConnString field would

--- a/pgconn/export_test.go
+++ b/pgconn/export_test.go
@@ -1,11 +1,3 @@
 // File export_test exports some methods for better testing.
 
 package pgconn
-
-func NewParseConfigError(conn, msg string, err error) error {
-	return &ParseConfigError{
-		ConnString: conn,
-		msg:        msg,
-		err:        err,
-	}
-}

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -321,10 +321,10 @@ func ParseConfig(connString string) (*Config, error) {
 		delete(connConfig.Config.RuntimeParams, "pool_max_conns")
 		n, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse pool_max_conns: %w", err)
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse pool_max_conns", err)
 		}
 		if n < 1 {
-			return nil, fmt.Errorf("pool_max_conns too small: %d", n)
+			return nil, pgconn.NewParseConfigError(connString, "pool_max_conns too small", err)
 		}
 		config.MaxConns = int32(n)
 	} else {
@@ -338,7 +338,7 @@ func ParseConfig(connString string) (*Config, error) {
 		delete(connConfig.Config.RuntimeParams, "pool_min_conns")
 		n, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse pool_min_conns: %w", err)
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse pool_min_conns", err)
 		}
 		config.MinConns = int32(n)
 	} else {
@@ -349,7 +349,7 @@ func ParseConfig(connString string) (*Config, error) {
 		delete(connConfig.Config.RuntimeParams, "pool_min_idle_conns")
 		n, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse pool_min_idle_conns: %w", err)
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse pool_min_idle_conns", err)
 		}
 		config.MinIdleConns = int32(n)
 	} else {
@@ -360,7 +360,7 @@ func ParseConfig(connString string) (*Config, error) {
 		delete(connConfig.Config.RuntimeParams, "pool_max_conn_lifetime")
 		d, err := time.ParseDuration(s)
 		if err != nil {
-			return nil, fmt.Errorf("invalid pool_max_conn_lifetime: %w", err)
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse pool_max_conn_lifetime", err)
 		}
 		config.MaxConnLifetime = d
 	} else {
@@ -371,7 +371,7 @@ func ParseConfig(connString string) (*Config, error) {
 		delete(connConfig.Config.RuntimeParams, "pool_max_conn_idle_time")
 		d, err := time.ParseDuration(s)
 		if err != nil {
-			return nil, fmt.Errorf("invalid pool_max_conn_idle_time: %w", err)
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse pool_max_conn_idle_time", err)
 		}
 		config.MaxConnIdleTime = d
 	} else {
@@ -382,7 +382,7 @@ func ParseConfig(connString string) (*Config, error) {
 		delete(connConfig.Config.RuntimeParams, "pool_health_check_period")
 		d, err := time.ParseDuration(s)
 		if err != nil {
-			return nil, fmt.Errorf("invalid pool_health_check_period: %w", err)
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse pool_health_check_period", err)
 		}
 		config.HealthCheckPeriod = d
 	} else {
@@ -393,7 +393,7 @@ func ParseConfig(connString string) (*Config, error) {
 		delete(connConfig.Config.RuntimeParams, "pool_max_conn_lifetime_jitter")
 		d, err := time.ParseDuration(s)
 		if err != nil {
-			return nil, fmt.Errorf("invalid pool_max_conn_lifetime_jitter: %w", err)
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse pool_max_conn_lifetime_jitter", err)
 		}
 		config.MaxConnLifetimeJitter = d
 	}

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -2,7 +2,6 @@ package pgxpool
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"runtime"
 	"strconv"


### PR DESCRIPTION
The `ParseConfig` functions in the `pgx` and `pgxpool` packages currently do not use the `pgconn.ParseConfigError` type for errors they return.
This PR updates them to correctly use `pgconn.ParseConfigError`.