### PR TITLE
fix documentation links

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -179,7 +179,7 @@ func NetworkAddress(host string, port uint16) (network, address string) {
 //
 // ParseConfig supports specifying multiple hosts in similar manner to libpq. Host and port may include comma separated
 // values that will be tried in order. This can be used as part of a high availability system. See
-// https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS for more information.
+// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS for more information.
 //
 //	# Example URL
 //	postgres://jack:secret@foo.example.com:5432,bar.example.com:5432/mydb
@@ -206,9 +206,9 @@ func NetworkAddress(host string, port uint16) (network, address string) {
 //	PGTARGETSESSIONATTRS
 //	PGTZ
 //
-// See http://www.postgresql.org/docs/11/static/libpq-envars.html for details on the meaning of environment variables.
+// See http://www.postgresql.org/docs/current/static/libpq-envars.html for details on the meaning of environment variables.
 //
-// See https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-PARAMKEYWORDS for parameter key word names. They are
+// See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS for parameter key word names. They are
 // usually but not always the environment variable name downcased and without the "PG" prefix.
 //
 // Important Security Notes:
@@ -216,7 +216,7 @@ func NetworkAddress(host string, port uint16) (network, address string) {
 // ParseConfig tries to match libpq behavior with regard to PGSSLMODE. This includes defaulting to "prefer" behavior if
 // not set.
 //
-// See http://www.postgresql.org/docs/11/static/libpq-ssl.html#LIBPQ-SSL-PROTECTION for details on what level of
+// See http://www.postgresql.org/docs/current/static/libpq-ssl.html#LIBPQ-SSL-PROTECTION for details on what level of
 // security each sslmode provides.
 //
 // The sslmode "prefer" (the default), sslmode "allow", and multiple hosts are implemented via the Fallbacks field of
@@ -713,7 +713,7 @@ func configTLS(settings map[string]string, thisHost string, parseConfigOptions P
 		// According to PostgreSQL documentation, if a root CA file exists,
 		// the behavior of sslmode=require should be the same as that of verify-ca
 		//
-		// See https://www.postgresql.org/docs/12/libpq-ssl.html
+		// See https://www.postgresql.org/docs/current/libpq-ssl.html
 		if sslrootcert != "" {
 			goto nextCase
 		}

--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -27,7 +27,7 @@ func Timeout(err error) bool {
 }
 
 // PgError represents an error reported by the PostgreSQL server. See
-// http://www.postgresql.org/docs/11/static/protocol-error-fields.html for
+// http://www.postgresql.org/docs/current/static/protocol-error-fields.html for
 // detailed field description.
 type PgError struct {
 	Severity            string

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -135,7 +135,7 @@ func ConnectWithOptions(ctx context.Context, connString string, parseConfigOptio
 //
 // If config.Fallbacks are present they will sequentially be tried in case of error establishing network connection. An
 // authentication error will terminate the chain of attempts (like libpq:
-// https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS) and be returned as the error.
+// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS) and be returned as the error.
 func ConnectConfig(ctx context.Context, config *Config) (*PgConn, error) {
 	// Default values are set in ParseConfig. Enforce initial creation by ParseConfig rather than setting defaults from
 	// zero values.
@@ -991,7 +991,8 @@ func noticeResponseToNotice(msg *pgproto3.NoticeResponse) *Notice {
 
 // CancelRequest sends a cancel request to the PostgreSQL server. It returns an error if unable to deliver the cancel
 // request, but lack of an error does not ensure that the query was canceled. As specified in the documentation, there
-// is no way to be sure a query was canceled. See https://www.postgresql.org/docs/11/protocol-flow.html#id-1.10.5.7.9
+// is no way to be sure a query was canceled.
+// See https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-CANCELING-REQUESTS
 func (pgConn *PgConn) CancelRequest(ctx context.Context) error {
 	// Open a cancellation request to the same server. The address is taken from the net.Conn directly instead of reusing
 	// the connection config. This is important in high availability configurations where fallback connections may be

--- a/pgtype/bool.go
+++ b/pgtype/bool.go
@@ -328,7 +328,7 @@ func (scanPlanTextAnyToBoolScanner) Scan(src []byte, dst any) error {
 	return s.ScanBool(Bool{Bool: v, Valid: true})
 }
 
-// https://www.postgresql.org/docs/11/datatype-boolean.html
+// https://www.postgresql.org/docs/current/datatype-boolean.html
 func planTextToBool(src []byte) (bool, error) {
 	s := string(bytes.ToLower(bytes.TrimSpace(src)))
 


### PR DESCRIPTION
replace documentation links to [outdated PostgreSQL versions](https://www.postgresql.org/support/versioning/) with version agnostic `current` links