### PR TITLE
Add AcquireTimeout to Pool

### DIFF
--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -94,6 +94,7 @@ type Pool struct {
 	maxConnLifetimeJitter time.Duration
 	maxConnIdleTime       time.Duration
 	healthCheckPeriod     time.Duration
+	acquireTimeout        time.Duration
 
 	healthCheckChan chan struct{}
 
@@ -170,6 +171,9 @@ type Config struct {
 	// HealthCheckPeriod is the duration between checks of the health of idle connections.
 	HealthCheckPeriod time.Duration
 
+	// AcquireTimeout is the timeout for acquiring a connection from the pool
+	AcquireTimeout time.Duration
+
 	createdByParseConfig bool // Used to enforce created by ParseConfig rule.
 }
 
@@ -225,6 +229,7 @@ func NewWithConfig(ctx context.Context, config *Config) (*Pool, error) {
 		maxConnLifetimeJitter: config.MaxConnLifetimeJitter,
 		maxConnIdleTime:       config.MaxConnIdleTime,
 		healthCheckPeriod:     config.HealthCheckPeriod,
+		acquireTimeout:        config.AcquireTimeout,
 		healthCheckChan:       make(chan struct{}, 1),
 		closeChan:             make(chan struct{}),
 	}
@@ -564,6 +569,12 @@ func (p *Pool) Acquire(ctx context.Context) (c *Conn, err error) {
 			}
 			p.acquireTracer.TraceAcquireEnd(ctx, p, TraceAcquireEndData{Conn: conn, Err: err})
 		}()
+	}
+
+	if p.acquireTimeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, p.acquireTimeout)
+		defer cancel()
 	}
 
 	// Try to acquire from the connection pool up to maxConns + 1 times, so that


### PR DESCRIPTION
Adds a timeout for acquiring a free connection from the connection pool.

This existed in previous versions of PGX: https://github.com/jackc/pgx/blob/v2/conn_pool.go#L29.

This is useful for cases where queries may be slow, but acquiring a connection from the pool is expected to be fast, and it is desirable for requests to fail fast if the connection pool is starved. This is possible today by manually calling `Acquire()` for every query and passing a context with a shorter timeout, but there is no way to configure a separate timeout for `Acquire()` when using the `Query()`, `QueryRow()`, `Exec()`, etc. helper functions on Pool.