### PR TITLE
Ensure zeronull int types implement Int64Scanner

### DIFF
--- a/pgtype/zeronull/int.go
+++ b/pgtype/zeronull/int.go
@@ -15,19 +15,19 @@ type Int2 int16
 func (Int2) SkipUnderlyingTypePlan() {}
 
 // ScanInt64 implements the Int64Scanner interface.
-func (dst *Int2) ScanInt64(n int64, valid bool) error {
-	if !valid {
+func (dst *Int2) ScanInt64(n pgtype.Int8) error {
+	if !n.Valid {
 		*dst = 0
 		return nil
 	}
 
-	if n < math.MinInt16 {
-		return fmt.Errorf("%d is greater than maximum value for Int2", n)
+	if n.Int64 < math.MinInt16 {
+		return fmt.Errorf("%d is less than minimum value for Int2", n.Int64)
 	}
-	if n > math.MaxInt16 {
-		return fmt.Errorf("%d is greater than maximum value for Int2", n)
+	if n.Int64 > math.MaxInt16 {
+		return fmt.Errorf("%d is greater than maximum value for Int2", n.Int64)
 	}
-	*dst = Int2(n)
+	*dst = Int2(n.Int64)
 
 	return nil
 }
@@ -63,19 +63,19 @@ type Int4 int32
 func (Int4) SkipUnderlyingTypePlan() {}
 
 // ScanInt64 implements the Int64Scanner interface.
-func (dst *Int4) ScanInt64(n int64, valid bool) error {
-	if !valid {
+func (dst *Int4) ScanInt64(n pgtype.Int8) error {
+	if !n.Valid {
 		*dst = 0
 		return nil
 	}
 
-	if n < math.MinInt32 {
-		return fmt.Errorf("%d is greater than maximum value for Int4", n)
+	if n.Int64 < math.MinInt32 {
+		return fmt.Errorf("%d is less than minimum value for Int4", n.Int64)
 	}
-	if n > math.MaxInt32 {
-		return fmt.Errorf("%d is greater than maximum value for Int4", n)
+	if n.Int64 > math.MaxInt32 {
+		return fmt.Errorf("%d is greater than maximum value for Int4", n.Int64)
 	}
-	*dst = Int4(n)
+	*dst = Int4(n.Int64)
 
 	return nil
 }
@@ -111,19 +111,19 @@ type Int8 int64
 func (Int8) SkipUnderlyingTypePlan() {}
 
 // ScanInt64 implements the Int64Scanner interface.
-func (dst *Int8) ScanInt64(n int64, valid bool) error {
-	if !valid {
+func (dst *Int8) ScanInt64(n pgtype.Int8) error {
+	if !n.Valid {
 		*dst = 0
 		return nil
 	}
 
-	if n < math.MinInt64 {
-		return fmt.Errorf("%d is greater than maximum value for Int8", n)
+	if n.Int64 < math.MinInt64 {
+		return fmt.Errorf("%d is less than minimum value for Int8", n.Int64)
 	}
-	if n > math.MaxInt64 {
-		return fmt.Errorf("%d is greater than maximum value for Int8", n)
+	if n.Int64 > math.MaxInt64 {
+		return fmt.Errorf("%d is greater than maximum value for Int8", n.Int64)
 	}
-	*dst = Int8(n)
+	*dst = Int8(n.Int64)
 
 	return nil
 }

--- a/pgtype/zeronull/int.go.erb
+++ b/pgtype/zeronull/int.go.erb
@@ -15,19 +15,19 @@ type Int<%= pg_byte_size %> int<%= pg_bit_size %>
 func (Int<%= pg_byte_size %>) SkipUnderlyingTypePlan() {}
 
 // ScanInt64 implements the Int64Scanner interface.
-func (dst *Int<%= pg_byte_size %>) ScanInt64(n int64, valid bool) error {
-	if !valid {
+func (dst *Int<%= pg_byte_size %>) ScanInt64(n pgtype.Int8) error {
+	if !n.Valid {
 		*dst = 0
 		return nil
 	}
 
-	if n < math.MinInt<%= pg_bit_size %> {
-		return fmt.Errorf("%d is greater than maximum value for Int<%= pg_byte_size %>", n)
+	if n.Int64 < math.MinInt<%= pg_bit_size %> {
+		return fmt.Errorf("%d is less than minimum value for Int<%= pg_byte_size %>", n.Int64)
 	}
-	if n > math.MaxInt<%= pg_bit_size %> {
-		return fmt.Errorf("%d is greater than maximum value for Int<%= pg_byte_size %>", n)
+	if n.Int64 > math.MaxInt<%= pg_bit_size %> {
+		return fmt.Errorf("%d is greater than maximum value for Int<%= pg_byte_size %>", n.Int64)
 	}
-	*dst = Int<%= pg_byte_size %>(n)
+	*dst = Int<%= pg_byte_size %>(n.Int64)
 
 	return nil
 }


### PR DESCRIPTION
Currently the `Int2`/`Int4`/`Int8` type in `zeronull` package does not implement `pgtype.Int64Scanner` interface correctly. 

This PR fixes the implementations but does not change the scanning behavior, since the `sql.Scanner` implementations are already in place.

Also correct error string when comparing minimum value.