### PR TITLE
Add support for Go doc comment links

### DIFF
--- a/pgtype/array.go
+++ b/pgtype/array.go
@@ -374,8 +374,8 @@ func quoteArrayElementIfNeeded(src string) string {
 	return src
 }
 
-// Array represents a PostgreSQL array for T. It implements the ArrayGetter and ArraySetter interfaces. It preserves
-// PostgreSQL dimensions and custom lower bounds. Use FlatArray if these are not needed.
+// Array represents a PostgreSQL array for T. It implements the [ArrayGetter] and [ArraySetter] interfaces. It preserves
+// PostgreSQL dimensions and custom lower bounds. Use [FlatArray] if these are not needed.
 type Array[T any] struct {
 	Elements []T
 	Dims     []ArrayDimension
@@ -419,8 +419,8 @@ func (a Array[T]) ScanIndexType() any {
 	return new(T)
 }
 
-// FlatArray implements the ArrayGetter and ArraySetter interfaces for any slice of T. It ignores PostgreSQL dimensions
-// and custom lower bounds. Use Array to preserve these.
+// FlatArray implements the [ArrayGetter] and [ArraySetter] interfaces for any slice of T. It ignores PostgreSQL dimensions
+// and custom lower bounds. Use [Array] to preserve these.
 type FlatArray[T any] []T
 
 func (a FlatArray[T]) Dimensions() []ArrayDimension {

--- a/pgtype/bits.go
+++ b/pgtype/bits.go
@@ -23,16 +23,18 @@ type Bits struct {
 	Valid bool
 }
 
+// ScanBits implements the [BitsScanner] interface.
 func (b *Bits) ScanBits(v Bits) error {
 	*b = v
 	return nil
 }
 
+// BitsValue implements the [BitsValuer] interface.
 func (b Bits) BitsValue() (Bits, error) {
 	return b, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Bits) Scan(src any) error {
 	if src == nil {
 		*dst = Bits{}
@@ -47,7 +49,7 @@ func (dst *Bits) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Bits) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil

--- a/pgtype/bool.go
+++ b/pgtype/bool.go
@@ -22,16 +22,18 @@ type Bool struct {
 	Valid bool
 }
 
+// ScanBool implements the [BoolScanner] interface.
 func (b *Bool) ScanBool(v Bool) error {
 	*b = v
 	return nil
 }
 
+// BoolValue implements the [BoolValuer] interface.
 func (b Bool) BoolValue() (Bool, error) {
 	return b, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Bool) Scan(src any) error {
 	if src == nil {
 		*dst = Bool{}
@@ -61,7 +63,7 @@ func (dst *Bool) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Bool) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -70,6 +72,7 @@ func (src Bool) Value() (driver.Value, error) {
 	return src.Bool, nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src Bool) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -82,6 +85,7 @@ func (src Bool) MarshalJSON() ([]byte, error) {
 	}
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *Bool) UnmarshalJSON(b []byte) error {
 	var v *bool
 	err := json.Unmarshal(b, &v)

--- a/pgtype/box.go
+++ b/pgtype/box.go
@@ -24,16 +24,18 @@ type Box struct {
 	Valid bool
 }
 
+// ScanBox implements the [BoxScanner] interface.
 func (b *Box) ScanBox(v Box) error {
 	*b = v
 	return nil
 }
 
+// BoxValue implements the [BoxValuer] interface.
 func (b Box) BoxValue() (Box, error) {
 	return b, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Box) Scan(src any) error {
 	if src == nil {
 		*dst = Box{}
@@ -48,7 +50,7 @@ func (dst *Box) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Box) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil

--- a/pgtype/circle.go
+++ b/pgtype/circle.go
@@ -25,16 +25,18 @@ type Circle struct {
 	Valid bool
 }
 
+// ScanCircle implements the [CircleScanner] interface.
 func (c *Circle) ScanCircle(v Circle) error {
 	*c = v
 	return nil
 }
 
+// CircleValue implements the [CircleValuer] interface.
 func (c Circle) CircleValue() (Circle, error) {
 	return c, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Circle) Scan(src any) error {
 	if src == nil {
 		*dst = Circle{}
@@ -49,7 +51,7 @@ func (dst *Circle) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Circle) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil

--- a/pgtype/date.go
+++ b/pgtype/date.go
@@ -26,11 +26,13 @@ type Date struct {
 	Valid            bool
 }
 
+// ScanDate implements the [DateScanner] interface.
 func (d *Date) ScanDate(v Date) error {
 	*d = v
 	return nil
 }
 
+// DateValue implements the [DateValuer] interface.
 func (d Date) DateValue() (Date, error) {
 	return d, nil
 }
@@ -40,7 +42,7 @@ const (
 	infinityDayOffset         = 2147483647
 )
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Date) Scan(src any) error {
 	if src == nil {
 		*dst = Date{}
@@ -58,7 +60,7 @@ func (dst *Date) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Date) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -70,6 +72,7 @@ func (src Date) Value() (driver.Value, error) {
 	return src.Time, nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src Date) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -89,6 +92,7 @@ func (src Date) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *Date) UnmarshalJSON(b []byte) error {
 	var s *string
 	err := json.Unmarshal(b, &s)

--- a/pgtype/float4.go
+++ b/pgtype/float4.go
@@ -16,26 +16,29 @@ type Float4 struct {
 	Valid   bool
 }
 
-// ScanFloat64 implements the Float64Scanner interface.
+// ScanFloat64 implements the [Float64Scanner] interface.
 func (f *Float4) ScanFloat64(n Float8) error {
 	*f = Float4{Float32: float32(n.Float64), Valid: n.Valid}
 	return nil
 }
 
+// Float64Value implements the [Float64Valuer] interface.
 func (f Float4) Float64Value() (Float8, error) {
 	return Float8{Float64: float64(f.Float32), Valid: f.Valid}, nil
 }
 
+// ScanInt64 implements the [Int64Scanner] interface.
 func (f *Float4) ScanInt64(n Int8) error {
 	*f = Float4{Float32: float32(n.Int64), Valid: n.Valid}
 	return nil
 }
 
+// Int64Value implements the [Int64Valuer] interface.
 func (f Float4) Int64Value() (Int8, error) {
 	return Int8{Int64: int64(f.Float32), Valid: f.Valid}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (f *Float4) Scan(src any) error {
 	if src == nil {
 		*f = Float4{}
@@ -58,7 +61,7 @@ func (f *Float4) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (f Float4) Value() (driver.Value, error) {
 	if !f.Valid {
 		return nil, nil
@@ -66,6 +69,7 @@ func (f Float4) Value() (driver.Value, error) {
 	return float64(f.Float32), nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (f Float4) MarshalJSON() ([]byte, error) {
 	if !f.Valid {
 		return []byte("null"), nil
@@ -73,6 +77,7 @@ func (f Float4) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.Float32)
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (f *Float4) UnmarshalJSON(b []byte) error {
 	var n *float32
 	err := json.Unmarshal(b, &n)

--- a/pgtype/float8.go
+++ b/pgtype/float8.go
@@ -24,26 +24,29 @@ type Float8 struct {
 	Valid   bool
 }
 
-// ScanFloat64 implements the Float64Scanner interface.
+// ScanFloat64 implements the [Float64Scanner] interface.
 func (f *Float8) ScanFloat64(n Float8) error {
 	*f = n
 	return nil
 }
 
+// Float64Value implements the [Float64Valuer] interface.
 func (f Float8) Float64Value() (Float8, error) {
 	return f, nil
 }
 
+// ScanInt64 implements the [Int64Scanner] interface.
 func (f *Float8) ScanInt64(n Int8) error {
 	*f = Float8{Float64: float64(n.Int64), Valid: n.Valid}
 	return nil
 }
 
+// Int64Value implements the [Int64Valuer] interface.
 func (f Float8) Int64Value() (Int8, error) {
 	return Int8{Int64: int64(f.Float64), Valid: f.Valid}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (f *Float8) Scan(src any) error {
 	if src == nil {
 		*f = Float8{}
@@ -66,7 +69,7 @@ func (f *Float8) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (f Float8) Value() (driver.Value, error) {
 	if !f.Valid {
 		return nil, nil
@@ -74,6 +77,7 @@ func (f Float8) Value() (driver.Value, error) {
 	return f.Float64, nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (f Float8) MarshalJSON() ([]byte, error) {
 	if !f.Valid {
 		return []byte("null"), nil
@@ -81,6 +85,7 @@ func (f Float8) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.Float64)
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (f *Float8) UnmarshalJSON(b []byte) error {
 	var n *float64
 	err := json.Unmarshal(b, &n)

--- a/pgtype/hstore.go
+++ b/pgtype/hstore.go
@@ -22,16 +22,18 @@ type HstoreValuer interface {
 // associated with its keys.
 type Hstore map[string]*string
 
+// ScanHstore implements the [HstoreScanner] interface.
 func (h *Hstore) ScanHstore(v Hstore) error {
 	*h = v
 	return nil
 }
 
+// HstoreValue implements the [HstoreValuer] interface.
 func (h Hstore) HstoreValue() (Hstore, error) {
 	return h, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (h *Hstore) Scan(src any) error {
 	if src == nil {
 		*h = nil
@@ -46,7 +48,7 @@ func (h *Hstore) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (h Hstore) Value() (driver.Value, error) {
 	if h == nil {
 		return nil, nil

--- a/pgtype/inet.go
+++ b/pgtype/inet.go
@@ -24,7 +24,7 @@ type NetipPrefixValuer interface {
 	NetipPrefixValue() (netip.Prefix, error)
 }
 
-// InetCodec handles both inet and cidr PostgreSQL types. The preferred Go types are netip.Prefix and netip.Addr. If
+// InetCodec handles both inet and cidr PostgreSQL types. The preferred Go types are [netip.Prefix] and [netip.Addr]. If
 // IsValid() is false then they are treated as SQL NULL.
 type InetCodec struct{}
 

--- a/pgtype/int.go
+++ b/pgtype/int.go
@@ -26,7 +26,7 @@ type Int2 struct {
 	Valid bool
 }
 
-// ScanInt64 implements the Int64Scanner interface.
+// ScanInt64 implements the [Int64Scanner] interface.
 func (dst *Int2) ScanInt64(n Int8) error {
 	if !n.Valid {
 		*dst = Int2{}
@@ -44,11 +44,12 @@ func (dst *Int2) ScanInt64(n Int8) error {
 	return nil
 }
 
+// Int64Value implements the [Int64Valuer] interface.
 func (n Int2) Int64Value() (Int8, error) {
 	return Int8{Int64: int64(n.Int16), Valid: n.Valid}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Int2) Scan(src any) error {
 	if src == nil {
 		*dst = Int2{}
@@ -87,7 +88,7 @@ func (dst *Int2) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Int2) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -95,6 +96,7 @@ func (src Int2) Value() (driver.Value, error) {
 	return int64(src.Int16), nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src Int2) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -102,6 +104,7 @@ func (src Int2) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.FormatInt(int64(src.Int16), 10)), nil
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *Int2) UnmarshalJSON(b []byte) error {
 	var n *int16
 	err := json.Unmarshal(b, &n)
@@ -586,7 +589,7 @@ type Int4 struct {
 	Valid bool
 }
 
-// ScanInt64 implements the Int64Scanner interface.
+// ScanInt64 implements the [Int64Scanner] interface.
 func (dst *Int4) ScanInt64(n Int8) error {
 	if !n.Valid {
 		*dst = Int4{}
@@ -604,11 +607,12 @@ func (dst *Int4) ScanInt64(n Int8) error {
 	return nil
 }
 
+// Int64Value implements the [Int64Valuer] interface.
 func (n Int4) Int64Value() (Int8, error) {
 	return Int8{Int64: int64(n.Int32), Valid: n.Valid}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Int4) Scan(src any) error {
 	if src == nil {
 		*dst = Int4{}
@@ -647,7 +651,7 @@ func (dst *Int4) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Int4) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -655,6 +659,7 @@ func (src Int4) Value() (driver.Value, error) {
 	return int64(src.Int32), nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src Int4) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -662,6 +667,7 @@ func (src Int4) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.FormatInt(int64(src.Int32), 10)), nil
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *Int4) UnmarshalJSON(b []byte) error {
 	var n *int32
 	err := json.Unmarshal(b, &n)
@@ -1157,7 +1163,7 @@ type Int8 struct {
 	Valid bool
 }
 
-// ScanInt64 implements the Int64Scanner interface.
+// ScanInt64 implements the [Int64Scanner] interface.
 func (dst *Int8) ScanInt64(n Int8) error {
 	if !n.Valid {
 		*dst = Int8{}
@@ -1175,11 +1181,12 @@ func (dst *Int8) ScanInt64(n Int8) error {
 	return nil
 }
 
+// Int64Value implements the [Int64Valuer] interface.
 func (n Int8) Int64Value() (Int8, error) {
 	return Int8{Int64: int64(n.Int64), Valid: n.Valid}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Int8) Scan(src any) error {
 	if src == nil {
 		*dst = Int8{}
@@ -1218,7 +1225,7 @@ func (dst *Int8) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Int8) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -1226,6 +1233,7 @@ func (src Int8) Value() (driver.Value, error) {
 	return int64(src.Int64), nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src Int8) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -1233,6 +1241,7 @@ func (src Int8) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.FormatInt(int64(src.Int64), 10)), nil
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *Int8) UnmarshalJSON(b []byte) error {
 	var n *int64
 	err := json.Unmarshal(b, &n)

--- a/pgtype/int.go.erb
+++ b/pgtype/int.go.erb
@@ -27,7 +27,7 @@ type Int<%= pg_byte_size %> struct {
 	Valid bool
 }
 
-// ScanInt64 implements the Int64Scanner interface.
+// ScanInt64 implements the [Int64Scanner] interface.
 func (dst *Int<%= pg_byte_size %>) ScanInt64(n Int8) error {
 	if !n.Valid {
 		*dst = Int<%= pg_byte_size %>{}
@@ -45,11 +45,12 @@ func (dst *Int<%= pg_byte_size %>) ScanInt64(n Int8) error {
 	return nil
 }
 
+// Int64Value implements the [Int64Valuer] interface.
 func (n Int<%= pg_byte_size %>) Int64Value() (Int8, error) {
 	return Int8{Int64: int64(n.Int<%= pg_bit_size %>), Valid: n.Valid}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Int<%= pg_byte_size %>) Scan(src any) error {
 	if src == nil {
 		*dst = Int<%= pg_byte_size %>{}
@@ -88,7 +89,7 @@ func (dst *Int<%= pg_byte_size %>) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Int<%= pg_byte_size %>) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -96,6 +97,7 @@ func (src Int<%= pg_byte_size %>) Value() (driver.Value, error) {
 	return int64(src.Int<%= pg_bit_size %>), nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src Int<%= pg_byte_size %>) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -103,6 +105,7 @@ func (src Int<%= pg_byte_size %>) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.FormatInt(int64(src.Int<%= pg_bit_size %>), 10)), nil
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *Int<%= pg_byte_size %>) UnmarshalJSON(b []byte) error {
 	var n *int<%= pg_bit_size %>
 	err := json.Unmarshal(b, &n)

--- a/pgtype/interval.go
+++ b/pgtype/interval.go
@@ -33,16 +33,18 @@ type Interval struct {
 	Valid        bool
 }
 
+// ScanInterval implements the [IntervalScanner] interface.
 func (interval *Interval) ScanInterval(v Interval) error {
 	*interval = v
 	return nil
 }
 
+// IntervalValue implements the [IntervalValuer] interface.
 func (interval Interval) IntervalValue() (Interval, error) {
 	return interval, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (interval *Interval) Scan(src any) error {
 	if src == nil {
 		*interval = Interval{}
@@ -57,7 +59,7 @@ func (interval *Interval) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (interval Interval) Value() (driver.Value, error) {
 	if !interval.Valid {
 		return nil, nil

--- a/pgtype/line.go
+++ b/pgtype/line.go
@@ -24,11 +24,13 @@ type Line struct {
 	Valid   bool
 }
 
+// ScanLine implements the [LineScanner] interface.
 func (line *Line) ScanLine(v Line) error {
 	*line = v
 	return nil
 }
 
+// LineValue implements the [LineValuer] interface.
 func (line Line) LineValue() (Line, error) {
 	return line, nil
 }
@@ -37,7 +39,7 @@ func (line *Line) Set(src any) error {
 	return fmt.Errorf("cannot convert %v to Line", src)
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (line *Line) Scan(src any) error {
 	if src == nil {
 		*line = Line{}
@@ -52,7 +54,7 @@ func (line *Line) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (line Line) Value() (driver.Value, error) {
 	if !line.Valid {
 		return nil, nil

--- a/pgtype/lseg.go
+++ b/pgtype/lseg.go
@@ -24,16 +24,18 @@ type Lseg struct {
 	Valid bool
 }
 
+// ScanLseg implements the [LsegScanner] interface.
 func (lseg *Lseg) ScanLseg(v Lseg) error {
 	*lseg = v
 	return nil
 }
 
+// LsegValue implements the [LsegValuer] interface.
 func (lseg Lseg) LsegValue() (Lseg, error) {
 	return lseg, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (lseg *Lseg) Scan(src any) error {
 	if src == nil {
 		*lseg = Lseg{}
@@ -48,7 +50,7 @@ func (lseg *Lseg) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (lseg Lseg) Value() (driver.Value, error) {
 	if !lseg.Valid {
 		return nil, nil

--- a/pgtype/multirange.go
+++ b/pgtype/multirange.go
@@ -403,8 +403,8 @@ func parseRange(buf *bytes.Buffer) (string, error) {
 
 // Multirange is a generic multirange type.
 //
-// T should implement RangeValuer and *T should implement RangeScanner. However, there does not appear to be a way to
-// enforce the RangeScanner constraint.
+// T should implement [RangeValuer] and *T should implement [RangeScanner]. However, there does not appear to be a way to
+// enforce the [RangeScanner] constraint.
 type Multirange[T RangeValuer] []T
 
 func (r Multirange[T]) IsNull() bool {

--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -54,15 +54,18 @@ type Numeric struct {
 	Valid            bool
 }
 
+// ScanNumeric implements the [NumericScanner] interface.
 func (n *Numeric) ScanNumeric(v Numeric) error {
 	*n = v
 	return nil
 }
 
+// NumericValue implements the [NumericValuer] interface.
 func (n Numeric) NumericValue() (Numeric, error) {
 	return n, nil
 }
 
+// Float64Value implements the [Float64Valuer] interface.
 func (n Numeric) Float64Value() (Float8, error) {
 	if !n.Valid {
 		return Float8{}, nil
@@ -92,6 +95,7 @@ func (n Numeric) Float64Value() (Float8, error) {
 	return Float8{Float64: f, Valid: true}, nil
 }
 
+// ScanInt64 implements the [Int64Scanner] interface.
 func (n *Numeric) ScanInt64(v Int8) error {
 	if !v.Valid {
 		*n = Numeric{}
@@ -102,6 +106,7 @@ func (n *Numeric) ScanInt64(v Int8) error {
 	return nil
 }
 
+// Int64Value implements the [Int64Valuer] interface.
 func (n Numeric) Int64Value() (Int8, error) {
 	if !n.Valid {
 		return Int8{}, nil
@@ -203,7 +208,7 @@ func nbaseDigitsToInt64(src []byte) (accum int64, bytesRead, digitsRead int) {
 	return accum, rp, digits
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (n *Numeric) Scan(src any) error {
 	if src == nil {
 		*n = Numeric{}
@@ -218,7 +223,7 @@ func (n *Numeric) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (n Numeric) Value() (driver.Value, error) {
 	if !n.Valid {
 		return nil, nil
@@ -231,6 +236,7 @@ func (n Numeric) Value() (driver.Value, error) {
 	return string(buf), err
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (n Numeric) MarshalJSON() ([]byte, error) {
 	if !n.Valid {
 		return []byte("null"), nil
@@ -243,6 +249,7 @@ func (n Numeric) MarshalJSON() ([]byte, error) {
 	return n.numberTextBytes(), nil
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (n *Numeric) UnmarshalJSON(src []byte) error {
 	if bytes.Equal(src, []byte(`null`)) {
 		*n = Numeric{}

--- a/pgtype/path.go
+++ b/pgtype/path.go
@@ -25,16 +25,18 @@ type Path struct {
 	Valid  bool
 }
 
+// ScanPath implements the [PathScanner] interface.
 func (path *Path) ScanPath(v Path) error {
 	*path = v
 	return nil
 }
 
+// PathValue implements the [PathValuer] interface.
 func (path Path) PathValue() (Path, error) {
 	return path, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (path *Path) Scan(src any) error {
 	if src == nil {
 		*path = Path{}
@@ -49,7 +51,7 @@ func (path *Path) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (path Path) Value() (driver.Value, error) {
 	if !path.Valid {
 		return nil, nil

--- a/pgtype/point.go
+++ b/pgtype/point.go
@@ -30,11 +30,13 @@ type Point struct {
 	Valid bool
 }
 
+// ScanPoint implements the [PointScanner] interface.
 func (p *Point) ScanPoint(v Point) error {
 	*p = v
 	return nil
 }
 
+// PointValue implements the [PointValuer] interface.
 func (p Point) PointValue() (Point, error) {
 	return p, nil
 }
@@ -68,7 +70,7 @@ func parsePoint(src []byte) (*Point, error) {
 	return &Point{P: Vec2{x, y}, Valid: true}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Point) Scan(src any) error {
 	if src == nil {
 		*dst = Point{}
@@ -83,7 +85,7 @@ func (dst *Point) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Point) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -96,6 +98,7 @@ func (src Point) Value() (driver.Value, error) {
 	return string(buf), err
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src Point) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -108,6 +111,7 @@ func (src Point) MarshalJSON() ([]byte, error) {
 	return buff.Bytes(), nil
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *Point) UnmarshalJSON(point []byte) error {
 	p, err := parsePoint(point)
 	if err != nil {

--- a/pgtype/polygon.go
+++ b/pgtype/polygon.go
@@ -24,16 +24,18 @@ type Polygon struct {
 	Valid bool
 }
 
+// ScanPolygon implements the [PolygonScanner] interface.
 func (p *Polygon) ScanPolygon(v Polygon) error {
 	*p = v
 	return nil
 }
 
+// PolygonValue implements the [PolygonValuer] interface.
 func (p Polygon) PolygonValue() (Polygon, error) {
 	return p, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (p *Polygon) Scan(src any) error {
 	if src == nil {
 		*p = Polygon{}
@@ -48,7 +50,7 @@ func (p *Polygon) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (p Polygon) Value() (driver.Value, error) {
 	if !p.Valid {
 		return nil, nil

--- a/pgtype/text.go
+++ b/pgtype/text.go
@@ -19,16 +19,18 @@ type Text struct {
 	Valid  bool
 }
 
+// ScanText implements the [TextScanner] interface.
 func (t *Text) ScanText(v Text) error {
 	*t = v
 	return nil
 }
 
+// TextValue implements the [TextValuer] interface.
 func (t Text) TextValue() (Text, error) {
 	return t, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Text) Scan(src any) error {
 	if src == nil {
 		*dst = Text{}
@@ -47,7 +49,7 @@ func (dst *Text) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Text) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -55,6 +57,7 @@ func (src Text) Value() (driver.Value, error) {
 	return src.String, nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src Text) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -63,6 +66,7 @@ func (src Text) MarshalJSON() ([]byte, error) {
 	return json.Marshal(src.String)
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *Text) UnmarshalJSON(b []byte) error {
 	var s *string
 	err := json.Unmarshal(b, &s)

--- a/pgtype/tid.go
+++ b/pgtype/tid.go
@@ -35,16 +35,18 @@ type TID struct {
 	Valid        bool
 }
 
+// ScanTID implements the [TIDScanner] interface.
 func (b *TID) ScanTID(v TID) error {
 	*b = v
 	return nil
 }
 
+// TIDValue implements the [TIDValuer] interface.
 func (b TID) TIDValue() (TID, error) {
 	return b, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *TID) Scan(src any) error {
 	if src == nil {
 		*dst = TID{}
@@ -59,7 +61,7 @@ func (dst *TID) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src TID) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil

--- a/pgtype/time.go
+++ b/pgtype/time.go
@@ -29,16 +29,18 @@ type Time struct {
 	Valid        bool
 }
 
+// ScanTime implements the [TimeScanner] interface.
 func (t *Time) ScanTime(v Time) error {
 	*t = v
 	return nil
 }
 
+// TimeValue implements the [TimeValuer] interface.
 func (t Time) TimeValue() (Time, error) {
 	return t, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (t *Time) Scan(src any) error {
 	if src == nil {
 		*t = Time{}
@@ -58,7 +60,7 @@ func (t *Time) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (t Time) Value() (driver.Value, error) {
 	if !t.Valid {
 		return nil, nil

--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -29,16 +29,18 @@ type Timestamp struct {
 	Valid            bool
 }
 
+// ScanTimestamp implements the [TimestampScanner] interface.
 func (ts *Timestamp) ScanTimestamp(v Timestamp) error {
 	*ts = v
 	return nil
 }
 
+// TimestampValue implements the [TimestampValuer] interface.
 func (ts Timestamp) TimestampValue() (Timestamp, error) {
 	return ts, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (ts *Timestamp) Scan(src any) error {
 	if src == nil {
 		*ts = Timestamp{}
@@ -56,7 +58,7 @@ func (ts *Timestamp) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (ts Timestamp) Value() (driver.Value, error) {
 	if !ts.Valid {
 		return nil, nil
@@ -68,6 +70,7 @@ func (ts Timestamp) Value() (driver.Value, error) {
 	return ts.Time, nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (ts Timestamp) MarshalJSON() ([]byte, error) {
 	if !ts.Valid {
 		return []byte("null"), nil
@@ -87,6 +90,7 @@ func (ts Timestamp) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (ts *Timestamp) UnmarshalJSON(b []byte) error {
 	var s *string
 	err := json.Unmarshal(b, &s)

--- a/pgtype/timestamptz.go
+++ b/pgtype/timestamptz.go
@@ -36,16 +36,18 @@ type Timestamptz struct {
 	Valid            bool
 }
 
+// ScanTimestamptz implements the [TimestamptzScanner] interface.
 func (tstz *Timestamptz) ScanTimestamptz(v Timestamptz) error {
 	*tstz = v
 	return nil
 }
 
+// TimestamptzValue implements the [TimestamptzValuer] interface.
 func (tstz Timestamptz) TimestamptzValue() (Timestamptz, error) {
 	return tstz, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (tstz *Timestamptz) Scan(src any) error {
 	if src == nil {
 		*tstz = Timestamptz{}
@@ -63,7 +65,7 @@ func (tstz *Timestamptz) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (tstz Timestamptz) Value() (driver.Value, error) {
 	if !tstz.Valid {
 		return nil, nil
@@ -75,6 +77,7 @@ func (tstz Timestamptz) Value() (driver.Value, error) {
 	return tstz.Time, nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (tstz Timestamptz) MarshalJSON() ([]byte, error) {
 	if !tstz.Valid {
 		return []byte("null"), nil
@@ -94,6 +97,7 @@ func (tstz Timestamptz) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (tstz *Timestamptz) UnmarshalJSON(b []byte) error {
 	var s *string
 	err := json.Unmarshal(b, &s)

--- a/pgtype/uint32.go
+++ b/pgtype/uint32.go
@@ -25,16 +25,18 @@ type Uint32 struct {
 	Valid  bool
 }
 
+// ScanUint32 implements the [Uint32Scanner] interface.
 func (n *Uint32) ScanUint32(v Uint32) error {
 	*n = v
 	return nil
 }
 
+// Uint32Value implements the [Uint32Valuer] interface.
 func (n Uint32) Uint32Value() (Uint32, error) {
 	return n, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Uint32) Scan(src any) error {
 	if src == nil {
 		*dst = Uint32{}
@@ -68,7 +70,7 @@ func (dst *Uint32) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Uint32) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -76,6 +78,7 @@ func (src Uint32) Value() (driver.Value, error) {
 	return int64(src.Uint32), nil
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src Uint32) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -83,6 +86,7 @@ func (src Uint32) MarshalJSON() ([]byte, error) {
 	return json.Marshal(src.Uint32)
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *Uint32) UnmarshalJSON(b []byte) error {
 	var n *uint32
 	err := json.Unmarshal(b, &n)

--- a/pgtype/uint64.go
+++ b/pgtype/uint64.go
@@ -24,16 +24,18 @@ type Uint64 struct {
 	Valid  bool
 }
 
+// ScanUint64 implements the [Uint64Scanner] interface.
 func (n *Uint64) ScanUint64(v Uint64) error {
 	*n = v
 	return nil
 }
 
+// Uint64Value implements the [Uint64Valuer] interface.
 func (n Uint64) Uint64Value() (Uint64, error) {
 	return n, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Uint64) Scan(src any) error {
 	if src == nil {
 		*dst = Uint64{}
@@ -63,7 +65,7 @@ func (dst *Uint64) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Uint64) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil

--- a/pgtype/uuid.go
+++ b/pgtype/uuid.go
@@ -20,11 +20,13 @@ type UUID struct {
 	Valid bool
 }
 
+// ScanUUID implements the [UUIDScanner] interface.
 func (b *UUID) ScanUUID(v UUID) error {
 	*b = v
 	return nil
 }
 
+// UUIDValue implements the [UUIDValuer] interface.
 func (b UUID) UUIDValue() (UUID, error) {
 	return b, nil
 }
@@ -67,7 +69,7 @@ func encodeUUID(src [16]byte) string {
 	return string(buf[:])
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *UUID) Scan(src any) error {
 	if src == nil {
 		*dst = UUID{}
@@ -87,7 +89,7 @@ func (dst *UUID) Scan(src any) error {
 	return fmt.Errorf("cannot scan %T", src)
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src UUID) Value() (driver.Value, error) {
 	if !src.Valid {
 		return nil, nil
@@ -104,6 +106,7 @@ func (src UUID) String() string {
 	return encodeUUID(src.Bytes)
 }
 
+// MarshalJSON implements the [encoding/json.Marshaler] interface.
 func (src UUID) MarshalJSON() ([]byte, error) {
 	if !src.Valid {
 		return []byte("null"), nil
@@ -116,6 +119,7 @@ func (src UUID) MarshalJSON() ([]byte, error) {
 	return buff.Bytes(), nil
 }
 
+// UnmarshalJSON implements the [encoding/json.Unmarshaler] interface.
 func (dst *UUID) UnmarshalJSON(src []byte) error {
 	if bytes.Equal(src, []byte("null")) {
 		*dst = UUID{}

--- a/pgtype/zeronull/float8.go
+++ b/pgtype/zeronull/float8.go
@@ -8,9 +8,10 @@ import (
 
 type Float8 float64
 
+// SkipUnderlyingTypePlan implements the [pgtype.SkipUnderlyingTypePlanner] interface.
 func (Float8) SkipUnderlyingTypePlan() {}
 
-// ScanFloat64 implements the Float64Scanner interface.
+// ScanFloat64 implements the [pgtype.Float64Scanner] interface.
 func (f *Float8) ScanFloat64(n pgtype.Float8) error {
 	if !n.Valid {
 		*f = 0
@@ -22,6 +23,7 @@ func (f *Float8) ScanFloat64(n pgtype.Float8) error {
 	return nil
 }
 
+// Float64Value implements the [pgtype.Float64Valuer] interface.
 func (f Float8) Float64Value() (pgtype.Float8, error) {
 	if f == 0 {
 		return pgtype.Float8{}, nil
@@ -29,7 +31,7 @@ func (f Float8) Float64Value() (pgtype.Float8, error) {
 	return pgtype.Float8{Float64: float64(f), Valid: true}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (f *Float8) Scan(src any) error {
 	if src == nil {
 		*f = 0
@@ -47,7 +49,7 @@ func (f *Float8) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (f Float8) Value() (driver.Value, error) {
 	if f == 0 {
 		return nil, nil

--- a/pgtype/zeronull/int.go
+++ b/pgtype/zeronull/int.go
@@ -12,9 +12,10 @@ import (
 
 type Int2 int16
 
+// SkipUnderlyingTypePlan implements the [pgtype.SkipUnderlyingTypePlanner] interface.
 func (Int2) SkipUnderlyingTypePlan() {}
 
-// ScanInt64 implements the Int64Scanner interface.
+// ScanInt64 implements the [pgtype.Int64Scanner] interface.
 func (dst *Int2) ScanInt64(n int64, valid bool) error {
 	if !valid {
 		*dst = 0
@@ -32,7 +33,7 @@ func (dst *Int2) ScanInt64(n int64, valid bool) error {
 	return nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Int2) Scan(src any) error {
 	if src == nil {
 		*dst = 0
@@ -50,7 +51,7 @@ func (dst *Int2) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Int2) Value() (driver.Value, error) {
 	if src == 0 {
 		return nil, nil
@@ -60,9 +61,10 @@ func (src Int2) Value() (driver.Value, error) {
 
 type Int4 int32
 
+// SkipUnderlyingTypePlan implements the [pgtype.SkipUnderlyingTypePlanner] interface.
 func (Int4) SkipUnderlyingTypePlan() {}
 
-// ScanInt64 implements the Int64Scanner interface.
+// ScanInt64 implements the [pgtype.Int64Scanner] interface.
 func (dst *Int4) ScanInt64(n int64, valid bool) error {
 	if !valid {
 		*dst = 0
@@ -80,7 +82,7 @@ func (dst *Int4) ScanInt64(n int64, valid bool) error {
 	return nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Int4) Scan(src any) error {
 	if src == nil {
 		*dst = 0
@@ -98,7 +100,7 @@ func (dst *Int4) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Int4) Value() (driver.Value, error) {
 	if src == 0 {
 		return nil, nil
@@ -108,9 +110,10 @@ func (src Int4) Value() (driver.Value, error) {
 
 type Int8 int64
 
+// SkipUnderlyingTypePlan implements the [pgtype.SkipUnderlyingTypePlanner] interface.
 func (Int8) SkipUnderlyingTypePlan() {}
 
-// ScanInt64 implements the Int64Scanner interface.
+// ScanInt64 implements the [pgtype.Int64Scanner] interface.
 func (dst *Int8) ScanInt64(n int64, valid bool) error {
 	if !valid {
 		*dst = 0
@@ -128,7 +131,7 @@ func (dst *Int8) ScanInt64(n int64, valid bool) error {
 	return nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Int8) Scan(src any) error {
 	if src == nil {
 		*dst = 0
@@ -146,7 +149,7 @@ func (dst *Int8) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Int8) Value() (driver.Value, error) {
 	if src == 0 {
 		return nil, nil

--- a/pgtype/zeronull/int.go.erb
+++ b/pgtype/zeronull/int.go.erb
@@ -12,9 +12,10 @@ import (
 <% pg_bit_size = pg_byte_size * 8 %>
 type Int<%= pg_byte_size %> int<%= pg_bit_size %>
 
+// SkipUnderlyingTypePlan implements the [pgtype.SkipUnderlyingTypePlanner] interface.
 func (Int<%= pg_byte_size %>) SkipUnderlyingTypePlan() {}
 
-// ScanInt64 implements the Int64Scanner interface.
+// ScanInt64 implements the [pgtype.Int64Scanner] interface.
 func (dst *Int<%= pg_byte_size %>) ScanInt64(n int64, valid bool) error {
 	if !valid {
 		*dst = 0
@@ -32,7 +33,7 @@ func (dst *Int<%= pg_byte_size %>) ScanInt64(n int64, valid bool) error {
 	return nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Int<%= pg_byte_size %>) Scan(src any) error {
 	if src == nil {
 		*dst = 0
@@ -50,7 +51,7 @@ func (dst *Int<%= pg_byte_size %>) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Int<%= pg_byte_size %>) Value() (driver.Value, error) {
 	if src == 0 {
 		return nil, nil

--- a/pgtype/zeronull/text.go
+++ b/pgtype/zeronull/text.go
@@ -8,9 +8,10 @@ import (
 
 type Text string
 
+// SkipUnderlyingTypePlan implements the [pgtype.SkipUnderlyingTypePlanner] interface.
 func (Text) SkipUnderlyingTypePlan() {}
 
-// ScanText implements the TextScanner interface.
+// ScanText implements the [pgtype.TextScanner] interface.
 func (dst *Text) ScanText(v pgtype.Text) error {
 	if !v.Valid {
 		*dst = ""
@@ -22,7 +23,7 @@ func (dst *Text) ScanText(v pgtype.Text) error {
 	return nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (dst *Text) Scan(src any) error {
 	if src == nil {
 		*dst = ""
@@ -40,7 +41,7 @@ func (dst *Text) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (src Text) Value() (driver.Value, error) {
 	if src == "" {
 		return nil, nil

--- a/pgtype/zeronull/timestamp.go
+++ b/pgtype/zeronull/timestamp.go
@@ -10,8 +10,10 @@ import (
 
 type Timestamp time.Time
 
+// SkipUnderlyingTypePlan implements the [pgtype.SkipUnderlyingTypePlanner] interface.
 func (Timestamp) SkipUnderlyingTypePlan() {}
 
+// ScanTimestamp implements the [pgtype.TimestampScanner] interface.
 func (ts *Timestamp) ScanTimestamp(v pgtype.Timestamp) error {
 	if !v.Valid {
 		*ts = Timestamp{}
@@ -31,6 +33,7 @@ func (ts *Timestamp) ScanTimestamp(v pgtype.Timestamp) error {
 	}
 }
 
+// TimestampValue implements the [pgtype.TimestampValuer] interface.
 func (ts Timestamp) TimestampValue() (pgtype.Timestamp, error) {
 	if time.Time(ts).IsZero() {
 		return pgtype.Timestamp{}, nil
@@ -39,7 +42,7 @@ func (ts Timestamp) TimestampValue() (pgtype.Timestamp, error) {
 	return pgtype.Timestamp{Time: time.Time(ts), Valid: true}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (ts *Timestamp) Scan(src any) error {
 	if src == nil {
 		*ts = Timestamp{}
@@ -57,7 +60,7 @@ func (ts *Timestamp) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (ts Timestamp) Value() (driver.Value, error) {
 	if time.Time(ts).IsZero() {
 		return nil, nil

--- a/pgtype/zeronull/timestamptz.go
+++ b/pgtype/zeronull/timestamptz.go
@@ -10,8 +10,10 @@ import (
 
 type Timestamptz time.Time
 
+// SkipUnderlyingTypePlan implements the [pgtype.SkipUnderlyingTypePlanner] interface.
 func (Timestamptz) SkipUnderlyingTypePlan() {}
 
+// ScanTimestamptz implements the [pgtype.TimestamptzScanner] interface.
 func (ts *Timestamptz) ScanTimestamptz(v pgtype.Timestamptz) error {
 	if !v.Valid {
 		*ts = Timestamptz{}
@@ -31,6 +33,7 @@ func (ts *Timestamptz) ScanTimestamptz(v pgtype.Timestamptz) error {
 	}
 }
 
+// TimestamptzValue implements the [pgtype.TimestamptzValuer] interface.
 func (ts Timestamptz) TimestamptzValue() (pgtype.Timestamptz, error) {
 	if time.Time(ts).IsZero() {
 		return pgtype.Timestamptz{}, nil
@@ -39,7 +42,7 @@ func (ts Timestamptz) TimestamptzValue() (pgtype.Timestamptz, error) {
 	return pgtype.Timestamptz{Time: time.Time(ts), Valid: true}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (ts *Timestamptz) Scan(src any) error {
 	if src == nil {
 		*ts = Timestamptz{}
@@ -57,7 +60,7 @@ func (ts *Timestamptz) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (ts Timestamptz) Value() (driver.Value, error) {
 	if time.Time(ts).IsZero() {
 		return nil, nil

--- a/pgtype/zeronull/uuid.go
+++ b/pgtype/zeronull/uuid.go
@@ -8,9 +8,10 @@ import (
 
 type UUID [16]byte
 
+// SkipUnderlyingTypePlan implements the [pgtype.SkipUnderlyingTypePlanner] interface.
 func (UUID) SkipUnderlyingTypePlan() {}
 
-// ScanUUID implements the UUIDScanner interface.
+// ScanUUID implements the [pgtype.UUIDScanner] interface.
 func (u *UUID) ScanUUID(v pgtype.UUID) error {
 	if !v.Valid {
 		*u = UUID{}
@@ -22,6 +23,7 @@ func (u *UUID) ScanUUID(v pgtype.UUID) error {
 	return nil
 }
 
+// UUIDValue implements the [pgtype.UUIDValuer] interface.
 func (u UUID) UUIDValue() (pgtype.UUID, error) {
 	if u == (UUID{}) {
 		return pgtype.UUID{}, nil
@@ -29,7 +31,7 @@ func (u UUID) UUIDValue() (pgtype.UUID, error) {
 	return pgtype.UUID{Bytes: u, Valid: true}, nil
 }
 
-// Scan implements the database/sql Scanner interface.
+// Scan implements the [database/sql.Scanner] interface.
 func (u *UUID) Scan(src any) error {
 	if src == nil {
 		*u = UUID{}
@@ -47,7 +49,7 @@ func (u *UUID) Scan(src any) error {
 	return nil
 }
 
-// Value implements the database/sql/driver Valuer interface.
+// Value implements the [database/sql/driver.Valuer] interface.
 func (u UUID) Value() (driver.Value, error) {
 	if u == (UUID{}) {
 		return nil, nil


### PR DESCRIPTION
This PR adds support for Go [doc comment links](https://tip.golang.org/doc/comment#doclinks) for an improved documentation navigation experience.