### PR TITLE
Improvement/setup formatters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+# See for configurations: https://golangci-lint.run/usage/configuration/
+version: 2
+
+# See: https://golangci-lint.run/usage/formatters/
+formatters:
+  default: none
+  enable:
+    - gofmt # https://pkg.go.dev/cmd/gofmt
+    - gofumpt # https://github.com/mvdan/gofumpt
+
+  settings:
+    gofmt:
+      simplify: true # Simplify code: gofmt with `-s` option.
+
+    gofumpt:
+      # Module path which contains the source code being formatted.
+      # Default: ""
+      module-path: github.com/jackc/pgx/v5 # Should match with module in go.mod
+      # Choose whether to use the extra rules.
+      # Default: false
+      extra-rules: true

--- a/batch.go
+++ b/batch.go
@@ -207,7 +207,6 @@ func (br *batchResults) Query() (Rows, error) {
 func (br *batchResults) QueryRow() Row {
 	rows, _ := br.Query()
 	return (*connRow)(rows.(*baseRows))
-
 }
 
 // Close closes the batch operation. Any error that occurred during a batch operation may have made it impossible to
@@ -378,7 +377,6 @@ func (br *pipelineBatchResults) Query() (Rows, error) {
 func (br *pipelineBatchResults) QueryRow() Row {
 	rows, _ := br.Query()
 	return (*connRow)(rows.(*baseRows))
-
 }
 
 // Close closes the batch operation. Any error that occurred during a batch operation may have made it impossible to

--- a/batch_test.go
+++ b/batch_test.go
@@ -488,7 +488,6 @@ func TestConnSendBatchCloseRowsPartiallyRead(t *testing.T) {
 	defer cancel()
 
 	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		batch := &pgx.Batch{}
 		batch.Queue("select n from generate_series(0,5) n")
 		batch.Queue("select n from generate_series(0,5) n")
@@ -539,7 +538,6 @@ func TestConnSendBatchCloseRowsPartiallyRead(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
 	})
 }
 
@@ -550,7 +548,6 @@ func TestConnSendBatchQueryError(t *testing.T) {
 	defer cancel()
 
 	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		batch := &pgx.Batch{}
 		batch.Queue("select n from generate_series(0,5) n where 100/(5-n) > 0")
 		batch.Queue("select n from generate_series(0,5) n")
@@ -580,7 +577,6 @@ func TestConnSendBatchQueryError(t *testing.T) {
 		if pgErr, ok := err.(*pgconn.PgError); !(ok && pgErr.Code == "22012") {
 			t.Errorf("br.Close() => %v, want error code %v", err, 22012)
 		}
-
 	})
 }
 
@@ -591,7 +587,6 @@ func TestConnSendBatchQuerySyntaxError(t *testing.T) {
 	defer cancel()
 
 	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		batch := &pgx.Batch{}
 		batch.Queue("select 1 1")
 
@@ -607,7 +602,6 @@ func TestConnSendBatchQuerySyntaxError(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error")
 		}
-
 	})
 }
 
@@ -618,7 +612,6 @@ func TestConnSendBatchQueryRowInsert(t *testing.T) {
 	defer cancel()
 
 	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		sql := `create temporary table ledger(
 	  id serial primary key,
 	  description varchar not null,
@@ -647,7 +640,6 @@ func TestConnSendBatchQueryRowInsert(t *testing.T) {
 		}
 
 		br.Close()
-
 	})
 }
 
@@ -658,7 +650,6 @@ func TestConnSendBatchQueryPartialReadInsert(t *testing.T) {
 	defer cancel()
 
 	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		sql := `create temporary table ledger(
 	  id serial primary key,
 	  description varchar not null,
@@ -687,7 +678,6 @@ func TestConnSendBatchQueryPartialReadInsert(t *testing.T) {
 		}
 
 		br.Close()
-
 	})
 }
 
@@ -698,7 +688,6 @@ func TestTxSendBatch(t *testing.T) {
 	defer cancel()
 
 	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		sql := `create temporary table ledger1(
 	  id serial primary key,
 	  description varchar not null
@@ -757,7 +746,6 @@ func TestTxSendBatch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
 	})
 }
 
@@ -768,7 +756,6 @@ func TestTxSendBatchRollback(t *testing.T) {
 	defer cancel()
 
 	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		sql := `create temporary table ledger1(
 	  id serial primary key,
 	  description varchar not null
@@ -795,7 +782,6 @@ func TestTxSendBatchRollback(t *testing.T) {
 		if count != 0 {
 			t.Errorf("count => %v, want %v", count, 0)
 		}
-
 	})
 }
 
@@ -855,7 +841,6 @@ func TestConnBeginBatchDeferredError(t *testing.T) {
 	defer cancel()
 
 	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		pgxtest.SkipCockroachDB(t, conn, "Server does not support deferred constraint (https://github.com/cockroachdb/cockroach/issues/31632)")
 
 		mustExec(t, conn, `create temporary table t (
@@ -894,7 +879,6 @@ func TestConnBeginBatchDeferredError(t *testing.T) {
 		if err, ok := err.(*pgconn.PgError); !ok || err.Code != "23505" {
 			t.Fatalf("expected error 23505, got %v", err)
 		}
-
 	})
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -516,7 +516,6 @@ func multiInsert(conn *pgx.Conn, tableName string, columnNames []string, rowSrc 
 	}
 
 	return rowCount, nil
-
 }
 
 func benchmarkWriteNRowsViaMultiInsert(b *testing.B, n int) {
@@ -535,7 +534,8 @@ func benchmarkWriteNRowsViaMultiInsert(b *testing.B, n int) {
 		src := newBenchmarkWriteTableCopyFromSrc(n)
 
 		_, err := multiInsert(conn, "t",
-			[]string{"varchar_1",
+			[]string{
+				"varchar_1",
 				"varchar_2",
 				"varchar_null_1",
 				"date_1",
@@ -547,7 +547,8 @@ func benchmarkWriteNRowsViaMultiInsert(b *testing.B, n int) {
 				"tstz_2",
 				"bool_1",
 				"bool_2",
-				"bool_3"},
+				"bool_3",
+			},
 			src)
 		if err != nil {
 			b.Fatal(err)
@@ -568,7 +569,8 @@ func benchmarkWriteNRowsViaCopy(b *testing.B, n int) {
 
 		_, err := conn.CopyFrom(context.Background(),
 			pgx.Identifier{"t"},
-			[]string{"varchar_1",
+			[]string{
+				"varchar_1",
 				"varchar_2",
 				"varchar_null_1",
 				"date_1",
@@ -580,7 +582,8 @@ func benchmarkWriteNRowsViaCopy(b *testing.B, n int) {
 				"tstz_2",
 				"bool_1",
 				"bool_2",
-				"bool_3"},
+				"bool_3",
+			},
 			src)
 		if err != nil {
 			b.Fatal(err)
@@ -611,6 +614,7 @@ func BenchmarkWrite5RowsViaInsert(b *testing.B) {
 func BenchmarkWrite5RowsViaMultiInsert(b *testing.B) {
 	benchmarkWriteNRowsViaMultiInsert(b, 5)
 }
+
 func BenchmarkWrite5RowsViaBatchInsert(b *testing.B) {
 	benchmarkWriteNRowsViaBatchInsert(b, 5)
 }
@@ -626,6 +630,7 @@ func BenchmarkWrite10RowsViaInsert(b *testing.B) {
 func BenchmarkWrite10RowsViaMultiInsert(b *testing.B) {
 	benchmarkWriteNRowsViaMultiInsert(b, 10)
 }
+
 func BenchmarkWrite10RowsViaBatchInsert(b *testing.B) {
 	benchmarkWriteNRowsViaBatchInsert(b, 10)
 }
@@ -641,6 +646,7 @@ func BenchmarkWrite100RowsViaInsert(b *testing.B) {
 func BenchmarkWrite100RowsViaMultiInsert(b *testing.B) {
 	benchmarkWriteNRowsViaMultiInsert(b, 100)
 }
+
 func BenchmarkWrite100RowsViaBatchInsert(b *testing.B) {
 	benchmarkWriteNRowsViaBatchInsert(b, 100)
 }
@@ -672,6 +678,7 @@ func BenchmarkWrite10000RowsViaInsert(b *testing.B) {
 func BenchmarkWrite10000RowsViaMultiInsert(b *testing.B) {
 	benchmarkWriteNRowsViaMultiInsert(b, 10000)
 }
+
 func BenchmarkWrite10000RowsViaBatchInsert(b *testing.B) {
 	benchmarkWriteNRowsViaBatchInsert(b, 10000)
 }
@@ -1043,7 +1050,6 @@ func BenchmarkSelectRowsScanDecoder(b *testing.B) {
 			}
 			for _, format := range formats {
 				b.Run(format.name, func(b *testing.B) {
-
 					br := &BenchRowDecoder{}
 					for i := 0; i < b.N; i++ {
 						rows, err := conn.Query(

--- a/conn_test.go
+++ b/conn_test.go
@@ -412,7 +412,6 @@ func TestExecPerQuerySimpleProtocol(t *testing.T) {
 	if commandTag.String() != "INSERT 0 1" {
 		t.Fatalf("Unexpected results from Exec: %v", commandTag)
 	}
-
 }
 
 func TestPrepare(t *testing.T) {
@@ -1089,7 +1088,7 @@ func TestLoadRangeType(t *testing.T) {
 		conn.TypeMap().RegisterType(newRangeType)
 		conn.TypeMap().RegisterDefaultPgType(pgtype.Range[float64]{}, "examplefloatrange")
 
-		var inputRangeType = pgtype.Range[float64]{
+		inputRangeType := pgtype.Range[float64]{
 			Lower:     1.0,
 			Upper:     2.0,
 			LowerType: pgtype.Inclusive,
@@ -1129,7 +1128,7 @@ func TestLoadMultiRangeType(t *testing.T) {
 		conn.TypeMap().RegisterType(newMultiRangeType)
 		conn.TypeMap().RegisterDefaultPgType(pgtype.Multirange[pgtype.Range[float64]]{}, "examplefloatmultirange")
 
-		var inputMultiRangeType = pgtype.Multirange[pgtype.Range[float64]]{
+		inputMultiRangeType := pgtype.Multirange[pgtype.Range[float64]]{
 			{
 				Lower:     1.0,
 				Upper:     2.0,

--- a/copy_from_test.go
+++ b/copy_from_test.go
@@ -76,7 +76,6 @@ func TestConnCopyWithAllQueryExecModes(t *testing.T) {
 }
 
 func TestConnCopyWithKnownOIDQueryExecModes(t *testing.T) {
-
 	for _, mode := range pgxtest.KnownOIDQueryExecModes {
 		t.Run(mode.String(), func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/internal/stmtcache/lru_cache.go
+++ b/internal/stmtcache/lru_cache.go
@@ -31,7 +31,6 @@ func (c *LRUCache) Get(key string) *pgconn.StatementDescription {
 	}
 
 	return nil
-
 }
 
 // Put stores sd in the cache. Put panics if sd.SQL is "". Put does nothing if sd.SQL already exists in the cache or

--- a/pgbouncer_test.go
+++ b/pgbouncer_test.go
@@ -72,5 +72,4 @@ func testPgbouncer(t *testing.T, config *pgx.ConnConfig, workers, iterations int
 	for i := 0; i < workers; i++ {
 		<-doneChan
 	}
-
 }

--- a/pgconn/auth_scram.go
+++ b/pgconn/auth_scram.go
@@ -263,7 +263,7 @@ func computeClientProof(saltedPassword, authMessage []byte) []byte {
 	return buf
 }
 
-func computeServerSignature(saltedPassword []byte, authMessage []byte) []byte {
+func computeServerSignature(saltedPassword, authMessage []byte) []byte {
 	serverKey := computeHMAC(saltedPassword, []byte("Server Key"))
 	serverSignature := computeHMAC(serverKey, authMessage)
 	buf := make([]byte, base64.StdEncoding.EncodedLen(len(serverSignature)))

--- a/pgconn/benchmark_test.go
+++ b/pgconn/benchmark_test.go
@@ -78,7 +78,6 @@ func BenchmarkExec(b *testing.B) {
 						}
 					}
 					_, err = rr.Close()
-
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -127,7 +126,6 @@ func BenchmarkExecPossibleToCancel(b *testing.B) {
 				}
 			}
 			_, err = rr.Close()
-
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -184,7 +182,6 @@ func BenchmarkExecPrepared(b *testing.B) {
 					}
 				}
 				_, err = rr.Close()
-
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -227,7 +224,6 @@ func BenchmarkExecPreparedPossibleToCancel(b *testing.B) {
 			}
 		}
 		_, err = rr.Close()
-
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -23,9 +23,11 @@ import (
 	"github.com/jackc/pgx/v5/pgproto3"
 )
 
-type AfterConnectFunc func(ctx context.Context, pgconn *PgConn) error
-type ValidateConnectFunc func(ctx context.Context, pgconn *PgConn) error
-type GetSSLPasswordFunc func(ctx context.Context) string
+type (
+	AfterConnectFunc    func(ctx context.Context, pgconn *PgConn) error
+	ValidateConnectFunc func(ctx context.Context, pgconn *PgConn) error
+	GetSSLPasswordFunc  func(ctx context.Context) string
+)
 
 // Config is the settings used to establish a connection to a PostgreSQL server. It must be created by [ParseConfig]. A
 // manually initialized Config will cause ConnectConfig to panic.
@@ -784,8 +786,8 @@ func configTLS(settings map[string]string, thisHost string, parseConfigOptions P
 			if sslpassword != "" {
 				decryptedKey, decryptedError = x509.DecryptPEMBlock(block, []byte(sslpassword))
 			}
-			//if sslpassword not provided or has decryption error when use it
-			//try to find sslpassword with callback function
+			// if sslpassword not provided or has decryption error when use it
+			// try to find sslpassword with callback function
 			if sslpassword == "" || decryptedError != nil {
 				if parseConfigOptions.GetSSLPassword != nil {
 					sslpassword = parseConfigOptions.GetSSLPassword(context.Background())

--- a/pgconn/config_test.go
+++ b/pgconn/config_test.go
@@ -133,7 +133,6 @@ func TestParseConfig(t *testing.T) {
 			name:       "sslmode prefer",
 			connString: "postgres://jack:secret@localhost:5432/mydb?sslmode=prefer",
 			config: &pgconn.Config{
-
 				User:     "jack",
 				Password: "secret",
 				Host:     "localhost",
@@ -567,7 +566,8 @@ func TestParseConfig(t *testing.T) {
 						TLSConfig: &tls.Config{
 							InsecureSkipVerify: true,
 							ServerName:         "bar",
-						}},
+						},
+					},
 					{
 						Host:      "bar",
 						Port:      defaultPort,
@@ -579,7 +579,8 @@ func TestParseConfig(t *testing.T) {
 						TLSConfig: &tls.Config{
 							InsecureSkipVerify: true,
 							ServerName:         "baz",
-						}},
+						},
+					},
 					{
 						Host:      "baz",
 						Port:      defaultPort,
@@ -1023,7 +1024,7 @@ func TestParseConfigReadsPgPassfile(t *testing.T) {
 	t.Parallel()
 
 	tfName := filepath.Join(t.TempDir(), "config")
-	err := os.WriteFile(tfName, []byte("test1:5432:curlydb:curly:nyuknyuknyuk"), 0600)
+	err := os.WriteFile(tfName, []byte("test1:5432:curlydb:curly:nyuknyuknyuk"), 0o600)
 	require.NoError(t, err)
 
 	connString := fmt.Sprintf("postgres://curly@test1:5432/curlydb?sslmode=disable&passfile=%s", tfName)
@@ -1061,7 +1062,7 @@ host = def.example.com
 dbname = defdb
 user = defuser
 application_name = spaced string
-`), 0600)
+`), 0o600)
 	require.NoError(t, err)
 
 	defaultPort := getDefaultPort(t)

--- a/pgconn/krb5.go
+++ b/pgconn/krb5.go
@@ -28,7 +28,7 @@ func RegisterGSSProvider(newGSSArg NewGSSFunc) {
 
 // GSS provides GSSAPI authentication (e.g., Kerberos).
 type GSS interface {
-	GetInitToken(host string, service string) ([]byte, error)
+	GetInitToken(host, service string) ([]byte, error)
 	GetInitTokenFromSPN(spn string) ([]byte, error)
 	Continue(inToken []byte) (done bool, outToken []byte, err error)
 }

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -1141,7 +1141,7 @@ func (pgConn *PgConn) Exec(ctx context.Context, sql string) *MultiResultReader {
 // binary format. If resultFormats is nil all results will be in text format.
 //
 // ResultReader must be closed before PgConn can be used again.
-func (pgConn *PgConn) ExecParams(ctx context.Context, sql string, paramValues [][]byte, paramOIDs []uint32, paramFormats []int16, resultFormats []int16) *ResultReader {
+func (pgConn *PgConn) ExecParams(ctx context.Context, sql string, paramValues [][]byte, paramOIDs []uint32, paramFormats, resultFormats []int16) *ResultReader {
 	result := pgConn.execExtendedPrefix(ctx, paramValues)
 	if result.closed {
 		return result
@@ -1167,7 +1167,7 @@ func (pgConn *PgConn) ExecParams(ctx context.Context, sql string, paramValues []
 // binary format. If resultFormats is nil all results will be in text format.
 //
 // ResultReader must be closed before PgConn can be used again.
-func (pgConn *PgConn) ExecPrepared(ctx context.Context, stmtName string, paramValues [][]byte, paramFormats []int16, resultFormats []int16) *ResultReader {
+func (pgConn *PgConn) ExecPrepared(ctx context.Context, stmtName string, paramValues [][]byte, paramFormats, resultFormats []int16) *ResultReader {
 	result := pgConn.execExtendedPrefix(ctx, paramValues)
 	if result.closed {
 		return result
@@ -1713,7 +1713,7 @@ type Batch struct {
 }
 
 // ExecParams appends an ExecParams command to the batch. See PgConn.ExecParams for parameter descriptions.
-func (batch *Batch) ExecParams(sql string, paramValues [][]byte, paramOIDs []uint32, paramFormats []int16, resultFormats []int16) {
+func (batch *Batch) ExecParams(sql string, paramValues [][]byte, paramOIDs []uint32, paramFormats, resultFormats []int16) {
 	if batch.err != nil {
 		return
 	}
@@ -1726,7 +1726,7 @@ func (batch *Batch) ExecParams(sql string, paramValues [][]byte, paramOIDs []uin
 }
 
 // ExecPrepared appends an ExecPrepared e command to the batch. See PgConn.ExecPrepared for parameter descriptions.
-func (batch *Batch) ExecPrepared(stmtName string, paramValues [][]byte, paramFormats []int16, resultFormats []int16) {
+func (batch *Batch) ExecPrepared(stmtName string, paramValues [][]byte, paramFormats, resultFormats []int16) {
 	if batch.err != nil {
 		return
 	}
@@ -2202,7 +2202,7 @@ func (p *Pipeline) SendDeallocate(name string) {
 }
 
 // SendQueryParams is the pipeline version of *PgConn.QueryParams.
-func (p *Pipeline) SendQueryParams(sql string, paramValues [][]byte, paramOIDs []uint32, paramFormats []int16, resultFormats []int16) {
+func (p *Pipeline) SendQueryParams(sql string, paramValues [][]byte, paramOIDs []uint32, paramFormats, resultFormats []int16) {
 	if p.closed {
 		return
 	}
@@ -2215,7 +2215,7 @@ func (p *Pipeline) SendQueryParams(sql string, paramValues [][]byte, paramOIDs [
 }
 
 // SendQueryPrepared is the pipeline version of *PgConn.QueryPrepared.
-func (p *Pipeline) SendQueryPrepared(stmtName string, paramValues [][]byte, paramFormats []int16, resultFormats []int16) {
+func (p *Pipeline) SendQueryPrepared(stmtName string, paramValues [][]byte, paramFormats, resultFormats []int16) {
 	if p.closed {
 		return
 	}

--- a/pgconn/pgconn_private_test.go
+++ b/pgconn/pgconn_private_test.go
@@ -9,7 +9,7 @@ import (
 func TestCommandTag(t *testing.T) {
 	t.Parallel()
 
-	var tests = []struct {
+	tests := []struct {
 		commandTag   CommandTag
 		rowsAffected int64
 		isInsert     bool

--- a/pgproto3/authentication_cleartext_password.go
+++ b/pgproto3/authentication_cleartext_password.go
@@ -9,8 +9,7 @@ import (
 )
 
 // AuthenticationCleartextPassword is a message sent from the backend indicating that a clear-text password is required.
-type AuthenticationCleartextPassword struct {
-}
+type AuthenticationCleartextPassword struct{}
 
 // Backend identifies this message as sendable by the PostgreSQL backend.
 func (*AuthenticationCleartextPassword) Backend() {}

--- a/pgproto3/authentication_ok.go
+++ b/pgproto3/authentication_ok.go
@@ -9,8 +9,7 @@ import (
 )
 
 // AuthenticationOk is a message sent from the backend indicating that authentication was successful.
-type AuthenticationOk struct {
-}
+type AuthenticationOk struct{}
 
 // Backend identifies this message as sendable by the PostgreSQL backend.
 func (*AuthenticationOk) Backend() {}

--- a/pgproto3/copy_done.go
+++ b/pgproto3/copy_done.go
@@ -4,8 +4,7 @@ import (
 	"encoding/json"
 )
 
-type CopyDone struct {
-}
+type CopyDone struct{}
 
 // Backend identifies this message as sendable by the PostgreSQL backend.
 func (*CopyDone) Backend() {}

--- a/pgproto3/gss_enc_request.go
+++ b/pgproto3/gss_enc_request.go
@@ -10,8 +10,7 @@ import (
 
 const gssEncReqNumber = 80877104
 
-type GSSEncRequest struct {
-}
+type GSSEncRequest struct{}
 
 // Frontend identifies this message as sendable by a PostgreSQL frontend.
 func (*GSSEncRequest) Frontend() {}

--- a/pgproto3/json_test.go
+++ b/pgproto3/json_test.go
@@ -332,7 +332,7 @@ func TestJSONUnmarshalRowDescription(t *testing.T) {
 }
 
 func TestJSONUnmarshalBind(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		desc string
 		data []byte
 	}{
@@ -348,7 +348,7 @@ func TestJSONUnmarshalBind(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			var want = Bind{
+			want := Bind{
 				PreparedStatement:    "lrupsc_1_0",
 				ParameterFormatCodes: []int16{0},
 				Parameters:           [][]byte{[]byte("ABC-123")},

--- a/pgproto3/row_description.go
+++ b/pgproto3/row_description.go
@@ -56,7 +56,6 @@ func (*RowDescription) Backend() {}
 // Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message
 // type identifier and 4 byte message length.
 func (dst *RowDescription) Decode(src []byte) error {
-
 	if len(src) < 2 {
 		return &invalidMessageFormatErr{messageType: "RowDescription"}
 	}

--- a/pgproto3/ssl_request.go
+++ b/pgproto3/ssl_request.go
@@ -10,8 +10,7 @@ import (
 
 const sslRequestNumber = 80877103
 
-type SSLRequest struct {
-}
+type SSLRequest struct{}
 
 // Frontend identifies this message as sendable by a PostgreSQL frontend.
 func (*SSLRequest) Frontend() {}

--- a/pgtype/array_codec_test.go
+++ b/pgtype/array_codec_test.go
@@ -256,7 +256,6 @@ func TestArrayCodecScanMultipleDimensions(t *testing.T) {
 	skipCockroachDB(t, "Server does not support nested arrays (https://github.com/cockroachdb/cockroach/issues/36815)")
 
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		rows, err := conn.Query(ctx, `select '{{1,2,3,4}, {5,6,7,8}, {9,10,11,12}}'::int4[]`)
 		require.NoError(t, err)
 

--- a/pgtype/bits.go
+++ b/pgtype/bits.go
@@ -127,7 +127,6 @@ func (encodePlanBitsCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 }
 
 func (BitsCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/bool.go
+++ b/pgtype/bool.go
@@ -200,7 +200,6 @@ func (encodePlanBoolCodecTextBool) Encode(value any, buf []byte) (newBuf []byte,
 }
 
 func (BoolCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/box.go
+++ b/pgtype/box.go
@@ -127,7 +127,6 @@ func (encodePlanBoxCodecText) Encode(value any, buf []byte) (newBuf []byte, err 
 }
 
 func (BoxCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/builtin_wrappers.go
+++ b/pgtype/builtin_wrappers.go
@@ -527,6 +527,7 @@ func (w *netIPNetWrapper) ScanNetipPrefix(v netip.Prefix) error {
 
 	return nil
 }
+
 func (w netIPNetWrapper) NetipPrefixValue() (netip.Prefix, error) {
 	ip, ok := netip.AddrFromSlice(w.IP)
 	if !ok {
@@ -881,7 +882,6 @@ func (a *anyMultiDimSliceArray) SetDimensions(dimensions []ArrayDimension) error
 
 		return nil
 	}
-
 }
 
 func (a *anyMultiDimSliceArray) makeMultidimensionalSlice(sliceType reflect.Type, dimensions []ArrayDimension, flatSlice reflect.Value, flatSliceIdx int) reflect.Value {

--- a/pgtype/bytea.go
+++ b/pgtype/bytea.go
@@ -148,7 +148,6 @@ func (encodePlanBytesCodecTextBytesValuer) Encode(value any, buf []byte) (newBuf
 }
 
 func (ByteaCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/composite.go
+++ b/pgtype/composite.go
@@ -276,7 +276,6 @@ func (c *CompositeCodec) DecodeValue(m *Map, oid uint32, format int16, src []byt
 	default:
 		return nil, fmt.Errorf("unknown format code %d", format)
 	}
-
 }
 
 type CompositeBinaryScanner struct {

--- a/pgtype/composite_test.go
+++ b/pgtype/composite_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestCompositeCodecTranscode(t *testing.T) {
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		_, err := conn.Exec(ctx, `drop type if exists ct_test;
 
 create type ct_test as (
@@ -90,7 +89,6 @@ func (p *point3d) ScanIndex(i int) any {
 
 func TestCompositeCodecTranscodeStruct(t *testing.T) {
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		_, err := conn.Exec(ctx, `drop type if exists point3d;
 
 create type point3d as (
@@ -125,7 +123,6 @@ create type point3d as (
 
 func TestCompositeCodecTranscodeStructWrapper(t *testing.T) {
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		_, err := conn.Exec(ctx, `drop type if exists point3d;
 
 create type point3d as (
@@ -164,7 +161,6 @@ create type point3d as (
 
 func TestCompositeCodecDecodeValue(t *testing.T) {
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		_, err := conn.Exec(ctx, `drop type if exists point3d;
 
 create type point3d as (
@@ -209,7 +205,6 @@ func TestCompositeCodecTranscodeStructWrapperForTable(t *testing.T) {
 	skipCockroachDB(t, "Server does not support composite types from table definitions")
 
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		_, err := conn.Exec(ctx, `drop table if exists point3d;
 
 create table point3d (

--- a/pgtype/date.go
+++ b/pgtype/date.go
@@ -223,7 +223,6 @@ func (encodePlanDateCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 }
 
 func (DateCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/enum_codec_test.go
+++ b/pgtype/enum_codec_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestEnumCodec(t *testing.T) {
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		_, err := conn.Exec(ctx, `drop type if exists enum_test;
 
 create type enum_test as enum ('foo', 'bar', 'baz');`)
@@ -47,7 +46,6 @@ create type enum_test as enum ('foo', 'bar', 'baz');`)
 
 func TestEnumCodecValues(t *testing.T) {
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		_, err := conn.Exec(ctx, `drop type if exists enum_test;
 
 create type enum_test as enum ('foo', 'bar', 'baz');`)

--- a/pgtype/float4.go
+++ b/pgtype/float4.go
@@ -170,7 +170,6 @@ func (encodePlanFloat4CodecBinaryInt64Valuer) Encode(value any, buf []byte) (new
 }
 
 func (Float4Codec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/float8.go
+++ b/pgtype/float8.go
@@ -208,7 +208,6 @@ func (encodePlanTextInt64Valuer) Encode(value any, buf []byte) (newBuf []byte, e
 }
 
 func (Float8Codec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/hstore.go
+++ b/pgtype/hstore.go
@@ -162,7 +162,6 @@ func (encodePlanHstoreCodecText) Encode(value any, buf []byte) (newBuf []byte, e
 }
 
 func (HstoreCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {
@@ -298,7 +297,7 @@ func (p *hstoreParser) consume() (b byte, end bool) {
 	return b, false
 }
 
-func unexpectedByteErr(actualB byte, expectedB byte) error {
+func unexpectedByteErr(actualB, expectedB byte) error {
 	return fmt.Errorf("expected '%c' ('%#v'); found '%c' ('%#v')", expectedB, expectedB, actualB, actualB)
 }
 
@@ -316,7 +315,7 @@ func (p *hstoreParser) consumeExpectedByte(expectedB byte) error {
 
 // consumeExpected2 consumes two expected bytes or returns an error.
 // This was a bit faster than using a string argument (better inlining? Not sure).
-func (p *hstoreParser) consumeExpected2(one byte, two byte) error {
+func (p *hstoreParser) consumeExpected2(one, two byte) error {
 	if p.pos+2 > len(p.str) {
 		return errors.New("unexpected end of string")
 	}

--- a/pgtype/hstore_test.go
+++ b/pgtype/hstore_test.go
@@ -306,12 +306,13 @@ func TestRoundTrip(t *testing.T) {
 			})
 		}
 	}
-
 }
 
 func BenchmarkHstoreEncode(b *testing.B) {
-	h := pgtype.Hstore{"a x": stringPtr("100"), "b": stringPtr("200"), "c": stringPtr("300"),
-		"d": stringPtr("400"), "e": stringPtr("500")}
+	h := pgtype.Hstore{
+		"a x": stringPtr("100"), "b": stringPtr("200"), "c": stringPtr("300"),
+		"d": stringPtr("400"), "e": stringPtr("500"),
+	}
 
 	serializeConfigs := []struct {
 		name       string

--- a/pgtype/inet.go
+++ b/pgtype/inet.go
@@ -107,7 +107,6 @@ func (encodePlanInetCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 }
 
 func (InetCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/interval.go
+++ b/pgtype/interval.go
@@ -157,7 +157,6 @@ func (encodePlanIntervalCodecText) Encode(value any, buf []byte) (newBuf []byte,
 }
 
 func (IntervalCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/jsonb_test.go
+++ b/pgtype/jsonb_test.go
@@ -95,7 +95,8 @@ func TestJSONBCodecCustomMarshal(t *testing.T) {
 				Unmarshal: func(data []byte, v any) error {
 					return json.Unmarshal([]byte(`{"custom":"value"}`), v)
 				},
-			}})
+			},
+		})
 	}
 
 	pgxtest.RunValueRoundTripTests(context.Background(), t, connTestRunner, pgxtest.KnownOIDQueryExecModes, "jsonb", []pgxtest.ValueRoundTripTest{

--- a/pgtype/line.go
+++ b/pgtype/line.go
@@ -129,7 +129,6 @@ func (encodePlanLineCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 }
 
 func (LineCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/lseg.go
+++ b/pgtype/lseg.go
@@ -127,7 +127,6 @@ func (encodePlanLsegCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 }
 
 func (LsegCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/multirange.go
+++ b/pgtype/multirange.go
@@ -374,7 +374,6 @@ parseValueLoop:
 	}
 
 	return elements, nil
-
 }
 
 func parseRange(buf *bytes.Buffer) (string, error) {

--- a/pgtype/multirange_test.go
+++ b/pgtype/multirange_test.go
@@ -71,7 +71,6 @@ func TestMultirangeCodecDecodeValue(t *testing.T) {
 	skipCockroachDB(t, "Server does not support range types (see https://github.com/cockroachdb/cockroach/issues/27791)")
 
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, _ testing.TB, conn *pgx.Conn) {
-
 		for _, tt := range []struct {
 			sql      string
 			expected any

--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -27,16 +27,20 @@ const (
 	pgNumericNegInfSign = 0xf000
 )
 
-var big0 *big.Int = big.NewInt(0)
-var big1 *big.Int = big.NewInt(1)
-var big10 *big.Int = big.NewInt(10)
-var big100 *big.Int = big.NewInt(100)
-var big1000 *big.Int = big.NewInt(1000)
+var (
+	big0    *big.Int = big.NewInt(0)
+	big1    *big.Int = big.NewInt(1)
+	big10   *big.Int = big.NewInt(10)
+	big100  *big.Int = big.NewInt(100)
+	big1000 *big.Int = big.NewInt(1000)
+)
 
-var bigNBase *big.Int = big.NewInt(nbase)
-var bigNBaseX2 *big.Int = big.NewInt(nbase * nbase)
-var bigNBaseX3 *big.Int = big.NewInt(nbase * nbase * nbase)
-var bigNBaseX4 *big.Int = big.NewInt(nbase * nbase * nbase * nbase)
+var (
+	bigNBase   *big.Int = big.NewInt(nbase)
+	bigNBaseX2 *big.Int = big.NewInt(nbase * nbase)
+	bigNBaseX3 *big.Int = big.NewInt(nbase * nbase * nbase)
+	bigNBaseX4 *big.Int = big.NewInt(nbase * nbase * nbase * nbase)
+)
 
 type NumericScanner interface {
 	ScanNumeric(v Numeric) error
@@ -553,7 +557,6 @@ func encodeNumericText(n Numeric, buf []byte) (newBuf []byte, err error) {
 }
 
 func (NumericCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -198,7 +198,6 @@ func TestNumericMarshalJSON(t *testing.T) {
 	skipCockroachDB(t, "server formats numeric text format differently")
 
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		for i, tt := range []struct {
 			decString string
 		}{

--- a/pgtype/path.go
+++ b/pgtype/path.go
@@ -154,7 +154,6 @@ func (encodePlanPathCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 }
 
 func (PathCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -2010,7 +2010,7 @@ var valuerReflectType = reflect.TypeFor[driver.Valuer]()
 
 // isNilDriverValuer returns true if value is any type of nil unless it implements driver.Valuer. *T is not considered to implement
 // driver.Valuer if it is only implemented by T.
-func isNilDriverValuer(value any) (isNil bool, callNilDriverValuer bool) {
+func isNilDriverValuer(value any) (isNil, callNilDriverValuer bool) {
 	if value == nil {
 		return true, false
 	}

--- a/pgtype/pgtype_test.go
+++ b/pgtype/pgtype_test.go
@@ -34,17 +34,19 @@ func init() {
 }
 
 // Test for renamed types
-type _string string
-type _bool bool
-type _uint8 uint8
-type _int8 int8
-type _int16 int16
-type _int16Slice []int16
-type _int32Slice []int32
-type _int64Slice []int64
-type _float32Slice []float32
-type _float64Slice []float64
-type _byteSlice []byte
+type (
+	_string       string
+	_bool         bool
+	_uint8        uint8
+	_int8         int8
+	_int16        int16
+	_int16Slice   []int16
+	_int32Slice   []int32
+	_int64Slice   []int64
+	_float32Slice []float32
+	_float64Slice []float64
+	_byteSlice    []byte
+)
 
 // unregisteredOID represents an actual type that is not registered. Cannot use 0 because that represents that the type
 // is not known (e.g. when using the simple protocol).
@@ -530,7 +532,8 @@ func TestMapEncodePlanCacheUUIDTypeConfusion(t *testing.T) {
 		0, 0, 0, 16,
 		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 		0, 0, 0, 16,
-		15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+		15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+	}
 
 	m := pgtype.NewMap()
 	buf, err := m.Encode(pgtype.UUIDArrayOID, pgtype.BinaryFormatCode,

--- a/pgtype/point.go
+++ b/pgtype/point.go
@@ -178,7 +178,6 @@ func (encodePlanPointCodecText) Encode(value any, buf []byte) (newBuf []byte, er
 }
 
 func (PointCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/polygon.go
+++ b/pgtype/polygon.go
@@ -139,7 +139,6 @@ func (encodePlanPolygonCodecText) Encode(value any, buf []byte) (newBuf []byte, 
 }
 
 func (PolygonCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/range.go
+++ b/pgtype/range.go
@@ -191,11 +191,13 @@ type untypedBinaryRange struct {
 // 18 = [      = 10010
 // 24 =        = 11000
 
-const emptyMask = 1
-const lowerInclusiveMask = 2
-const upperInclusiveMask = 4
-const lowerUnboundedMask = 8
-const upperUnboundedMask = 16
+const (
+	emptyMask          = 1
+	lowerInclusiveMask = 2
+	upperInclusiveMask = 4
+	lowerUnboundedMask = 8
+	upperUnboundedMask = 16
+)
 
 func parseUntypedBinaryRange(src []byte) (*untypedBinaryRange, error) {
 	ubr := &untypedBinaryRange{}
@@ -273,7 +275,6 @@ func parseUntypedBinaryRange(src []byte) (*untypedBinaryRange, error) {
 	}
 
 	return ubr, nil
-
 }
 
 // Range is a generic range type.

--- a/pgtype/range_codec_test.go
+++ b/pgtype/range_codec_test.go
@@ -75,7 +75,6 @@ func TestRangeCodecScanRangeTwiceWithUnbounded(t *testing.T) {
 	skipCockroachDB(t, "Server does not support range types (see https://github.com/cockroachdb/cockroach/issues/27791)")
 
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-
 		var r pgtype.Range[pgtype.Int4]
 
 		err := conn.QueryRow(context.Background(), `select '[1,5)'::int4range`).Scan(&r)
@@ -129,7 +128,6 @@ func TestRangeCodecDecodeValue(t *testing.T) {
 	skipCockroachDB(t, "Server does not support range types (see https://github.com/cockroachdb/cockroach/issues/27791)")
 
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, _ testing.TB, conn *pgx.Conn) {
-
 		for _, tt := range []struct {
 			sql      string
 			expected any

--- a/pgtype/record_codec.go
+++ b/pgtype/record_codec.go
@@ -121,5 +121,4 @@ func (RecordCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (an
 	default:
 		return nil, fmt.Errorf("unknown format code %d", format)
 	}
-
 }

--- a/pgtype/text.go
+++ b/pgtype/text.go
@@ -146,7 +146,6 @@ func (encodePlanTextCodecTextValuer) Encode(value any, buf []byte) (newBuf []byt
 }
 
 func (TextCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case TextFormatCode, BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/tid.go
+++ b/pgtype/tid.go
@@ -131,7 +131,6 @@ func (encodePlanTIDCodecText) Encode(value any, buf []byte) (newBuf []byte, err 
 }
 
 func (TIDCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/time.go
+++ b/pgtype/time.go
@@ -137,7 +137,6 @@ func (encodePlanTimeCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 }
 
 func (TimeCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -11,8 +11,10 @@ import (
 	"github.com/jackc/pgx/v5/internal/pgio"
 )
 
-const pgTimestampFormat = "2006-01-02 15:04:05.999999999"
-const jsonISO8601 = "2006-01-02T15:04:05.999999999"
+const (
+	pgTimestampFormat = "2006-01-02 15:04:05.999999999"
+	jsonISO8601       = "2006-01-02T15:04:05.999999999"
+)
 
 type TimestampScanner interface {
 	ScanTimestamp(v Timestamp) error

--- a/pgtype/timestamp_test.go
+++ b/pgtype/timestamp_test.go
@@ -102,7 +102,6 @@ func TestTimestampCodecDecodeTextInvalid(t *testing.T) {
 }
 
 func TestTimestampMarshalJSON(t *testing.T) {
-
 	tsStruct := struct {
 		TS pgtype.Timestamp `json:"ts"`
 	}{}

--- a/pgtype/timestamptz.go
+++ b/pgtype/timestamptz.go
@@ -11,10 +11,12 @@ import (
 	"github.com/jackc/pgx/v5/internal/pgio"
 )
 
-const pgTimestamptzHourFormat = "2006-01-02 15:04:05.999999999Z07"
-const pgTimestamptzMinuteFormat = "2006-01-02 15:04:05.999999999Z07:00"
-const pgTimestamptzSecondFormat = "2006-01-02 15:04:05.999999999Z07:00:00"
-const microsecFromUnixEpochToY2K = 946684800 * 1000000
+const (
+	pgTimestamptzHourFormat    = "2006-01-02 15:04:05.999999999Z07"
+	pgTimestamptzMinuteFormat  = "2006-01-02 15:04:05.999999999Z07:00"
+	pgTimestamptzSecondFormat  = "2006-01-02 15:04:05.999999999Z07:00:00"
+	microsecFromUnixEpochToY2K = 946684800 * 1000000
+)
 
 const (
 	negativeInfinityMicrosecondOffset = -9223372036854775808
@@ -225,7 +227,6 @@ func (encodePlanTimestamptzCodecText) Encode(value any, buf []byte) (newBuf []by
 }
 
 func (c *TimestamptzCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/uint32.go
+++ b/pgtype/uint32.go
@@ -221,7 +221,6 @@ func (encodePlanUint32CodecTextInt64Valuer) Encode(value any, buf []byte) (newBu
 }
 
 func (Uint32Codec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgtype/uint64.go
+++ b/pgtype/uint64.go
@@ -194,7 +194,6 @@ func (encodePlanUint64CodecTextInt64Valuer) Encode(value any, buf []byte) (newBu
 }
 
 func (Uint64Codec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
-
 	switch format {
 	case BinaryFormatCode:
 		switch target.(type) {

--- a/pgxpool/common_test.go
+++ b/pgxpool/common_test.go
@@ -97,7 +97,8 @@ func testCopyFrom(t *testing.T, ctx context.Context, db interface {
 	execer
 	queryer
 	copyFromer
-}) {
+},
+) {
 	_, err := db.Exec(ctx, `create temporary table foo(a int2, b int4, c int8, d varchar, e text, f date, g timestamptz)`)
 	require.NoError(t, err)
 

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -15,12 +15,14 @@ import (
 	"github.com/jackc/puddle/v2"
 )
 
-var defaultMaxConns = int32(4)
-var defaultMinConns = int32(0)
-var defaultMinIdleConns = int32(0)
-var defaultMaxConnLifetime = time.Hour
-var defaultMaxConnIdleTime = time.Minute * 30
-var defaultHealthCheckPeriod = time.Minute
+var (
+	defaultMaxConns          = int32(4)
+	defaultMinConns          = int32(0)
+	defaultMinIdleConns      = int32(0)
+	defaultMaxConnLifetime   = time.Hour
+	defaultMaxConnIdleTime   = time.Minute * 30
+	defaultHealthCheckPeriod = time.Minute
+)
 
 type connResource struct {
 	conn       *pgx.Conn

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -776,7 +776,6 @@ func TestPoolQuery(t *testing.T) {
 	stats = pool.Stat()
 	assert.EqualValues(t, 0, stats.AcquiredConns())
 	assert.EqualValues(t, 1, stats.TotalConns())
-
 }
 
 func TestPoolQueryRow(t *testing.T) {
@@ -1204,7 +1203,6 @@ func TestConnectEagerlyReachesMinPoolSize(t *testing.T) {
 	}
 
 	t.Fatal("did not reach min pool size")
-
 }
 
 func TestPoolSendBatchBatchCloseTwice(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -568,7 +568,6 @@ func TestConnQueryErrorWhileReturningRows(t *testing.T) {
 			ensureConnValid(t, conn)
 		}()
 	}
-
 }
 
 func TestQueryEncodeError(t *testing.T) {
@@ -2208,7 +2207,6 @@ insert into products (name, price) values
 	}
 
 	rows, err := conn.Query(ctx, "select name, price from products where price < $1 order by price desc", 12)
-
 	// It is unnecessary to check err. If an error occurred it will be returned by rows.Err() later. But in rare
 	// cases it may be useful to detect the error as early as possible.
 	if err != nil {

--- a/testsetup/generate_certs.go
+++ b/testsetup/generate_certs.go
@@ -161,7 +161,6 @@ func writeEncryptedPrivateKey(path string, privateKey *rsa.PrivateKey, password 
 	}
 
 	return nil
-
 }
 
 func writeCertificate(path string, certBytes []byte) error {

--- a/tracelog/tracelog.go
+++ b/tracelog/tracelog.go
@@ -104,7 +104,7 @@ func logQueryArgs(args []any) []any {
 			}
 		case string:
 			if len(v) > 64 {
-				var l = 0
+				l := 0
 				for w := 0; l < 64; l += w {
 					_, w = utf8.DecodeRuneInString(v[l:])
 				}

--- a/tracelog/tracelog_test.go
+++ b/tracelog/tracelog_test.go
@@ -362,7 +362,6 @@ func TestLogBatchStatementsOnExec(t *testing.T) {
 		assert.Equal(t, "BatchQuery", logger.logs[1].msg)
 		assert.Equal(t, "drop table foo", logger.logs[1].data["sql"])
 		assert.Equal(t, "BatchClose", logger.logs[2].msg)
-
 	})
 }
 

--- a/values_test.go
+++ b/values_test.go
@@ -117,7 +117,6 @@ func TestJSONAndJSONBTranscodeExtendedOnly(t *testing.T) {
 		testJSONInt16ArrayFailureDueToOverflow(t, conn, typename)
 		testJSONStruct(t, conn, typename)
 	}
-
 }
 
 func testJSONString(t testing.TB, conn *pgx.Conn, typename string) {
@@ -597,7 +596,9 @@ func TestArrayDecoding(t *testing.T) {
 			assert func(testing.TB, any, any)
 		}{
 			{
-				"select $1::bool[]", []bool{true, false, true}, &[]bool{},
+				"select $1::bool[]",
+				[]bool{true, false, true},
+				&[]bool{},
 				func(t testing.TB, query, scan any) {
 					if !reflect.DeepEqual(query, *(scan.(*[]bool))) {
 						t.Errorf("failed to encode bool[]")
@@ -605,7 +606,9 @@ func TestArrayDecoding(t *testing.T) {
 				},
 			},
 			{
-				"select $1::smallint[]", []int16{2, 4, 484, 32767}, &[]int16{},
+				"select $1::smallint[]",
+				[]int16{2, 4, 484, 32767},
+				&[]int16{},
 				func(t testing.TB, query, scan any) {
 					if !reflect.DeepEqual(query, *(scan.(*[]int16))) {
 						t.Errorf("failed to encode smallint[]")
@@ -613,7 +616,9 @@ func TestArrayDecoding(t *testing.T) {
 				},
 			},
 			{
-				"select $1::smallint[]", []uint16{2, 4, 484, 32767}, &[]uint16{},
+				"select $1::smallint[]",
+				[]uint16{2, 4, 484, 32767},
+				&[]uint16{},
 				func(t testing.TB, query, scan any) {
 					if !reflect.DeepEqual(query, *(scan.(*[]uint16))) {
 						t.Errorf("failed to encode smallint[]")
@@ -621,7 +626,9 @@ func TestArrayDecoding(t *testing.T) {
 				},
 			},
 			{
-				"select $1::int[]", []int32{2, 4, 484}, &[]int32{},
+				"select $1::int[]",
+				[]int32{2, 4, 484},
+				&[]int32{},
 				func(t testing.TB, query, scan any) {
 					if !reflect.DeepEqual(query, *(scan.(*[]int32))) {
 						t.Errorf("failed to encode int[]")
@@ -629,7 +636,9 @@ func TestArrayDecoding(t *testing.T) {
 				},
 			},
 			{
-				"select $1::int[]", []uint32{2, 4, 484, 2147483647}, &[]uint32{},
+				"select $1::int[]",
+				[]uint32{2, 4, 484, 2147483647},
+				&[]uint32{},
 				func(t testing.TB, query, scan any) {
 					if !reflect.DeepEqual(query, *(scan.(*[]uint32))) {
 						t.Errorf("failed to encode int[]")
@@ -637,7 +646,9 @@ func TestArrayDecoding(t *testing.T) {
 				},
 			},
 			{
-				"select $1::bigint[]", []int64{2, 4, 484, 9223372036854775807}, &[]int64{},
+				"select $1::bigint[]",
+				[]int64{2, 4, 484, 9223372036854775807},
+				&[]int64{},
 				func(t testing.TB, query, scan any) {
 					if !reflect.DeepEqual(query, *(scan.(*[]int64))) {
 						t.Errorf("failed to encode bigint[]")
@@ -645,7 +656,9 @@ func TestArrayDecoding(t *testing.T) {
 				},
 			},
 			{
-				"select $1::bigint[]", []uint64{2, 4, 484, 9223372036854775807}, &[]uint64{},
+				"select $1::bigint[]",
+				[]uint64{2, 4, 484, 9223372036854775807},
+				&[]uint64{},
 				func(t testing.TB, query, scan any) {
 					if !reflect.DeepEqual(query, *(scan.(*[]uint64))) {
 						t.Errorf("failed to encode bigint[]")
@@ -653,7 +666,9 @@ func TestArrayDecoding(t *testing.T) {
 				},
 			},
 			{
-				"select $1::text[]", []string{"it's", "over", "9000!"}, &[]string{},
+				"select $1::text[]",
+				[]string{"it's", "over", "9000!"},
+				&[]string{},
 				func(t testing.TB, query, scan any) {
 					if !reflect.DeepEqual(query, *(scan.(*[]string))) {
 						t.Errorf("failed to encode text[]")
@@ -661,7 +676,9 @@ func TestArrayDecoding(t *testing.T) {
 				},
 			},
 			{
-				"select $1::timestamptz[]", []time.Time{time.Unix(323232, 0), time.Unix(3239949334, 00)}, &[]time.Time{},
+				"select $1::timestamptz[]",
+				[]time.Time{time.Unix(323232, 0), time.Unix(3239949334, 0o0)},
+				&[]time.Time{},
 				func(t testing.TB, query, scan any) {
 					queryTimeSlice := query.([]time.Time)
 					scanTimeSlice := *(scan.(*[]time.Time))
@@ -672,7 +689,9 @@ func TestArrayDecoding(t *testing.T) {
 				},
 			},
 			{
-				"select $1::bytea[]", [][]byte{{0, 1, 2, 3}, {4, 5, 6, 7}}, &[][]byte{},
+				"select $1::bytea[]",
+				[][]byte{{0, 1, 2, 3}, {4, 5, 6, 7}},
+				&[][]byte{},
 				func(t testing.TB, query, scan any) {
 					queryBytesSliceSlice := query.([][]byte)
 					scanBytesSliceSlice := *(scan.(*[][]byte))


### PR DESCRIPTION
- Added a .golangci.yaml configuration file for golangci-lint to standardize linting across the codebase.
- Applied code formatting throughout the project using the standard Go formatter.
- **Note for reviewers**:
This PR touches many files, but the changes are limited to whitespace cleanup and basic formatting improvements—no functional code changes have been made.
