### PR TITLE
ParseConfigError - redact password in connection string included in error message

### DIFF
--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -128,7 +128,8 @@ func (e *ParseConfigError) Error() string {
 	if e.err == nil {
 		return fmt.Sprintf("cannot parse `%s`: %s", connString, e.msg)
 	}
-	return fmt.Sprintf("cannot parse `%s`: %s (%s)", connString, e.msg, e.err.Error())
+	errorRedacted := redactPW(e.err.Error())
+	return fmt.Sprintf("cannot parse `%s`: %s (%s)", connString, e.msg, errorRedacted)
 }
 
 func (e *ParseConfigError) Unwrap() error {

--- a/pgconn/errors_test.go
+++ b/pgconn/errors_test.go
@@ -1,6 +1,7 @@
 package pgconn_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -42,6 +43,11 @@ func TestConfigError(t *testing.T) {
 			name:        "url without password",
 			err:         pgconn.NewParseConfigError("postgresql://other@host/db", "msg", nil),
 			expectedMsg: "cannot parse `postgresql://other@host/db`: msg",
+		},
+		{
+			name:        "url with password, include error",
+			err:         pgconn.NewParseConfigError("postgresql://foo:password@host", "msg", errors.New(`failed to parse as URL (postgresql://foo:password@host)`)),
+			expectedMsg: "cannot parse `postgresql://foo:xxxxx@host`: msg (failed to parse as URL (postgresql://foo:xxxxxx@host))",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes https://github.com/jackc/pgx/issues/1271

Since `redactPW` can redact the password even if URL parse fails, we can remove the password also from the error string.