### PR TITLE
Always wrap arguments in parentheses in the SQL sanitizer

### DIFF
--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -53,6 +53,10 @@ func (q *Query) Sanitize(args ...interface{}) (string, error) {
 				return "", errors.Errorf("invalid arg type: %T", arg)
 			}
 			argUse[argIdx] = true
+
+			// Prevent SQL injection via Line Comment Creation
+			// https://github.com/jackc/pgx/security/advisories/GHSA-m7wr-2xf7-cm9p
+			str = "(" + str + ")"
 		default:
 			return "", errors.Errorf("invalid Part type: %T", part)
 		}

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -98,37 +98,37 @@ func TestQuerySanitize(t *testing.T) {
 		{
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},
 			args:     []interface{}{float64(1.23)},
-			expected: `select 1.23`,
+			expected: `select (1.23)`,
 		},
 		{
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},
 			args:     []interface{}{true},
-			expected: `select true`,
+			expected: `select (true)`,
 		},
 		{
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},
 			args:     []interface{}{[]byte{0, 1, 2, 3, 255}},
-			expected: `select '\x00010203ff'::bytea`,
+			expected: `select ('\x00010203ff')`,
 		},
 		{
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},
 			args:     []interface{}{nil},
-			expected: `select null`,
+			expected: `select (null)`,
 		},
 		{
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},
 			args:     []interface{}{"foobar"},
-			expected: `select 'foobar'`,
+			expected: `select ('foobar')`,
 		},
 		{
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},
 			args:     []interface{}{"foo'bar"},
-			expected: `select 'foo''bar'`,
+			expected: `select ('foo''bar')`,
 		},
 		{
 			query:    sanitize.Query{Parts: []sanitize.Part{"select ", 1}},
 			args:     []interface{}{`foo\'bar`},
-			expected: `select 'foo\''bar'`,
+			expected: `select ('foo\''bar')`,
 		},
 	}
 


### PR DESCRIPTION
My project discovered two security vulnerabilities during vulnerability scanning when referencing pgx/v3: CVE-2024-27289, CVE-2024-27304. This commit comes from v4: f94eb0e2. But I can't upgrade to v4, so I brought up this MR and hope to agree.