### PR TITLE
Draft: Add support for OAuth

### DIFF
--- a/pgconn/auth_oauth.go
+++ b/pgconn/auth_oauth.go
@@ -1,0 +1,67 @@
+package pgconn
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+)
+
+func (c *PgConn) oauthAuth(ctx context.Context) error {
+	if c.config.OAuthTokenProvider == nil {
+		return errors.New("OAuth authentication required but no token provider configured")
+	}
+
+	token, err := c.config.OAuthTokenProvider(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to obtain OAuth token: %w", err)
+	}
+
+	// https://www.rfc-editor.org/rfc/rfc7628.html#section-3.1
+	initialResponse := []byte("n,,\x01auth=Bearer " + token + "\x01\x01")
+
+	saslInitialResponse := &pgproto3.SASLInitialResponse{
+		AuthMechanism: "OAUTHBEARER",
+		Data:          initialResponse,
+	}
+	c.frontend.Send(saslInitialResponse)
+	err = c.flushWithPotentialWriteReadDeadlock()
+	if err != nil {
+		return err
+	}
+
+	msg, err := c.receiveMessage()
+	if err != nil {
+		return err
+	}
+
+	switch m := msg.(type) {
+	case *pgproto3.AuthenticationOk:
+		return nil
+	case *pgproto3.AuthenticationSASLContinue:
+		// Server sent error response in SASL continue
+		// https://www.rfc-editor.org/rfc/rfc7628.html#section-3.2.2
+		// https://www.rfc-editor.org/rfc/rfc7628.html#section-3.2.3
+		errResponse := struct {
+			Status              string `json:"status"`
+			Scope               string `json:"scope"`
+			OpenIDConfiguration string `json:"openid-configuration"`
+		}{}
+		err := json.Unmarshal(m.Data, &errResponse)
+		if err != nil {
+			return fmt.Errorf("invalid OAuth error response from server: %w", err)
+		}
+
+		// Per RFC 7628 section 3.2.3, we should send a SASLResponse which only contains \x01.
+		// However, since the connection will be closed anyway, we can skip this
+		return fmt.Errorf("OAuth authentication failed: %s", errResponse.Status)
+
+	case *pgproto3.ErrorResponse:
+		return ErrorResponseToPgError(m)
+
+	default:
+		return fmt.Errorf("unexpected message type during OAuth auth: %T", msg)
+	}
+}

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -75,6 +75,10 @@ type Config struct {
 	// that you close on FATAL errors by returning false.
 	OnPgError PgErrorHandler
 
+	// OAuthTokenProvider is a function that returns an OAuth token for authentication. If set, it will be used for
+	// OAUTHBEARER SASL authentication when the server requests it.
+	OAuthTokenProvider func(context.Context) (string, error)
+
 	createdByParseConfig bool // Used to enforce created by ParseConfig rule.
 }
 


### PR DESCRIPTION
Postgres 18 introduces support for OAuth authentication. This PR does implement support for it. Also see #2382 

Related links: 
- https://www.postgresql.org/docs/18/auth-oauth.html
- https://www.postgresql.org/docs/current/sasl-authentication.html#SASL-OAUTHBEARER

Currently it uses OAuth SASL for authentication if the OAuthTokenProvider is configured and the server offers `OAUTHBEARER`.
I'm not sure if this selection of the SASL auth mechanism is too primitive? Should this be configurable as well?
On the other hand I'm not sure if it is even possible that Postgres returns multiple SASL mechanisms. If I configure SCRAM and OAUTH in pg_hba.conf it seems it only returns the first match.

Also currently tests are missing.