### PR TITLE
Make RowsAffected faster

### DIFF
--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -777,23 +777,18 @@ func NewCommandTag(s string) CommandTag {
 // RowsAffected returns the number of rows affected. If the CommandTag was not
 // for a row affecting command (e.g. "CREATE TABLE") then it returns 0.
 func (ct CommandTag) RowsAffected() int64 {
-	// Find last non-digit
-	idx := -1
+	// Parse the number from the end in a single pass.
+	var n int64
+	var mult int64 = 1
+
 	for i := len(ct.s) - 1; i >= 0; i-- {
-		if ct.s[i] >= '0' && ct.s[i] <= '9' {
-			idx = i
+		c := ct.s[i]
+		if c >= '0' && c <= '9' {
+			n += int64(c-'0') * mult
+			mult *= 10
 		} else {
 			break
 		}
-	}
-
-	if idx == -1 {
-		return 0
-	}
-
-	var n int64
-	for _, b := range ct.s[idx:] {
-		n = n*10 + int64(b-'0')
 	}
 
 	return n


### PR DESCRIPTION
The current implementation uses two loops, first one to find out where digits start and second one to loop over the digits. The modified implementation starts at the end and loops till digits end. It is a bit faster than baseline.

```
$ go test -run=NONE -bench=BenchmarkCommandTagRowsAffected -benchmem -count=10 > /tmp/new.txt
$ git checkout master
$ go test -run=NONE -bench=BenchmarkCommandTagRowsAffected -benchmem -count=10 > /tmp/old.txt
$ benchstat /tmp/old.txt /tmp/new.txt
goos: darwin
goarch: arm64
pkg: github.com/jackc/pgx/v5/pgconn
cpu: Apple M1 Max
                                             │ /tmp/old.txt │            /tmp/new.txt             │
                                             │    sec/op    │   sec/op     vs base                │
CommandTagRowsAffected/UPDATE_1-10              3.166n ± 3%   2.075n ± 1%  -34.44% (p=0.000 n=10)
CommandTagRowsAffected/UPDATE_123456789-10     10.045n ± 2%   6.237n ± 2%  -37.90% (p=0.000 n=10)
CommandTagRowsAffected/INSERT_0_1-10            3.211n ± 1%   2.085n ± 1%  -35.08% (p=0.000 n=10)
CommandTagRowsAffected/INSERT_0_123456789-10   10.120n ± 3%   6.327n ± 7%  -37.48% (p=0.000 n=10)
geomean                                         5.670n        3.615n       -36.25%

                                             │ /tmp/old.txt │            /tmp/new.txt             │
                                             │     B/op     │    B/op     vs base                 │
CommandTagRowsAffected/UPDATE_1-10             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CommandTagRowsAffected/UPDATE_123456789-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CommandTagRowsAffected/INSERT_0_1-10           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CommandTagRowsAffected/INSERT_0_123456789-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                   ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                             │ /tmp/old.txt │            /tmp/new.txt             │
                                             │  allocs/op   │ allocs/op   vs base                 │
CommandTagRowsAffected/UPDATE_1-10             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CommandTagRowsAffected/UPDATE_123456789-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CommandTagRowsAffected/INSERT_0_1-10           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CommandTagRowsAffected/INSERT_0_123456789-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                   ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```