### PR TITLE
Add sentinel value for acquire errors

### DIFF
--- a/pgxpool/errors.go
+++ b/pgxpool/errors.go
@@ -1,0 +1,5 @@
+package pgxpool
+
+import "errors"
+
+var ErrInfiniteAcquireLoop = errors.New("pgxpool: detected infinite loop acquiring connection; likely bug in PrepareConn or BeforeAcquire hook")

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -2,7 +2,6 @@ package pgxpool
 
 import (
 	"context"
-	"errors"
 	"math/rand/v2"
 	"runtime"
 	"strconv"
@@ -652,7 +651,7 @@ func (p *Pool) Acquire(ctx context.Context) (c *Conn, err error) {
 
 		return cr.getConn(p, res), nil
 	}
-	return nil, errors.New("pgxpool: detected infinite loop acquiring connection; likely bug in PrepareConn or BeforeAcquire hook")
+	return nil, ErrInfiniteAcquireLoop
 }
 
 // AcquireFunc acquires a *Conn and calls f with that *Conn. ctx will only affect the Acquire. It has no effect on the


### PR DESCRIPTION
Creates a sentinel value for the error thrown in https://github.com/jackc/pgx/issues/2451 so that it can be handled separately.