### PR TITLE
Enable ineffassign linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - govet
+    - ineffassign
 
 # See: https://golangci-lint.run/usage/formatters/
 formatters:

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -788,7 +788,7 @@ func configTLS(settings map[string]string, thisHost string, parseConfigOptions P
 			// Attempt decryption with pass phrase
 			// NOTE: only supports RSA (PKCS#1)
 			if sslpassword != "" {
-				decryptedKey, decryptedError = x509.DecryptPEMBlock(block, []byte(sslpassword))
+				decryptedKey, decryptedError = x509.DecryptPEMBlock(block, []byte(sslpassword)) //nolint:ineffassign
 			}
 			// if sslpassword not provided or has decryption error when use it
 			// try to find sslpassword with callback function

--- a/pgconn/ctxwatch/context_watcher_test.go
+++ b/pgconn/ctxwatch/context_watcher_test.go
@@ -116,6 +116,7 @@ func TestContextWatcherStress(t *testing.T) {
 
 	for i := range cycleCount {
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel() // satisfy linter; cancel is idempotent
 		cw.Watch(ctx)
 		if i%2 == 0 {
 			cancel()

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -2648,7 +2648,8 @@ func TestConnCloseWhileCancellableQueryInProgress(t *testing.T) {
 
 	pgConn.Exec(ctx, "select n from generate_series(1,10) n")
 
-	closeCtx, _ := context.WithCancel(ctx)
+	closeCtx, closeCancel := context.WithCancel(ctx)
+	defer closeCancel()
 	pgConn.Close(closeCtx)
 	select {
 	case <-pgConn.CleanupDone():
@@ -3909,7 +3910,7 @@ func TestSNISupport(t *testing.T) {
 
 			_, port, _ := strings.Cut(ln.Addr().String(), ":")
 			connStr := fmt.Sprintf("sslmode=require host=localhost port=%s %s", port, tt.sni_param)
-			_, err = pgconn.Connect(ctx, connStr)
+			_, _ = pgconn.Connect(ctx, connStr)
 
 			select {
 			case sniHost := <-serverSNINameChan:

--- a/pgtype/array.go
+++ b/pgtype/array.go
@@ -299,7 +299,7 @@ func arrayParseQuotedValue(buf *bytes.Buffer) (string, bool, error) {
 				return "", false, err
 			}
 		case '"':
-			r, _, err = buf.ReadRune()
+			_, _, err = buf.ReadRune()
 			if err != nil {
 				return "", false, err
 			}


### PR DESCRIPTION
This also fixes all warnings about it.
