### PR TITLE
Fix misleading ParseConfig error when default_query_exec_mode is invalid

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -203,7 +203,9 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 		case "simple_protocol":
 			defaultQueryExecMode = QueryExecModeSimpleProtocol
 		default:
-			return nil, pgconn.NewParseConfigError(connString, "invalid default_query_exec_mode", err)
+			return nil, pgconn.NewParseConfigError(
+				connString, "invalid default_query_exec_mode", fmt.Errorf("unknown value %q", s),
+			)
 		}
 	}
 


### PR DESCRIPTION
In ParseConfigWithOptions, an invalid default_query_exec_mode produces a ParseConfigError with a nil cause, because the default branch passes err, which is always nil.