### PR TITLE
Fix golangci-lint configuration file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 # See for configurations: https://golangci-lint.run/usage/configuration/
-version: 2
+version: "2"
 
 linters:
   default: none
@@ -8,7 +8,6 @@ linters:
 
 # See: https://golangci-lint.run/usage/formatters/
 formatters:
-  default: none
   enable:
     - gofmt # https://pkg.go.dev/cmd/gofmt
     - gofumpt # https://github.com/mvdan/gofumpt


### PR DESCRIPTION
This PR fixes wrong elements in the `.golangci.yml`:

```console
$ golangci-lint config verify
jsonschema: "version" does not validate with "/properties/version/type": got number, want string
jsonschema: "formatters" does not validate with "/properties/formatters/additionalProperties": additional properties 'default' not allowed
The command is terminated due to an error: the configuration contains invalid elements
```