### PR TITLE
docs(RegisterConnConfig): explain alternative usage

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -32,6 +32,12 @@
 //	connStr := stdlib.RegisterConnConfig(connConfig)
 //	db, _ := sql.Open("pgx", connStr)
 //
+// Consider using stdlib.OpenDB + sqlx.NewDb instead of RegisterConnConfig
+// if your client code perform many short-lived connections to multiple DBs (to avoid memory leaks).
+//
+// db := stdlib.OpenDB(*pgxConfig)
+// dbconn := sqlx.NewDb(db, "pgx")
+//
 // pgx uses standard PostgreSQL positional parameters in queries. e.g. $1, $2. It does not support named parameters.
 //
 //	db.QueryRow("select * from users where id=$1", userID)
@@ -393,6 +399,12 @@ func (dc *driverConnector) Driver() driver.Driver {
 }
 
 // RegisterConnConfig registers a ConnConfig and returns the connection string to use with Open.
+// It uses a package-level Driver struct that holds a map that tracks all the connections,
+// using as key the connection string and as a value the *pgx.ConnConfig.
+// Consider using stdlib.OpenDB + sqlx.NewDb instead of RegisterConnConfig
+// if your clients perform many short-lived connections to multiple DBs (to avoid memory leaks):
+// db := stdlib.OpenDB(*pgxConfig)
+// dbconn := sqlx.NewDb(db, "pgx")
 func RegisterConnConfig(c *pgx.ConnConfig) string {
 	return pgxDriver.registerConnConfig(c)
 }


### PR DESCRIPTION
**Context**
The fact that RegisterConnConfig "holds" an internal map that can grow without bound is something that could be stated explicitly.

**PR changes**
I believe it would be a good idea to explain an alternative for clients with many short-lived connections to many DBs, to avoid memory leaks. Being a bit more explicit and vocal in the comments about how that works will help clients to choose if they really want to use RegisterConnConfig or the alternative shared.

I placed the comment both in
- RegisterConnConfig() (I believe this would be the perfect place as when you use a library you just check the docs from your editor and sometimes don't browse pkg.go.dev), 
- the top of the file in case people is browsing the documentation in https://pkg.go.dev/ so they can read through.

WDYT ? 

Thank you!