### PR TITLE
stdlib: Discard connections with open transactions in ResetSession

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -555,6 +555,12 @@ func (c *Conn) ResetSession(ctx context.Context) error {
 		return driver.ErrBadConn
 	}
 
+	// Discard connection if it has an open transaction. This can happen if the
+	// application did not properly commit or rollback a transaction.
+	if c.conn.PgConn().TxStatus() != 'I' {
+		return driver.ErrBadConn
+	}
+
 	now := time.Now()
 	idle := now.Sub(c.lastResetSessionTime)
 


### PR DESCRIPTION
When a connection is returned to the database/sql pool with an open
transaction, ResetSession now returns driver.ErrBadConn to discard it.
This prevents transaction state from leaking between operations.

Previously, if application code failed to commit or rollback a
transaction, the connection would be returned to the pool and reused.
Subsequent operations would unknowingly execute inside the leaked
transaction, and their work would be lost when the connection was
eventually discarded.

This matches the behavior of pgxpool, which already checks TxStatus when
releasing connections and destroys those not in idle state.

Signed-off-by: Jeremy Schneider <schneider@ardentperf.com>
