### PR TITLE
Don't log pgx.QueryResultFormatsByOID

### DIFF
--- a/tracelog/tracelog.go
+++ b/tracelog/tracelog.go
@@ -94,7 +94,20 @@ func LogLevelFromString(s string) (LogLevel, error) {
 func logQueryArgs(args []any) []any {
 	logArgs := make([]any, 0, len(args))
 
-	for _, a := range args {
+	for i, a := range args {
+		if i == 0 {
+			switch a.(type) {
+			case pgx.QueryResultFormats:
+				continue
+			case pgx.QueryResultFormatsByOID:
+				continue
+			case pgx.QueryExecMode:
+				continue
+			case pgx.QueryRewriter:
+				continue
+			}
+		}
+
 		switch v := a.(type) {
 		case []byte:
 			if len(v) < 64 {


### PR DESCRIPTION
Hello!

In case using `stdlib.OpenDBFromPool()` there is senseless `map pgx.QueryResultFormatsByOID like [map[16:1 17:1 20:1 21:1 23:1 26:1 28:1 29:1 700:1 701:1 1082:1 1114:1 1184:1] 3]` as the first argument.

Reproducer is here https://github.com/nkonev/pgx-log-repro

Before (branch `master` of the reproducer)
<img width="1835" height="470" alt="Screenshot from 2026-01-19 01-22-15" src="https://github.com/user-attachments/assets/da7f63f1-f545-4b19-a01e-a826b43e05af" />

After (branch `fix` of the reproducer)
<img width="1835" height="470" alt="Screenshot from 2026-01-19 01-22-00" src="https://github.com/user-attachments/assets/2a00484b-316e-424d-84d2-336aafd4e2b1" />
