### PR TITLE
Fix empty user in connection string defaulting to OS user

### DIFF
--- a/pgconn/config_test.go
+++ b/pgconn/config_test.go
@@ -1161,8 +1161,23 @@ func TestParseConfigExplicitEmptyUserDefaultsToOSUser(t *testing.T) {
 		expected   string
 	}{
 		{
-			name:       "explicit empty user parameter",
+			name:       "keyword value explicit empty user",
 			connString: "host=localhost dbname=test user=",
+			expected:   currentUser.Username,
+		},
+		{
+			name:       "keyword value quoted empty user",
+			connString: "host=localhost dbname=test user=''",
+			expected:   currentUser.Username,
+		},
+		{
+			name:       "url explicit empty user without password",
+			connString: "postgres://@localhost/test",
+			expected:   currentUser.Username,
+		},
+		{
+			name:       "url explicit empty user with password",
+			connString: "postgres://:secret@localhost/test",
 			expected:   currentUser.Username,
 		},
 	}


### PR DESCRIPTION
Fixes #2495

Defaults the PostgreSQL user to the current OS user when the connection string explicitly specifies an empty `user=` parameter, matching libpq, psql, and asyncpg behavior.

### What
Default the PostgreSQL user to the current OS user when the connection string
explicitly specifies an empty `user=` parameter.

### Why
libpq and other drivers (e.g. psql, asyncpg) treat `user=` as a signal to fall
back to the current OS user. pgx currently leaves the user empty, which causes
the server to reject the startup packet with SQLSTATE 28000.

### How
- Detect when `user` is explicitly present but empty
- Default `Config.User` using `os/user.Current()`
- Ignore lookup errors to avoid introducing new failure modes

### Testing
- Added test covering explicit empty `user=` behavior