### PR TITLE
Fix BGReader deadlock when stopping background reads

### DIFF
--- a/pgconn/internal/bgreader/bgreader.go
+++ b/pgconn/internal/bgreader/bgreader.go
@@ -95,8 +95,8 @@ func (r *BGReader) Read(p []byte) (int, error) {
 		return r.readFromReadResults(p)
 	}
 
-	// There are no unread background read results and the background reader is stopped.
-	if r.status == StatusStopped {
+	// There are no unread background read results and the background reader is stopped or stopping.
+	if r.status == StatusStopped || r.status == StatusStopping {
 		return r.r.Read(p)
 	}
 


### PR DESCRIPTION
BGReader.Read could block forever if Stop() was called while the background goroutine was stuck in a read.

Read now falls back to direct reading when status is StatusStopping, not just StatusStopped.
Adds a unit test that reproduces the deadlock and verifies the fix.

Tests
go test ./pgconn/internal/bgreader -run TestBGReaderReadDoesNotWaitWhenStopping


Possible it's a fix for https://github.com/jackc/pgx/issues/2119
