### PR TITLE
Make LoadTypes query easier to support on "postgres-like" servers

### DIFF
--- a/derived_types.go
+++ b/derived_types.go
@@ -169,7 +169,7 @@ func (c *Conn) LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Typ
 	// the SQL not support recent structures such as multirange
 	serverVersion, _ := serverVersion(c)
 	sql := buildLoadDerivedTypesSQL(serverVersion, typeNames)
-	rows, err := c.Query(ctx, sql, typeNames)
+	rows, err := c.Query(ctx, sql, QueryResultFormats{TextFormatCode}, typeNames)
 	if err != nil {
 		return nil, fmt.Errorf("While generating load types query: %w", err)
 	}


### PR DESCRIPTION
I'm working with one of the many Postgres "compatible" servers, and making this small change to the query from the `LoadTypes` function makes it "just work". It was not needed to use the simple protocol for this query, it was only necessary for the results to use text encoding.