### PR TITLE
Skip standard_conforming_strings=off on PG19

### DIFF
--- a/pgxtest/pgxtest.go
+++ b/pgxtest/pgxtest.go
@@ -171,3 +171,21 @@ func SkipPostgreSQLVersionLessThan(t testing.TB, conn *pgx.Conn, minVersion int6
 		t.Skipf("Test requires PostgreSQL v%d+", minVersion)
 	}
 }
+
+func SkipPostgreSQLVersionGreaterThan(t testing.TB, conn *pgx.Conn, maxVersion int64) {
+	serverVersionStr := conn.PgConn().ParameterStatus("server_version")
+	serverVersionStr = regexp.MustCompile(`^[0-9]+`).FindString(serverVersionStr)
+	// if not PostgreSQL do nothing
+	if serverVersionStr == "" {
+		return
+	}
+
+	serverVersion, err := strconv.ParseInt(serverVersionStr, 10, 64)
+	if err != nil {
+		t.Fatalf("postgres version parsed failed: %s", err)
+	}
+
+	if serverVersion > maxVersion {
+		t.Skipf("Test requires PostgreSQL v%d or lower", maxVersion)
+	}
+}

--- a/query_test.go
+++ b/query_test.go
@@ -2031,6 +2031,7 @@ func TestConnSimpleProtocolRefusesNonStandardConformingStrings(t *testing.T) {
 	defer closeConn(t, conn)
 
 	pgxtest.SkipCockroachDB(t, conn, "Server does not support standard_conforming_strings = off (https://github.com/cockroachdb/cockroach/issues/36215)")
+	pgxtest.SkipPostgreSQLVersionGreaterThan(t, conn, 18) // PG19 stopped supporting standard_conforming_strings = off
 
 	mustExec(t, conn, "set standard_conforming_strings to off")
 


### PR DESCRIPTION
For the same security reason why `standard_conforming_strings=off` is disallowed by pgx in combination with the simple query protocol, in PG19 `standard_conforming_strings=off` won't be allowed anymore at all.

See this for details: https://github.com/postgres/postgres/commit/45762084545ec14dbbe66ace1d69d7e89f8978ac
