### PR TITLE
Add Batch.QueueBulkInsert for multi-row INSERT batching

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -85,6 +85,70 @@ func (b *Batch) Len() int {
 	return len(b.QueuedQueries)
 }
 
+// maxPostgresParameters is the maximum number of bind parameters allowed in a single
+// PostgreSQL query ($1 through $65535).
+const maxPostgresParameters = 65535
+
+// QueueBulkInsert splits the provided arguments into chunks of batchSize rows and queues each
+// chunk as a single multi-value INSERT. The query must be a single-row INSERT template using
+// positional placeholders ($1, $2, ...):
+//
+//	INSERT INTO t (a, b) VALUES ($1, $2)
+//
+// QueueBulkInsert rewrites this into:
+//
+//	INSERT INTO t (a, b) VALUES ($1, $2), ($3, $4), ($5, $6), ...
+//
+// Any clause after the VALUES tuple (e.g. ON CONFLICT, RETURNING) is preserved on every chunk.
+//
+// batchSize is the maximum number of rows per INSERT statement. Pass 0 to use the default of
+// 100. Returns (nil, nil) if no arguments are provided.
+//
+// Returns an error if batchSize * params-per-row exceeds the PostgreSQL bind parameter limit of
+// 65535, if the argument count is not divisible by params-per-row, or if the query cannot be
+// parsed.
+func (b *Batch) QueueBulkInsert(query string, batchSize int, arguments ...any) ([]*QueuedQuery, error) {
+	if len(arguments) == 0 {
+		return nil, nil
+	}
+
+	effectiveBatchSize := 100
+	if batchSize > 0 {
+		effectiveBatchSize = batchSize
+	}
+
+	prefix, inner, suffix, err := splitInsertTemplate(query)
+	if err != nil {
+		return nil, fmt.Errorf("QueueBulkInsert: %w", err)
+	}
+
+	paramsPerRow := countInsertParams(inner)
+	if paramsPerRow == 0 {
+		return nil, fmt.Errorf("QueueBulkInsert: no bind parameters found in VALUES clause")
+	}
+	if len(arguments)%paramsPerRow != 0 {
+		return nil, fmt.Errorf("QueueBulkInsert: argument count (%d) is not divisible by params per row (%d)",
+			len(arguments), paramsPerRow)
+	}
+
+	rowCount := len(arguments) / paramsPerRow
+
+	if effectiveBatchSize*paramsPerRow > maxPostgresParameters {
+		return nil, fmt.Errorf("QueueBulkInsert: batchSize (%d) * params per row (%d) = %d exceeds PostgreSQL bind parameter limit of %d",
+			effectiveBatchSize, paramsPerRow, effectiveBatchSize*paramsPerRow, maxPostgresParameters)
+	}
+
+	var qqs []*QueuedQuery
+	for i := 0; i < rowCount; i += effectiveBatchSize {
+		end := min(i+effectiveBatchSize, rowCount)
+		chunkSize := end - i
+		sql := buildBulkExpandedSQL(prefix, inner, suffix, chunkSize, paramsPerRow)
+		chunkArgs := arguments[i*paramsPerRow : end*paramsPerRow]
+		qqs = append(qqs, b.Queue(sql, chunkArgs...))
+	}
+	return qqs, nil
+}
+
 type BatchResults interface {
 	// Exec reads the results from the next query in the batch as if the query has been sent with Conn.Exec. Prefer
 	// calling Exec on the QueuedQuery, or just calling Close.

--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -1,0 +1,248 @@
+package pgx
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// findInsertValuesTupleRange finds the byte range of the first VALUES row tuple in an INSERT
+// query. Returns (start, end) where start is the index of '(' and end is the index of the
+// matching ')'. Handles single/double-quoted strings and line/block comments.
+func findInsertValuesTupleRange(sql string) (start, end int, err error) {
+	n := len(sql)
+	i := 0
+
+	// Phase 1: scan for the VALUES keyword, skipping strings and comments.
+	valuesFound := false
+	for i < n && !valuesFound {
+		switch {
+		case sql[i] == '\'':
+			i = skipInsertSingleQuote(sql, i+1)
+		case sql[i] == '"':
+			i = skipInsertDoubleQuote(sql, i+1)
+		case sql[i] == '-' && i+1 < n && sql[i+1] == '-':
+			i = skipInsertLineComment(sql, i+2)
+		case sql[i] == '/' && i+1 < n && sql[i+1] == '*':
+			i = skipInsertBlockComment(sql, i+2)
+		case (sql[i] == 'V' || sql[i] == 'v') && i+6 <= n && strings.EqualFold(sql[i:i+6], "VALUES"):
+			prevOK := i == 0 || !isInsertIDChar(sql[i-1])
+			nextOK := i+6 >= n || !isInsertIDChar(sql[i+6])
+			if prevOK && nextOK {
+				i += 6
+				valuesFound = true
+			} else {
+				i++
+			}
+		default:
+			i++
+		}
+	}
+
+	if !valuesFound {
+		return 0, 0, fmt.Errorf("VALUES clause not found in INSERT query")
+	}
+
+	// Phase 2: skip whitespace and find '('.
+	for i < n && isInsertSpace(sql[i]) {
+		i++
+	}
+	if i >= n || sql[i] != '(' {
+		return 0, 0, fmt.Errorf("expected '(' after VALUES in INSERT query")
+	}
+	start = i
+	i++
+
+	// Phase 3: balance parentheses to find the matching ')'.
+	depth := 1
+	for i < n {
+		switch {
+		case sql[i] == '(':
+			depth++
+			i++
+		case sql[i] == ')':
+			depth--
+			if depth == 0 {
+				return start, i, nil
+			}
+			i++
+		case sql[i] == '\'':
+			i = skipInsertSingleQuote(sql, i+1)
+		case sql[i] == '"':
+			i = skipInsertDoubleQuote(sql, i+1)
+		default:
+			i++
+		}
+	}
+
+	return 0, 0, fmt.Errorf("unbalanced parentheses in VALUES clause")
+}
+
+// splitInsertTemplate splits an INSERT...VALUES query template into three parts around the first
+// VALUES row tuple.
+//
+// For "INSERT INTO t (a, b) VALUES ($1, $2) ON CONFLICT DO NOTHING":
+//
+//	prefix = "INSERT INTO t (a, b) VALUES ("
+//	inner  = "$1, $2"
+//	suffix = " ON CONFLICT DO NOTHING"
+func splitInsertTemplate(sql string) (prefix, inner, suffix string, err error) {
+	tupleStart, tupleEnd, err := findInsertValuesTupleRange(sql)
+	if err != nil {
+		return "", "", "", err
+	}
+	prefix = sql[:tupleStart+1]          // up to and including '('
+	inner = sql[tupleStart+1 : tupleEnd] // content inside ()
+	suffix = sql[tupleEnd+1:]            // after ')'
+	return prefix, inner, suffix, nil
+}
+
+// countInsertParams returns the maximum $N placeholder index found in the SQL fragment.
+// String literals within the fragment are skipped.
+func countInsertParams(fragment string) int {
+	max := 0
+	n := len(fragment)
+	for i := 0; i < n; i++ {
+		switch {
+		case fragment[i] == '\'':
+			i = skipInsertSingleQuote(fragment, i+1) - 1
+		case fragment[i] == '"':
+			i = skipInsertDoubleQuote(fragment, i+1) - 1
+		case fragment[i] == '$' && i+1 < n && fragment[i+1] >= '1' && fragment[i+1] <= '9':
+			j := i + 1
+			for j < n && fragment[j] >= '0' && fragment[j] <= '9' {
+				j++
+			}
+			if num, e := strconv.Atoi(fragment[i+1 : j]); e == nil && num > max {
+				max = num
+			}
+			i = j - 1
+		}
+	}
+	return max
+}
+
+// renumberPlaceholders adds offset to every $N placeholder in template.
+// Single-quoted string literals are copied verbatim without modification.
+//
+//	renumberPlaceholders("$1, $2", 2)  → "$3, $4"
+//	renumberPlaceholders("$1, 'x'", 4) → "$5, 'x'"
+func renumberPlaceholders(template string, offset int) string {
+	var sb strings.Builder
+	i := 0
+	n := len(template)
+	for i < n {
+		switch {
+		case template[i] == '\'':
+			// Copy single-quoted string verbatim.
+			sb.WriteByte('\'')
+			i++
+			for i < n {
+				ch := template[i]
+				sb.WriteByte(ch)
+				i++
+				if ch == '\'' {
+					if i < n && template[i] == '\'' {
+						sb.WriteByte(template[i]) // escaped ''
+						i++
+					} else {
+						break
+					}
+				}
+			}
+		case template[i] == '$' && i+1 < n && template[i+1] >= '1' && template[i+1] <= '9':
+			j := i + 1
+			for j < n && template[j] >= '0' && template[j] <= '9' {
+				j++
+			}
+			num, _ := strconv.Atoi(template[i+1 : j])
+			sb.WriteByte('$')
+			sb.WriteString(strconv.Itoa(num + offset))
+			i = j
+		default:
+			sb.WriteByte(template[i])
+			i++
+		}
+	}
+	return sb.String()
+}
+
+// buildBulkExpandedSQL generates a multi-row INSERT SQL from a split template.
+//
+//	prefix = "INSERT INTO t (a, b) VALUES ("
+//	inner  = "$1, $2"
+//	suffix = ""
+//	rowCount=3, paramsPerRow=2
+//	→ "INSERT INTO t (a, b) VALUES ($1, $2), ($3, $4), ($5, $6)"
+func buildBulkExpandedSQL(prefix, inner, suffix string, rowCount, paramsPerRow int) string {
+	var sb strings.Builder
+	sb.WriteString(prefix) // ends with "("
+	for row := 0; row < rowCount; row++ {
+		if row > 0 {
+			sb.WriteString(", (")
+			sb.WriteString(renumberPlaceholders(inner, row*paramsPerRow))
+		} else {
+			sb.WriteString(inner)
+		}
+		sb.WriteByte(')')
+	}
+	sb.WriteString(suffix)
+	return sb.String()
+}
+
+func skipInsertSingleQuote(sql string, i int) int {
+	for i < len(sql) {
+		if sql[i] == '\'' {
+			i++
+			if i < len(sql) && sql[i] == '\'' {
+				i++ // escaped ''
+			} else {
+				return i
+			}
+		} else {
+			i++
+		}
+	}
+	return i
+}
+
+func skipInsertDoubleQuote(sql string, i int) int {
+	for i < len(sql) {
+		if sql[i] == '"' {
+			i++
+			if i < len(sql) && sql[i] == '"' {
+				i++ // escaped ""
+			} else {
+				return i
+			}
+		} else {
+			i++
+		}
+	}
+	return i
+}
+
+func skipInsertLineComment(sql string, i int) int {
+	for i < len(sql) && sql[i] != '\n' {
+		i++
+	}
+	return i
+}
+
+func skipInsertBlockComment(sql string, i int) int {
+	for i+1 < len(sql) {
+		if sql[i] == '*' && sql[i+1] == '/' {
+			return i + 2
+		}
+		i++
+	}
+	return len(sql)
+}
+
+func isInsertIDChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+func isInsertSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}

--- a/bulk_insert_test.go
+++ b/bulk_insert_test.go
@@ -1,0 +1,207 @@
+package pgx_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchQueueBulkInsert(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		mustExec(t, conn, `create temporary table ledger(
+  id serial primary key,
+  description varchar not null,
+  amount int not null
+);`)
+
+		batch := &pgx.Batch{}
+		qqs, err := batch.QueueBulkInsert(
+			"INSERT INTO ledger (description, amount) VALUES ($1, $2)",
+			0,
+			"q1", 1, "q2", 2, "q3", 3,
+		)
+		require.NoError(t, err)
+		require.Len(t, qqs, 1) // 3 rows, default batchSize=100 → single chunk
+		batch.Queue("select count(*) from ledger")
+
+		br := conn.SendBatch(ctx, batch)
+
+		ct, err := br.Exec()
+		require.NoError(t, err)
+		assert.EqualValues(t, 3, ct.RowsAffected())
+
+		var count int
+		err = br.QueryRow().Scan(&count)
+		require.NoError(t, err)
+		assert.EqualValues(t, 3, count)
+
+		err = br.Close()
+		require.NoError(t, err)
+	})
+}
+
+func TestBatchQueueBulkInsertEmptyArgs(t *testing.T) {
+	t.Parallel()
+
+	batch := &pgx.Batch{}
+	qqs, err := batch.QueueBulkInsert("INSERT INTO t (c1, c2) VALUES ($1, $2)", 0)
+	require.NoError(t, err)
+	assert.Nil(t, qqs)
+	assert.Equal(t, 0, batch.Len())
+}
+
+func TestBatchQueueBulkInsertBatchSize(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		mustExec(t, conn, `create temporary table ledger(
+  id serial primary key,
+  description varchar not null,
+  amount int not null
+);`)
+
+		// 250 rows, batchSize=100 → 3 chunks: 100+100+50
+		numInserts := 250
+		args := make([]any, 0, numInserts*2)
+		for i := range numInserts {
+			args = append(args, "description", i)
+		}
+
+		batch := &pgx.Batch{}
+		qqs, err := batch.QueueBulkInsert(
+			"INSERT INTO ledger (description, amount) VALUES ($1, $2)",
+			100,
+			args...,
+		)
+		require.NoError(t, err)
+		require.Len(t, qqs, 3)
+		batch.Queue("select count(*) from ledger")
+
+		br := conn.SendBatch(ctx, batch)
+
+		totalInserted := int64(0)
+		for range 3 {
+			ct, execErr := br.Exec()
+			require.NoError(t, execErr)
+			totalInserted += ct.RowsAffected()
+		}
+		assert.EqualValues(t, numInserts, totalInserted)
+
+		var count int
+		err = br.QueryRow().Scan(&count)
+		require.NoError(t, err)
+		assert.EqualValues(t, numInserts, count)
+
+		err = br.Close()
+		require.NoError(t, err)
+	})
+}
+
+func TestBatchQueueBulkInsertDefaultBatchSize(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		mustExec(t, conn, `create temporary table ledger(
+  id serial primary key,
+  description varchar not null,
+  amount int not null
+);`)
+
+		// 210 rows with default batchSize=100 → 3 chunks: 100+100+10
+		numInserts := 210
+		args := make([]any, 0, numInserts*2)
+		for i := range numInserts {
+			args = append(args, "description", i)
+		}
+
+		batch := &pgx.Batch{}
+		qqs, err := batch.QueueBulkInsert(
+			"INSERT INTO ledger (description, amount) VALUES ($1, $2)",
+			0, // use default
+			args...,
+		)
+		require.NoError(t, err)
+		require.Len(t, qqs, 3)
+
+		br := conn.SendBatch(ctx, batch)
+		for range 3 {
+			_, execErr := br.Exec()
+			require.NoError(t, execErr)
+		}
+		err = br.Close()
+		require.NoError(t, err)
+	})
+}
+
+func TestBatchQueueBulkInsertExceedsParameterLimit(t *testing.T) {
+	t.Parallel()
+
+	batch := &pgx.Batch{}
+	// batchSize=65536, paramsPerRow=1 → 65536 > 65535
+	_, err := batch.QueueBulkInsert("INSERT INTO t (c1) VALUES ($1)", 65536, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "65535")
+	assert.Equal(t, 0, batch.Len())
+}
+
+func TestBatchQueueBulkInsertArgMismatch(t *testing.T) {
+	t.Parallel()
+
+	batch := &pgx.Batch{}
+	// paramsPerRow=2, but 3 args → not divisible
+	_, err := batch.QueueBulkInsert("INSERT INTO t (c1, c2) VALUES ($1, $2)", 0, 1, 2, 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not divisible")
+	assert.Equal(t, 0, batch.Len())
+}
+
+func TestBatchQueueBulkInsertOnConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		pgxtest.SkipCockroachDB(t, conn, "ON CONFLICT behavior may differ")
+
+		mustExec(t, conn, `create temporary table kv(
+  key varchar primary key,
+  val int not null
+);`)
+		mustExec(t, conn, "INSERT INTO kv (key, val) VALUES ('a', 1), ('b', 2)")
+
+		// "a" and "b" already exist → ON CONFLICT DO NOTHING; only "c" is inserted
+		batch := &pgx.Batch{}
+		qqs, err := batch.QueueBulkInsert(
+			"INSERT INTO kv (key, val) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+			0,
+			"a", 10, "b", 20, "c", 30,
+		)
+		require.NoError(t, err)
+		require.Len(t, qqs, 1)
+
+		br := conn.SendBatch(ctx, batch)
+		ct, err := br.Exec()
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, ct.RowsAffected())
+
+		err = br.Close()
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Add `Batch.QueueBulkInsert` for multi-row INSERT batching

### Summary

Add a new `Batch.QueueBulkInsert` method that automatically rewrites a single-row INSERT template into a multi-row `INSERT ... VALUES (...), (...), (...)` statement and queues it as a batch query. This provides a convenient, high-performance way to bulk insert many rows using pgx's existing batch mechanism.

### Motivation

pgx's `Batch` already minimizes network round trips — `ExecBatch` sends all queued queries in a single round trip, and pipeline-based modes (CacheStatement, CacheDescribe, DescribeExec) pipeline everything through one or two flushes. **Round trips are not the problem.**

The problem is **per-statement overhead on the PostgreSQL server**. When N rows are queued as N individual `INSERT` statements within a batch, PostgreSQL must still parse, plan, and execute each statement separately, even though they all arrive in a single network write. Each statement also carries its own wire-protocol message sequence (Parse / Bind / Describe / Execute in extended protocol, or a separate semicolon-delimited SQL string in simple protocol). For large N this overhead dominates.

A multi-row `INSERT ... VALUES (...), (...), (...)` collapses N rows into a single statement that PostgreSQL parses once, plans once, and executes as one operation. This is significantly faster in practice.

pgx already provides `CopyFrom` for maximum throughput, but `COPY` cannot use `ON CONFLICT`, `RETURNING`, default expressions, or triggers on individual rows. Multi-row INSERT fills the gap: it's faster than N×1-row batched inserts while retaining full SQL flexibility.

Building the expanded SQL and renumbered placeholders by hand is tedious and error-prone. `QueueBulkInsert` automates this.

### Usage

```go
batch := &pgx.Batch{}
qqs, err := batch.QueueBulkInsert(
    "INSERT INTO ledger (description, amount) VALUES ($1, $2)",
    0,  // 0 = default chunk size of 100 rows per statement
    "a", 1, "b", 2, "c", 3,
)
// qqs contains one *QueuedQuery (3 rows < default 100)

br := conn.SendBatch(ctx, batch)
ct, err := br.Exec()
// ct.RowsAffected() == 3
err = br.Close()
```

For large inserts the arguments are automatically chunked:

```go
// 250 rows with batchSize=100 → 3 queued queries (100 + 100 + 50)
qqs, err := batch.QueueBulkInsert(
    "INSERT INTO ledger (description, amount) VALUES ($1, $2)",
    100,
    args...,
)
```

Trailing clauses like `ON CONFLICT` or `RETURNING` are preserved on every chunk.

### API

```go
func (b *Batch) QueueBulkInsert(query string, batchSize int, arguments ...any) ([]*QueuedQuery, error)
```

**Parameters:**
- `query` — A single-row INSERT template with positional placeholders (`$1`, `$2`, …).
- `batchSize` — Maximum number of rows per expanded INSERT. Pass `0` for the default (100).
- `arguments` — Flat list of arguments. Must be evenly divisible by the number of placeholders per row.

**Returns:**
- `[]*QueuedQuery` — The queued queries (one per chunk), or `nil` if no arguments are provided.
- `error` — Returned if the query cannot be parsed, arguments don't align, or `batchSize * paramsPerRow` exceeds PostgreSQL's 65535 bind parameter limit.

### Implementation details

| File | Description |
|---|---|
| `batch.go` | `QueueBulkInsert` method on `Batch` and `maxPostgresParameters` constant |
| `bulk_insert.go` | SQL parsing and rewriting helpers: `splitInsertTemplate`, `countInsertParams`, `renumberPlaceholders`, `buildBulkExpandedSQL`, and supporting scanner functions |
| `bulk_insert_test.go` | Integration and unit tests |

The SQL parser correctly handles:
- Single-quoted and double-quoted strings
- Line comments (`--`) and block comments (`/* */`)
- Nested parentheses in the VALUES tuple
- Case-insensitive `VALUES` keyword detection with identifier boundary checks

### Tests

| Test | What it covers |
|---|---|
| `TestBatchQueueBulkInsert` | Basic 3-row insert, verifies `RowsAffected` and row count |
| `TestBatchQueueBulkInsertEmptyArgs` | No arguments → returns `(nil, nil)`, batch unchanged |
| `TestBatchQueueBulkInsertBatchSize` | 250 rows / batchSize 100 → 3 chunks, verifies total count |
| `TestBatchQueueBulkInsertDefaultBatchSize` | 210 rows / default batchSize → 3 chunks |
| `TestBatchQueueBulkInsertExceedsParameterLimit` | batchSize exceeding 65535 params returns error |
| `TestBatchQueueBulkInsertArgMismatch` | Argument count not divisible by params-per-row returns error |
| `TestBatchQueueBulkInsertOnConflict` | `ON CONFLICT DO NOTHING` clause preserved and working |

All integration tests use `pgxtest.RunWithQueryExecModes` to verify behavior across all query execution modes.
