### PR TITLE
Fix a few issues in `devcontainers`.

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       PGPASSWORD: postgres
       PGDATABASE: pgx_test
       PGHOST: localhost
+      PGCLIENTENCODING: utf8
+
       # PGX test env vars target PG18 (port 5432) by default.
       # test.sh overrides these per-target.
       PGX_TEST_DATABASE: "host=localhost port=5432 user=postgres password=postgres dbname=pgx_test"
@@ -45,6 +47,7 @@ services:
       - ../testsetup/pg_ssl_init.sh:/docker-entrypoint-initdb.d/02-ssl-init.sh:ro
       - ../testsetup/pg_hba_devcontainer.conf:/etc/postgresql/pg_hba.conf:ro
       - ../testsetup/certs:/etc/postgresql/ssl:ro
+      - ../testsetup/postgresql_ssl.conf:/etc/postgresql/postgresql_ssl.conf:ro
       - pg-sockets:/var/run/postgresql
     network_mode: service:app
     environment:
@@ -52,7 +55,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: pgx_test
       POSTGRES_HOSTNAME: localhost
-    command: postgres -c port=5414 -c hba_file=/etc/postgresql/pg_hba.conf -c ssl=on -c ssl_cert_file=server.crt -c ssl_key_file=server.key -c ssl_ca_file=root.crt -c unix_socket_directories=/var/run/postgresql
+      PGPORT: 5414
+    command: postgres -c port=5414 -c hba_file=/etc/postgresql/pg_hba.conf -c unix_socket_directories=/var/run/postgresql
 
   postgres-15:
     image: postgres:15
@@ -63,6 +67,7 @@ services:
       - ../testsetup/pg_ssl_init.sh:/docker-entrypoint-initdb.d/02-ssl-init.sh:ro
       - ../testsetup/pg_hba_devcontainer.conf:/etc/postgresql/pg_hba.conf:ro
       - ../testsetup/certs:/etc/postgresql/ssl:ro
+      - ../testsetup/postgresql_ssl.conf:/etc/postgresql/postgresql_ssl.conf:ro
       - pg-sockets:/var/run/postgresql
     network_mode: service:app
     environment:
@@ -70,7 +75,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: pgx_test
       POSTGRES_HOSTNAME: localhost
-    command: postgres -c port=5415 -c hba_file=/etc/postgresql/pg_hba.conf -c ssl=on -c ssl_cert_file=server.crt -c ssl_key_file=server.key -c ssl_ca_file=root.crt -c unix_socket_directories=/var/run/postgresql
+      PGPORT: 5415
+    command: postgres -c port=5415 -c hba_file=/etc/postgresql/pg_hba.conf -c unix_socket_directories=/var/run/postgresql
 
   postgres-16:
     image: postgres:16
@@ -81,6 +87,7 @@ services:
       - ../testsetup/pg_ssl_init.sh:/docker-entrypoint-initdb.d/02-ssl-init.sh:ro
       - ../testsetup/pg_hba_devcontainer.conf:/etc/postgresql/pg_hba.conf:ro
       - ../testsetup/certs:/etc/postgresql/ssl:ro
+      - ../testsetup/postgresql_ssl.conf:/etc/postgresql/postgresql_ssl.conf:ro
       - pg-sockets:/var/run/postgresql
     network_mode: service:app
     environment:
@@ -88,7 +95,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: pgx_test
       POSTGRES_HOSTNAME: localhost
-    command: postgres -c port=5416 -c hba_file=/etc/postgresql/pg_hba.conf -c ssl=on -c ssl_cert_file=server.crt -c ssl_key_file=server.key -c ssl_ca_file=root.crt -c unix_socket_directories=/var/run/postgresql
+      PGPORT: 5416
+    command: postgres -c port=5416 -c hba_file=/etc/postgresql/pg_hba.conf -c unix_socket_directories=/var/run/postgresql
 
   postgres-17:
     image: postgres:17
@@ -99,6 +107,7 @@ services:
       - ../testsetup/pg_ssl_init.sh:/docker-entrypoint-initdb.d/02-ssl-init.sh:ro
       - ../testsetup/pg_hba_devcontainer.conf:/etc/postgresql/pg_hba.conf:ro
       - ../testsetup/certs:/etc/postgresql/ssl:ro
+      - ../testsetup/postgresql_ssl.conf:/etc/postgresql/postgresql_ssl.conf:ro
       - pg-sockets:/var/run/postgresql
     network_mode: service:app
     environment:
@@ -106,7 +115,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: pgx_test
       POSTGRES_HOSTNAME: localhost
-    command: postgres -c port=5417 -c hba_file=/etc/postgresql/pg_hba.conf -c ssl=on -c ssl_cert_file=server.crt -c ssl_key_file=server.key -c ssl_ca_file=root.crt -c unix_socket_directories=/var/run/postgresql
+      PGPORT: 5417
+    command: postgres -c port=5417 -c hba_file=/etc/postgresql/pg_hba.conf -c unix_socket_directories=/var/run/postgresql
 
   postgres-18:
     image: postgres:18
@@ -117,6 +127,7 @@ services:
       - ../testsetup/pg_ssl_init.sh:/docker-entrypoint-initdb.d/02-ssl-init.sh:ro
       - ../testsetup/pg_hba_devcontainer.conf:/etc/postgresql/pg_hba.conf:ro
       - ../testsetup/certs:/etc/postgresql/ssl:ro
+      - ../testsetup/postgresql_ssl.conf:/etc/postgresql/postgresql_ssl.conf:ro
       - pg-sockets:/var/run/postgresql
     network_mode: service:app
     environment:
@@ -124,7 +135,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: pgx_test
       POSTGRES_HOSTNAME: localhost
-    command: postgres -c hba_file=/etc/postgresql/pg_hba.conf -c ssl=on -c ssl_cert_file=server.crt -c ssl_key_file=server.key -c ssl_ca_file=root.crt -c unix_socket_directories=/var/run/postgresql
+    command: postgres -c hba_file=/etc/postgresql/pg_hba.conf -c unix_socket_directories=/var/run/postgresql
 
   cockroachdb:
     image: cockroachdb/cockroach:v25.4.4

--- a/testsetup/pg_ssl_init.sh
+++ b/testsetup/pg_ssl_init.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
-# Docker initdb script: copies SSL certificates to PGDATA with correct permissions.
-# Runs as the postgres user during container initialization.
+# Docker initdb script: copies SSL certificates to PGDATA with correct
+# permissions and enables SSL. Runs as the postgres user during container
+# initialization.
 base64 -d /etc/postgresql/ssl/localhost.crt.b64 > "$PGDATA/server.crt"
 base64 -d /etc/postgresql/ssl/localhost.key.b64 > "$PGDATA/server.key"
 base64 -d /etc/postgresql/ssl/ca.pem.b64 > "$PGDATA/root.crt"
 chmod 600 "$PGDATA/server.key"
+
+# Append SSL config to postgresql.conf rather than using command-line flags,
+# because the docker entrypoint passes command-line args to the temporary server
+# it starts before initdb scripts run. That temp server would fail with ssl=on
+# since the cert files don't exist yet.
+cat /etc/postgresql/postgresql_ssl.conf >> "$PGDATA/postgresql.conf"

--- a/testsetup/postgresql_setup.sql
+++ b/testsetup/postgresql_setup.sql
@@ -12,9 +12,14 @@ set password_encryption = 'scram-sha-256';
 create user pgx_pw with superuser PASSWORD 'secret';
 create user pgx_scram with superuser PASSWORD 'secret';
 create user pgx_oauth with superuser;
-\set whoami `whoami`
-create user :whoami with superuser; -- unix domain socket user
 
+-- When running in devcontainers, `whoami` will be `postgres`. Since the
+-- `postgres` user already exists, attempting to recreate it will fail.
+-- Therefore, we'll guard against that by no-op'ing if/when the user already
+-- exists and thereby not aborting the remaining setup.
+\set whoami `whoami`
+select format('create user %I with superuser', :'whoami')
+where not exists (select from pg_roles where rolname = :'whoami') \gexec
 
 -- The tricky test user, below, has to actually exist so that it can be used in a test
 -- of aclitem formatting. It turns out aclitems cannot contain non-existing users/roles.


### PR DESCRIPTION
While working on #2510 I encountered some issues with devcontainers that were
mostly introduced by `9b5e030e`:

* Unsupported client encoding for CRDB.
* SSL command-line flags cause the temp server to fail before initdb has copied
  the certs.
* `:whoami` user creation, when the user already exists.
* Postgres instances sharing `/var/run/postgresql` race on the default socket
  port.

The client encoding issue was discovered through some failing tests.
Specifically, with error: `no database or schema specified`. Digging in, it
became clear that the issue was rooted in the `init_crdb` function in `test.sh`
but was being silenced as `stderr` is redirected to `/dev/null`.

On startup `psql` attempts to determine from the environment[1] which client
encoding to use, falling back to `sqlascii`[2] when not set.  Unfortunately,
CRDB does not support this encoding[3], therefore attempts to setup CRDB
silently fails. We resolve this by simply setting `PGCLIENTENCODING` to `utf8`.

Removing the redirect demonstrates this:

```
❯ devcontainer exec --workspace-folder . ./test.sh crdb
==> Waiting for CockroachDB to be ready...
==> CockroachDB is ready
==> Ensuring pgx_test database exists on CockroachDB...
psql: error: connection to server at "localhost" (::1), port 26257 failed: Connection refused
        Is the server running on that host and accepting TCP/IP connections?
connection to server at "localhost" (127.0.0.1), port 26257 failed: ERROR:  unimplemented: unimplemented client encoding: "sqlascii"
HINT:  You have attempted to use a feature that is not yet implemented.
See: https://go.crdb.dev/issue-v/35882/v25.4
```

The SSL flag is a bit of a chicken-egg issue. The Docker entrypoint starts a
temporary server, using it to run initialization scripts, passing it the same
command-line arguments as the final server[4,5]. So, the problem is that because
`-c ssl=on` is set, the temporary server looks for the cert files that it is
trying to create. The seemingly simplest solution to this is to just move the
SSL configuration out of the command-line arguments and into `postgresql.conf`
directly.

The `:whoami` user creation was an interesting one. The simple explanation is
that when the setup script is run by the container, the user is `postgres`,
which obviously already exists. And further, since `ON_ERROR_STOP` is set[6],
this causes the execution of the setup to halt. So, the solution is an attempt
to simulate what I believe `CREATE USER ... IF NOT EXISTS` would do if it were
actually supported.

For the pg-sockets volume issue, all instances share the same
/var/run/postgresql. Each container must have a unique PGPORT set, because the
entrypoint always appends `-p ${PGPORT:-5432}`[7] when starting the temporary
server, overriding any `-c port=` from the user command. Without it, all
temporary servers race to bind port 5432 on the shared socket volume.

[1] https://github.com/postgres/postgres/blob/03facc1211b0ff1550f41bcd4da09329080c30f9/src/bin/psql/startup.c#L157
[2] https://github.com/postgres/postgres/blob/03facc1211b0ff1550f41bcd4da09329080c30f9/src/interfaces/libpq/fe-misc.c#L1281-L1298
[3] https://go.crdb.dev/issue-v/35882/v25.4
[4] https://github.com/docker-library/postgres/blob/6edb0a8c4def40c371514b34aef9037ec82d9110/docker-entrypoint.sh#L355
[5] https://github.com/docker-library/postgres/blob/6edb0a8c4def40c371514b34aef9037ec82d9110/docker-entrypoint.sh#L377
[6] https://github.com/docker-library/postgres/blob/6edb0a8c4def40c371514b34aef9037ec82d9110/docker-entrypoint.sh#L207
[7] https://github.com/docker-library/postgres/blob/6edb0a8c4def40c371514b34aef9037ec82d9110/docker-entrypoint.sh#L292