### PR TITLE
Add failing test: batch scan corrupted in cache_statement mode

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -1267,3 +1267,35 @@ func ExampleConn_SendBatch() {
 	// 3
 	// 5
 }
+
+// TestSendBatchPreservesResultFormats verifies that each batched query retains
+// its own result format codes. When the first query has a binary-preferred
+// column (int4) and the second has all text columns, scanning the first
+// query's int4 column must still work correctly.
+func TestSendBatchPreservesResultFormats(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		batch := &pgx.Batch{}
+		batch.Queue("SELECT 1::int4")
+		batch.Queue("SELECT 'hello'::text")
+
+		br := conn.SendBatch(ctx, batch)
+
+		var n int32
+		err := br.QueryRow().Scan(&n)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), n)
+
+		var s string
+		err = br.QueryRow().Scan(&s)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", s)
+
+		err = br.Close()
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
`sendBatchExtendedWithDescription` passes `eqb.ResultFormats` to `SendQueryStatement` by reference. The next `Build` call reuses the backing array, corrupting the stored format codes for earlier queries. The server sends binary data (`Bind` was encoded correctly), but the local scan plan uses the corrupted text format code.

Exposed in v5.9.0 by c3a17505 (`pgx batch uses SendQueryStatement`), part of `Skip Describe Portal for cached prepared statements reducing network round trips`. The previous `SendQueryPrepared` path sent Describe Portal, so the server's `RowDescription` provided correct format codes regardless of the stored slice contents.

@jackc This happened when we updated to 5.9.0. As the test describes, I think it classifies as a bug? I haven't dug into how to fix it yet though, maybe that's immediately obvious to you? 

Test fails reproducing the problem we have:

```
PGX_TEST_DATABASE="host=localhost port=5432 user=postgres sslmode=disable" go test -run TestSendBatchPreservesResultFormats
--- FAIL: TestSendBatchPreservesResultFormats (0.80s)
    --- FAIL: TestSendBatchPreservesResultFormats/cache_statement (0.51s)
        batch_test.go:1290:
                Error Trace:    /Users/dirkjan/code/jackc/pgx/batch_test.go:1290
                                                        /Users/dirkjan/code/jackc/pgx/pgxtest/pgxtest.go:78
                                                        /Users/dirkjan/code/jackc/pgx/pgxtest/pgxtest.go:99
                Error:          Received unexpected error:
                                can't scan into dest[0] (col: int4): strconv.ParseInt: parsing "\x00\x00\x00\x01": invalid syntax
                Test:           TestSendBatchPreservesResultFormats/cache_statement
FAIL
exit status 1
FAIL    github.com/jackc/pgx/v5 1.120s
```

It shows that it tries to parse the binary wire encoding for `1` as `text` since the second query in the pipeline uses `text`. 