### PR TITLE
pgconn: fix parseKeywordValueSettings rejecting trailing whitespace

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -631,6 +631,9 @@ func parseKeywordValueSettings(s string) (map[string]string, error) {
 		"dbname": "database",
 	}
 
+	// Trim any leading whitespace so that the loop exits cleanly when only
+	// spaces remain (e.g. trailing spaces after the last value).
+	s = strings.TrimLeft(s, " \t\n\r\v\f")
 	for len(s) > 0 {
 		var key, val string
 		eqIdx := strings.IndexRune(s, '=')
@@ -655,11 +658,9 @@ func parseKeywordValueSettings(s string) (map[string]string, error) {
 				}
 			}
 			val = strings.Replace(strings.Replace(s[:end], "\\\\", "\\", -1), "\\'", "'", -1)
-			if end == len(s) {
-				s = ""
-			} else {
-				s = s[end+1:]
-			}
+			// Consume the value and trim any subsequent whitespace so that
+			// multiple trailing spaces don't cause a spurious parse failure.
+			s = strings.TrimLeft(s[end:], " \t\n\r\v\f")
 		} else { // quoted string
 			s = s[1:]
 			end := 0
@@ -675,11 +676,8 @@ func parseKeywordValueSettings(s string) (map[string]string, error) {
 				return nil, errors.New("unterminated quoted string in connection info string")
 			}
 			val = strings.Replace(strings.Replace(s[:end], "\\\\", "\\", -1), "\\'", "'", -1)
-			if end == len(s) {
-				s = ""
-			} else {
-				s = s[end+1:]
-			}
+			// Consume the closing quote and any subsequent whitespace.
+			s = strings.TrimLeft(s[end+1:], " \t\n\r\v\f")
 		}
 
 		if k, ok := nameMap[key]; ok {

--- a/pgconn/config_test.go
+++ b/pgconn/config_test.go
@@ -799,6 +799,44 @@ func TestParseConfigKVTrailingBackslash(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid backslash")
 }
 
+// https://github.com/jackc/pgx/issues/2284
+// Multiple trailing spaces and trailing spaces after quoted values must be
+// accepted as valid keyword/value connection strings.
+func TestParseConfigKVTrailingWhitespace(t *testing.T) {
+	tests := []struct {
+		name       string
+		connString string
+	}{
+		{
+			name:       "single trailing space",
+			connString: "dbname=foo ",
+		},
+		{
+			name:       "multiple trailing spaces",
+			connString: "dbname=foo  ",
+		},
+		{
+			name:       "trailing tab",
+			connString: "dbname=foo\t",
+		},
+		{
+			name:       "quoted value with trailing spaces",
+			connString: "dbname='foo'  ",
+		},
+		{
+			name:       "two key-value pairs with trailing spaces",
+			connString: "port=5432 dbname=foo  ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := pgconn.ParseConfig(tt.connString)
+			require.NoErrorf(t, err, "conn string %q should not produce an error", tt.connString)
+		})
+	}
+}
+
 func TestConfigCopyReturnsEqualConfig(t *testing.T) {
 	connString := "postgres://jack:secret@localhost:5432/mydb?application_name=pgxtest&search_path=myschema&connect_timeout=5"
 	original, err := pgconn.ParseConfig(connString)


### PR DESCRIPTION
## Summary

Fixes #2284.

`parseKeywordValueSettings` rejected valid keyword/value connection strings that had trailing whitespace or multiple spaces between values.

### Root cause

After consuming each value, the parser advanced by one byte (`s[end+1:]` for unquoted values, `s[end+1:]` after the closing quote for quoted values). This skipped a single whitespace character but left any additional leading spaces in `s`. On the next iteration, the loop found no `=` in `"  "` and returned `"invalid keyword/value"`.

The same issue occurred with quoted values followed by **any** trailing whitespace, because `s[end+1:]` only moved past the closing `'` and left the spaces.

### Fix

- Trim leading whitespace from `s` once before entering the loop so that an entirely-whitespace input exits cleanly.
- After consuming each value (unquoted and quoted), use `strings.TrimLeft(…)` instead of `[end+1:]` to consume all subsequent whitespace. This matches `libpq`'s behavior and the PostgreSQL documentation, which describes the connection string syntax as allowing spaces between key-value pairs.

### Tests added

`TestParseConfigKVTrailingWhitespace` covers:
- single / multiple trailing spaces
- trailing tab
- quoted value followed by trailing spaces
- two key-value pairs with trailing spaces