### PR TITLE
feat: Add StructArgs and StrictStructArgs for named query arguments

### DIFF
--- a/named_args.go
+++ b/named_args.go
@@ -118,20 +118,10 @@ func structArgs(sa any) (map[string]any, error) {
 	return out, nil
 }
 
+// dbTagKey derives the named-argument key for a struct field. Tag parsing matches
+// RowToStructByName* in rows.go (structTagKey, Lookup, comma options, db:"-").
+// Anonymous embedded structs are skipped without flattening (unlike row scanning).
 func dbTagKey(sf reflect.StructField) (key string, ok bool, err error) {
-	tag := sf.Tag.Get("db")
-	if tag == "-" {
-		return "", false, nil
-	}
-
-	if tag != "" {
-		tag, _, _ = strings.Cut(tag, ",")
-		if tag == "" {
-			return "", false, fmt.Errorf("field %s has empty `db` tag", sf.Name)
-		}
-		return tag, true, nil
-	}
-
 	if sf.Anonymous {
 		ft := sf.Type
 		if ft.Kind() == reflect.Pointer {
@@ -140,6 +130,20 @@ func dbTagKey(sf reflect.StructField) (key string, ok bool, err error) {
 		if ft.Kind() == reflect.Struct {
 			return "", false, nil
 		}
+	}
+
+	dbTag, dbTagPresent := sf.Tag.Lookup(structTagKey)
+	if dbTagPresent {
+		dbTag, _, _ = strings.Cut(dbTag, ",")
+	}
+	if dbTag == "-" {
+		return "", false, nil
+	}
+	if dbTagPresent {
+		if dbTag == "" {
+			return "", false, fmt.Errorf("field %s has empty `%s` tag", sf.Name, structTagKey)
+		}
+		return dbTag, true, nil
 	}
 
 	return sf.Name, true, nil

--- a/named_args.go
+++ b/named_args.go
@@ -3,6 +3,7 @@ package pgx
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -18,6 +19,7 @@ import (
 //
 // Named placeholders are case sensitive and must start with a letter or underscore. Subsequent characters can be
 // letters, numbers, or underscores.
+
 type NamedArgs map[string]any
 
 // RewriteQuery implements the QueryRewriter interface.
@@ -32,6 +34,115 @@ type StrictNamedArgs map[string]any
 // RewriteQuery implements the QueryRewriter interface.
 func (sna StrictNamedArgs) RewriteQuery(ctx context.Context, conn *Conn, sql string, args []any) (newSQL string, newArgs []any, err error) {
 	return rewriteQuery(sna, sql, true)
+}
+
+type errorQueryRewriter struct {
+	err error
+}
+
+func (r errorQueryRewriter) RewriteQuery(ctx context.Context, conn *Conn, sql string, args []any) (newSQL string, newArgs []any, err error) {
+	return "", nil, r.err
+}
+
+// StructArgs converts exported fields of a struct into a QueryRewriter so it can
+// be used as the first argument to a query method (e.g. "where id=@id").
+//
+// Field names are taken from the `db` struct tag if present. Tag values may
+// include comma-separated options (e.g. `db:"id,omitempty"`). A `db:"-"` field is
+// ignored. If no `db` tag is present, the Go field name is used.
+//
+// sa may be a struct or a pointer to a struct.
+func StructArgs(sa any) QueryRewriter {
+	args, err := structArgs(sa)
+	if err != nil {
+		return errorQueryRewriter{err: err}
+	}
+	return NamedArgs(args)
+}
+
+// StrictStructArgs is like StructArgs but uses StrictNamedArgs rewriting
+// semantics (i.e. errors if the SQL query references missing arguments or if
+// extra arguments are provided).
+func StrictStructArgs(sa any) QueryRewriter {
+	args, err := structArgs(sa)
+	if err != nil {
+		return errorQueryRewriter{err: err}
+	}
+	return StrictNamedArgs(args)
+}
+
+func structArgs(sa any) (map[string]any, error) {
+	if sa == nil {
+		return nil, fmt.Errorf("StructArgs requires a struct or pointer to struct, got nil")
+	}
+
+	v := reflect.ValueOf(sa)
+	t := v.Type()
+
+	if t.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return nil, fmt.Errorf("StructArgs requires a non-nil pointer to struct")
+		}
+		v = v.Elem()
+		t = v.Type()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("StructArgs requires a struct or pointer to struct, got %s", t)
+	}
+
+	out := make(map[string]any, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+
+		// Ignore unexported fields.
+		if sf.PkgPath != "" {
+			continue
+		}
+
+		key, ok, err := dbTagKey(sf)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+
+		if _, exists := out[key]; exists {
+			return nil, fmt.Errorf("duplicate StructArgs key %q", key)
+		}
+
+		out[key] = v.Field(i).Interface()
+	}
+
+	return out, nil
+}
+
+func dbTagKey(sf reflect.StructField) (key string, ok bool, err error) {
+	tag := sf.Tag.Get("db")
+	if tag == "-" {
+		return "", false, nil
+	}
+
+	if tag != "" {
+		tag, _, _ = strings.Cut(tag, ",")
+		if tag == "" {
+			return "", false, fmt.Errorf("field %s has empty `db` tag", sf.Name)
+		}
+		return tag, true, nil
+	}
+
+	if sf.Anonymous {
+		ft := sf.Type
+		if ft.Kind() == reflect.Pointer {
+			ft = ft.Elem()
+		}
+		if ft.Kind() == reflect.Struct {
+			return "", false, nil
+		}
+	}
+
+	return sf.Name, true, nil
 }
 
 type namedArg string

--- a/named_args_test.go
+++ b/named_args_test.go
@@ -160,3 +160,191 @@ func TestStrictNamedArgsRewriteQuery(t *testing.T) {
 		}
 	}
 }
+
+func TestStructArgs(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name         string
+		input        any
+		sql          string
+		expectedSQL  string
+		expectedArgs []any
+		expectError  bool
+	}{
+		{
+			name: "basic",
+			input: struct {
+				ID   int    `db:"id"`
+				Name string `db:"name,omitempty"`
+				Skip string `db:"-"`
+			}{ID: 42, Name: "x", Skip: "ignored"},
+			sql:          "select * from t where id=@id and name=@name",
+			expectedSQL:  "select * from t where id=$1 and name=$2",
+			expectedArgs: []any{42, "x"},
+		},
+		{
+			name: "pointer",
+			input: func() any {
+				type S struct {
+					ID int `db:"id"`
+				}
+				return &S{ID: 7}
+			}(),
+			sql:          "select * from t where id=@id",
+			expectedSQL:  "select * from t where id=$1",
+			expectedArgs: []any{7},
+		},
+		{
+			name: "unexported fields omitted (missing placeholders become nil)",
+			input: struct {
+				id int `db:"id"`
+				ID int `db:"ID"`
+			}{id: 1, ID: 2},
+			sql:          "select * from t where ID=@ID and id=@id",
+			expectedSQL:  "select * from t where ID=$1 and id=$2",
+			expectedArgs: []any{2, nil},
+		},
+		{
+			name: "missing db tag falls back to field name",
+			input: struct {
+				ID int
+			}{ID: 9},
+			sql:          "select * from t where ID=@ID",
+			expectedSQL:  "select * from t where ID=$1",
+			expectedArgs: []any{9},
+		},
+		{
+			name: "duplicate keys error",
+			input: struct {
+				A int `db:"x"`
+				B int `db:"x"`
+			}{A: 1, B: 2},
+			sql:         "select * from t where x=@x",
+			expectError: true,
+		},
+		{
+			name: "nil pointer returns error",
+			input: func() any {
+				type S struct {
+					ID int `db:"id"`
+				}
+				var s *S
+				return s
+			}(),
+			sql:         "select * from t where id=@id",
+			expectError: true,
+		},
+		{
+			name:        "non struct returns error",
+			input:       42,
+			sql:         "select * from t where id=@id",
+			expectError: true,
+		},
+		{
+			name:        "nil input returns error",
+			input:       nil,
+			sql:         "select * from t where id=@id",
+			expectError: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			qr := pgx.StructArgs(tt.input)
+			sql, args, err := qr.RewriteQuery(context.Background(), nil, tt.sql, nil)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedSQL, sql)
+			assert.EqualValues(t, tt.expectedArgs, args)
+		})
+	}
+}
+
+func TestStrictStructArgs(t *testing.T) {
+	t.Parallel()
+
+	type MyInt int
+
+	for _, tt := range []struct {
+		name         string
+		input        any
+		sql          string
+		expectedSQL  string
+		expectedArgs []any
+		expectError  bool
+	}{
+		{
+			name: "fallback to field name without db tag",
+			input: struct {
+				ID int
+			}{ID: 1},
+			sql:          "select * from t where ID=@ID",
+			expectedSQL:  "select * from t where ID=$1",
+			expectedArgs: []any{1},
+		},
+		{
+			name: "empty db tag errors",
+			input: struct {
+				ID int `db:","`
+			}{ID: 1},
+			sql:         "select * from t where ID=@ID",
+			expectError: true,
+		},
+		{
+			name: "duplicate keys error",
+			input: struct {
+				A int `db:"x"`
+				B int `db:"x"`
+			}{A: 1, B: 2},
+			sql:         "select * from t where x=@x",
+			expectError: true,
+		},
+		{
+			name: "skips anonymous embedded structs without flattening",
+			input: func() any {
+				type Embedded struct {
+					ID int `db:"id"`
+				}
+				type S struct {
+					Embedded
+					Name string `db:"name"`
+				}
+				return S{Embedded: Embedded{ID: 1}, Name: "x"}
+			}(),
+			sql:         "select * from t where name=@name and id=@id",
+			expectError: true,
+		},
+		{
+			name: "anonymous embedded non-struct still requires tag in strict mode",
+			input: func() any {
+				type S struct {
+					MyInt
+				}
+				return S{MyInt: 1}
+			}(),
+			sql:          "select * from t where MyInt=@MyInt",
+			expectedSQL:  "select * from t where MyInt=$1",
+			expectedArgs: []any{MyInt(1)},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			qr := pgx.StrictStructArgs(tt.input)
+			sql, args, err := qr.RewriteQuery(context.Background(), nil, tt.sql, nil)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedSQL, sql)
+			assert.EqualValues(t, tt.expectedArgs, args)
+		})
+	}
+}


### PR DESCRIPTION
Hi
Currently, `NamedArgs` and `StrictNamedArgs` require manually building a map of argument names to values. With this change, callers can pass a struct or pointer to a struct and pgx will derive named arguments from exported fields.
Implementation Features:
- `StructArgs` converts exported struct fields into `NamedArgs`
- `StrictStructArgs` converts exported struct fields into `StrictNamedArgs`
- Field names are taken from the `db` struct tag when present (has options like `db:"name,omitempty";` only the part before the comma is used).
- If no `db` tag is present, falls back to the Go field name.
- Ignores unexported fields.
- Both struct values and pointers to structs are supported.

Design Note:
- embedded structs are intentionally skipped rather than flattened. This keeps the behavior predictable and avoids implicit recursive field expansion.

Example:
```
type Foo struct {
    ID   int    `db:"id"`
    Name string `db:"name,omitempty"`
}

f := Foo{ID:   1,Name: "alice"}
_, err := conn.Exec(ctx,
    "insert into foo (id, name) values (@id, @name)",
    pgx.StructArgs(f),
)
```

Fixes: #2406 