### PR TITLE
pgconn: use fresh context for fallback connection in connectPreferred

### DIFF
--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -292,7 +292,13 @@ func connectPreferred(ctx context.Context, config *Config, connectOneConfigs []*
 	}
 
 	if fallbackConnectOneConfig != nil {
-		pgConn, err := connectOne(ctx, config, fallbackConnectOneConfig, true)
+		fallbackCtx := octx
+		if config.ConnectTimeout != 0 {
+			var cancel context.CancelFunc
+			fallbackCtx, cancel = context.WithTimeout(octx, config.ConnectTimeout)
+			defer cancel()
+		}
+		pgConn, err := connectOne(fallbackCtx, config, fallbackConnectOneConfig, true)
 		if err == nil {
 			return pgConn, nil
 		}


### PR DESCRIPTION
When `ConnectTimeout` is set, `connectPreferred` creates a per-host timeout context (derived from `octx`) for each host in the loop. After the loop finishes, `ctx` holds whatever context was used for the last host, which may have already expired by the time we get to the fallback.

The fallback path (for `prefer-standby` / `prefer-primary`) was passing that stale `ctx` to `connectOne`, so it would immediately get a deadline exceeded error even though the caller's original context still had time left.

The fix creates a fresh `ConnectTimeout`-bounded context from `octx` for the fallback, same pattern as the loop uses for each host.

Fixes #2172