### PR TITLE
Add missing error check of rows.Err to load types.

### DIFF
--- a/derived_types.go
+++ b/derived_types.go
@@ -236,6 +236,11 @@ func (c *Conn) LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Typ
 		}
 		result = append(result, type_)
 	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("While processing rows: %w", err)
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
This is an alternative to #2549.

It fixes one of the issues described in https://github.com/jackc/pgx/issues/2544.