### PR TITLE
pgconn: add ErrConnClosed sentinel and unwrap it from connLockError

### DIFF
--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -93,6 +93,12 @@ func (e *perDialConnectError) Unwrap() error {
 	return e.err
 }
 
+// ErrConnClosed is returned (possibly wrapped) when an operation is attempted
+// on a connection that the driver has already closed, e.g. because a prior
+// query was cancelled mid-flight or the underlying socket went away. Use
+// errors.Is to test for it, since it shows up wrapped inside connLockError.
+var ErrConnClosed = errors.New("conn closed")
+
 type connLockError struct {
 	status string
 }
@@ -103,6 +109,13 @@ func (e *connLockError) SafeToRetry() bool {
 
 func (e *connLockError) Error() string {
 	return e.status
+}
+
+func (e *connLockError) Unwrap() error {
+	if e.status == "conn closed" {
+		return ErrConnClosed
+	}
+	return nil
 }
 
 // ParseConfigError is the error returned when a connection string cannot be parsed.

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -2981,6 +2981,26 @@ func TestHijackAndConstruct(t *testing.T) {
 	ensureConnValid(t, newConn)
 }
 
+// Operations on a closed connection should surface an error that
+// satisfies errors.Is(err, pgconn.ErrConnClosed) so callers can tell a
+// dead-transport failure apart from things like a *PgError.
+// See https://github.com/jackc/pgx/issues/2557.
+func TestExecOnClosedConnErrConnClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgConn, err := pgconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+
+	require.NoError(t, pgConn.Close(ctx))
+
+	_, err = pgConn.Exec(ctx, "select 1").ReadAll()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, pgconn.ErrConnClosed)
+}
+
 func TestConnCloseWhileCancellableQueryInProgress(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
For #2557.

`connLockError{status: "conn closed"}` is what callers get back when something hits a connection the driver has already torn down (cancelled mid-`Exec`, fatal i/o, asyncClose, etc). The string was fine for humans but there's no sentinel to `errors.Is` against, so callers either string-compared or used side-channel checks like `tx.Conn().IsClosed()`. `pgconn.SafeToRetry` is broader since it's also true for `conn busy`, which is an application bug you'd actually want to surface, not swallow.

This adds `ErrConnClosed` as a sentinel and makes `connLockError.Unwrap()` return it when the status is `"conn closed"`. No exported types or signatures change, no error strings change, so it's v5-safe.

Picks up the v5-safe piece of the design @sean- sketched in #2557. The Tx-layer "distinguish transport from server errors" piece is v6 territory.

After this, the `defer tx.Rollback()` pattern from the issue can be:

```go
defer func() {
    err := tx.Rollback(ctx)
    if err == nil || errors.Is(err, pgx.ErrTxClosed) || errors.Is(err, pgconn.ErrConnClosed) {
        return
    }
    log.Printf("rollback failed: %v", err)
}()
```

Regression test connects, closes, runs `Exec`, asserts `errors.Is(err, pgconn.ErrConnClosed)`. Ran the full `./pgconn/...` suite locally against PG14.