### PR TITLE
fix(pgxpool): enforce MaxConnLifetime at Acquire time

### DIFF
--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -619,6 +619,14 @@ func (p *Pool) Acquire(ctx context.Context) (c *Conn, err error) {
 
 		cr := res.Value()
 
+		// Enforce MaxConnLifetime on acquire so it holds on hot pools where
+		// connections are rarely idle when the background health check runs.
+		if p.isExpired(res) {
+			atomic.AddInt64(&p.lifetimeDestroyCount, 1)
+			res.Destroy()
+			continue
+		}
+
 		shouldPingParams := ShouldPingParams{Conn: cr.conn, IdleDuration: res.IdleDuration()}
 		if p.shouldPing(ctx, shouldPingParams) {
 			err := func() error {

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -614,6 +614,40 @@ func TestConnReleaseChecksMaxConnLifetime(t *testing.T) {
 	assert.EqualValues(t, 0, stats.TotalConns())
 }
 
+func TestPoolAcquireChecksMaxConnLifetime(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	config, err := pgxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+
+	config.MaxConnLifetime = 250 * time.Millisecond
+	// Push the background health check far out so this test isolates the
+	// Acquire-time expiry check.
+	config.HealthCheckPeriod = time.Hour
+
+	db, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err)
+	defer db.Close()
+
+	c, err := db.Acquire(ctx)
+	require.NoError(t, err)
+	c.Release()
+	waitForReleaseToComplete()
+
+	time.Sleep(config.MaxConnLifetime + 50*time.Millisecond)
+
+	c, err = db.Acquire(ctx)
+	require.NoError(t, err)
+	defer c.Release()
+
+	stats := db.Stat()
+	assert.EqualValues(t, 1, stats.MaxLifetimeDestroyCount())
+	assert.EqualValues(t, 2, stats.NewConnsCount())
+}
+
 func TestConnReleaseClosesBusyConn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
MaxConnLifetime was only checked by the background health check, which inspects idle connections. On a hot pool a connection is constantly acquired and returned, so it is rarely idle when the check fires and can live well past MaxConnLifetime. This adds an isExpired check in the Acquire loop so the limit holds regardless of pool utilization.

Closes #2560