### PR TITLE
pgxpool: fix data race on concurrent conn.Release

### DIFF
--- a/pgxpool/conn.go
+++ b/pgxpool/conn.go
@@ -11,20 +11,22 @@ import (
 
 // Conn is an acquired *pgx.Conn from a Pool.
 type Conn struct {
-	res *puddle.Resource[*connResource]
+	// res is accessed atomically so that concurrent Release/Hijack calls on the
+	// same Conn cannot both take ownership of the underlying puddle resource.
+	res atomic.Pointer[puddle.Resource[*connResource]]
 	p   *Pool
 }
 
 // Release returns c to the pool it was acquired from. Once Release has been called, other methods must not be called.
 // However, it is safe to call Release multiple times. Subsequent calls after the first will be ignored.
 func (c *Conn) Release() {
-	if c.res == nil {
+	// Swap to nil so all other calls will be a no-op.
+	res := c.res.Swap(nil)
+	if res == nil {
 		return
 	}
 
-	conn := c.Conn()
-	res := c.res
-	c.res = nil
+	conn := res.Value().conn
 
 	if c.p.releaseTracer != nil {
 		c.p.releaseTracer.TraceRelease(c.p, TraceReleaseData{Conn: conn})
@@ -70,14 +72,13 @@ func (c *Conn) Release() {
 // Hijack assumes ownership of the connection from the pool. Caller is responsible for closing the connection. Hijack
 // will panic if called on an already released or hijacked connection.
 func (c *Conn) Hijack() *pgx.Conn {
-	if c.res == nil {
+	// Swap to nil so all other calls will be a no-op.
+	res := c.res.Swap(nil)
+	if res == nil {
 		panic("cannot hijack already released or hijacked connection")
 	}
 
-	conn := c.Conn()
-	res := c.res
-	c.res = nil
-
+	conn := res.Value().conn
 	res.Hijack()
 
 	return conn
@@ -122,7 +123,7 @@ func (c *Conn) Conn() *pgx.Conn {
 }
 
 func (c *Conn) connResource() *connResource {
-	return c.res.Value()
+	return c.res.Load().Value()
 }
 
 func (c *Conn) getPoolRow(r pgx.Row) *poolRow {

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -40,7 +40,7 @@ func (cr *connResource) getConn(p *Pool, res *puddle.Resource[*connResource]) *C
 	c := &cr.conns[len(cr.conns)-1]
 	cr.conns = cr.conns[0 : len(cr.conns)-1]
 
-	c.res = res
+	c.res.Store(res)
 	c.p = p
 
 	return c


### PR DESCRIPTION
When the same Conn was released from two goroutines at once, both
calls passed the guard, grabbed the same puddle resource, and released it
twice.

Fixes #2260.


I tested with a piece of code that reproduced the bug:

```zsh
docker run --name some-postgres -e POSTGRES_PASSWORD=postgres -d postgres

export PGX_TEST_DATABASE="host=localhost port=5432 user=postgres password=postgres dbname=postgres"

go run -race .
```

```go
func main() {
	dsn := os.Getenv("PGX_TEST_DATABASE")
	fmt.Println(dsn)

	cfg, err := pgxpool.ParseConfig(dsn)
	if err != nil {
		panic(err)
	}
	cfg.MaxConns = 8
	cfg.MinConns = 2
	cfg.HealthCheckPeriod = 10 * time.Millisecond // hammer AcquireAllIdle

	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
	if err != nil {
		panic(err)
	}
	defer pool.Close()

	ctx := context.Background()
	deadline := time.Now().Add(60 * time.Second)
	var wg sync.WaitGroup

	for range 16 {
		wg.Go(func() {
			for time.Now().Before(deadline) {
				c, err := pool.Acquire(ctx)
				if err != nil {
					continue
				}
				_, _ = c.Exec(ctx, "select 1")

				// double release of the SAME *pgxpool.Conn, concurrently.
				var w sync.WaitGroup
				w.Add(2)
				go func() { defer w.Done(); c.Release() }()
				go func() { defer w.Done(); c.Release() }()
				w.Wait()
			}
		})
	}

	wg.Wait()
	fmt.Println("no panic -> ok")
}
```