### PR TITLE
chore: enable gocritic linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - govet
     - ineffassign
     - unconvert
+    - gocritic
 
 # See: https://golangci-lint.run/usage/formatters/
 formatters:

--- a/conn.go
+++ b/conn.go
@@ -808,7 +808,8 @@ optionLoop:
 
 	var err error
 	sd, explicitPreparedStatement := c.preparedStatements[sql]
-	if sd != nil || mode == QueryExecModeCacheStatement || mode == QueryExecModeCacheDescribe || mode == QueryExecModeDescribeExec {
+	switch {
+	case sd != nil || mode == QueryExecModeCacheStatement || mode == QueryExecModeCacheDescribe || mode == QueryExecModeDescribeExec:
 		if sd == nil {
 			sd, err = c.getStatementDescription(ctx, mode, sql)
 			if err != nil {
@@ -846,7 +847,7 @@ optionLoop:
 		} else {
 			rows.resultReader = c.pgConn.ExecStatement(ctx, sd, c.eqb.ParamValues, c.eqb.ParamFormats, resultFormats)
 		}
-	} else if mode == QueryExecModeExec {
+	case mode == QueryExecModeExec:
 		err := c.eqb.Build(c.typeMap, nil, args)
 		if err != nil {
 			rows.fatal(err)
@@ -854,7 +855,7 @@ optionLoop:
 		}
 
 		rows.resultReader = c.pgConn.ExecParams(ctx, sql, c.eqb.ParamValues, nil, c.eqb.ParamFormats, c.eqb.ResultFormats)
-	} else if mode == QueryExecModeSimpleProtocol {
+	case mode == QueryExecModeSimpleProtocol:
 		sql, err = c.sanitizeForSimpleQuery(sql, args...)
 		if err != nil {
 			rows.fatal(err)
@@ -872,7 +873,7 @@ optionLoop:
 		}
 
 		return rows, nil
-	} else {
+	default:
 		err = fmt.Errorf("unknown QueryExecMode: %v", mode)
 		rows.fatal(err)
 		return rows, rows.err

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -19,7 +19,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	go listen()
+	go func() {
+		if err := listen(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}()
 
 	fmt.Println(`Type a message and press enter.
 
@@ -47,25 +52,22 @@ Type "exit" to quit.`)
 	}
 }
 
-func listen() {
+func listen() error {
 	conn, err := pool.Acquire(context.Background())
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error acquiring connection:", err)
-		os.Exit(1)
+		return fmt.Errorf("acquiring connection: %w", err)
 	}
 	defer conn.Release()
 
 	_, err = conn.Exec(context.Background(), "listen chat")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error listening to chat channel:", err)
-		os.Exit(1)
+		return fmt.Errorf("listening to chat channel: %w", err)
 	}
 
 	for {
 		notification, err := conn.Conn().WaitForNotification(context.Background())
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Error waiting for notification:", err)
-			os.Exit(1)
+			return fmt.Errorf("waiting for notification: %w", err)
 		}
 
 		fmt.Println("PID:", notification.PID, "Channel:", notification.Channel, "Payload:", notification.Payload)

--- a/pgconn/auth_scram.go
+++ b/pgconn/auth_scram.go
@@ -229,11 +229,12 @@ func (sc *scramClient) clientFirstMessage() []byte {
 
 	sc.clientFirstMessageBare = fmt.Appendf(nil, "n=,r=%s", sc.clientNonce)
 
-	if sc.authMechanism == scramSHA256PlusName {
+	switch {
+	case sc.authMechanism == scramSHA256PlusName:
 		sc.clientGS2Header = []byte("p=tls-server-end-point,,")
-	} else if sc.hasTLS {
+	case sc.hasTLS:
 		sc.clientGS2Header = []byte("y,,")
-	} else {
+	default:
 		sc.clientGS2Header = []byte("n,,")
 	}
 

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"math"
 	"net"
@@ -308,9 +307,7 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 		User:                 settings["user"],
 		Password:             settings["password"],
 		RuntimeParams:        make(map[string]string),
-		BuildFrontend: func(r io.Reader, w io.Writer) *pgproto3.Frontend {
-			return pgproto3.NewFrontend(r, w)
-		},
+		BuildFrontend:        pgproto3.NewFrontend,
 		BuildContextWatcherHandler: func(pgConn *PgConn) ctxwatch.Handler {
 			return &DeadlineContextWatcherHandler{Conn: pgConn.conn}
 		},
@@ -643,8 +640,9 @@ func parseKeywordValueSettings(s string) (map[string]string, error) {
 
 		key = strings.Trim(s[:eqIdx], " \t\n\r\v\f")
 		s = strings.TrimLeft(s[eqIdx+1:], " \t\n\r\v\f")
-		if len(s) == 0 {
-		} else if s[0] != '\'' {
+		switch {
+		case len(s) == 0:
+		case s[0] != '\'':
 			end := 0
 			for ; end < len(s); end++ {
 				if asciiSpace[s[end]] == 1 {
@@ -657,11 +655,11 @@ func parseKeywordValueSettings(s string) (map[string]string, error) {
 					}
 				}
 			}
-			val = strings.Replace(strings.Replace(s[:end], "\\\\", "\\", -1), "\\'", "'", -1)
+			val = strings.ReplaceAll(strings.ReplaceAll(s[:end], "\\\\", "\\"), "\\'", "'")
 			// Consume the value and trim any subsequent whitespace so that
 			// multiple trailing spaces don't cause a spurious parse failure.
 			s = strings.TrimLeft(s[end:], " \t\n\r\v\f")
-		} else { // quoted string
+		default: // quoted string
 			s = s[1:]
 			end := 0
 			for ; end < len(s); end++ {
@@ -675,7 +673,7 @@ func parseKeywordValueSettings(s string) (map[string]string, error) {
 			if end == len(s) {
 				return nil, errors.New("unterminated quoted string in connection info string")
 			}
-			val = strings.Replace(strings.Replace(s[:end], "\\\\", "\\", -1), "\\'", "'", -1)
+			val = strings.ReplaceAll(strings.ReplaceAll(s[:end], "\\\\", "\\"), "\\'", "'")
 			// Consume the closing quote and any subsequent whitespace.
 			s = strings.TrimLeft(s[end+1:], " \t\n\r\v\f")
 		}

--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -151,12 +151,13 @@ func (e *ParseConfigError) Unwrap() error {
 func normalizeTimeoutError(ctx context.Context, err error) error {
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
-		if ctx.Err() == context.Canceled {
+		switch ctx.Err() {
+		case context.Canceled:
 			// Since the timeout was caused by a context cancellation, the actual error is context.Canceled not the timeout error.
 			return context.Canceled
-		} else if ctx.Err() == context.DeadlineExceeded {
+		case context.DeadlineExceeded:
 			return &errTimeout{err: ctx.Err()}
-		} else {
+		default:
 			return &errTimeout{err: err}
 		}
 	}

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -1125,8 +1125,7 @@ func (pgConn *PgConn) WaitForNotification(ctx context.Context) error {
 			return normalizeTimeoutError(ctx, err)
 		}
 
-		switch msg.(type) {
-		case *pgproto3.NotificationResponse:
+		if _, ok := msg.(*pgproto3.NotificationResponse); ok {
 			return nil
 		}
 	}
@@ -1711,8 +1710,7 @@ func (rr *ResultReader) NextRow() bool {
 			return false
 		}
 
-		switch msg := msg.(type) {
-		case *pgproto3.DataRow:
+		if msg, ok := msg.(*pgproto3.DataRow); ok {
 			rr.rowValues = msg.Values
 			return true
 		}
@@ -2009,7 +2007,7 @@ func (pgConn *PgConn) EscapeString(s string) (string, error) {
 		return "", errors.New("EscapeString must be run with client_encoding=UTF8")
 	}
 
-	return strings.Replace(s, "'", "''", -1), nil
+	return strings.ReplaceAll(s, "'", "''"), nil
 }
 
 // CheckConn checks the underlying connection without writing any bytes. This is currently implemented by doing a read

--- a/pgconn/pgconn_test.go
+++ b/pgconn/pgconn_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"net"
 	"os"
@@ -4141,13 +4140,15 @@ func Example() {
 
 	pgConn, err := pgconn.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
 	if err != nil {
-		log.Fatalln(err)
+		fmt.Fprintln(os.Stderr, err)
+		return
 	}
 	defer pgConn.Close(ctx)
 
 	result := pgConn.ExecParams(ctx, "select generate_series(1,3)", nil, nil, nil, nil).Read()
 	if result.Err != nil {
-		log.Fatalln(result.Err)
+		fmt.Fprintln(os.Stderr, result.Err)
+		return
 	}
 
 	for _, row := range result.Rows {

--- a/pgproto3/function_call.go
+++ b/pgproto3/function_call.go
@@ -66,11 +66,12 @@ func (dst *FunctionCall) Decode(src []byte) error {
 		// As a special case, -1 indicates a NULL argument value. No value bytes follow in the NULL case.
 		argumentLength := int(int32(binary.BigEndian.Uint32(src[rp:])))
 		rp += 4
-		if argumentLength == -1 {
+		switch {
+		case argumentLength == -1:
 			arguments[i] = nil
-		} else if argumentLength < 0 {
+		case argumentLength < 0:
 			return &invalidMessageFormatErr{messageType: "FunctionCall"}
-		} else {
+		default:
 			if len(src[rp:]) < argumentLength {
 				return &invalidMessageFormatErr{messageType: "FunctionCall"}
 			}

--- a/pgtype/array.go
+++ b/pgtype/array.go
@@ -242,10 +242,11 @@ func parseUntypedTextArray(src string) (*untypedTextArray, error) {
 		return nil, fmt.Errorf("unexpected trailing data: %v", buf.String())
 	}
 
-	if len(dst.Elements) == 0 {
-	} else if len(explicitDimensions) > 0 {
+	switch {
+	case len(dst.Elements) == 0:
+	case len(explicitDimensions) > 0:
 		dst.Dimensions = explicitDimensions
-	} else {
+	default:
 		dst.Dimensions = implicitDimensions
 	}
 

--- a/pgtype/array_codec.go
+++ b/pgtype/array_codec.go
@@ -391,10 +391,8 @@ func isRagged(slice reflect.Value) bool {
 	for i := range sliceLen {
 		if i == 0 {
 			innerLen = slice.Index(i).Len()
-		} else {
-			if slice.Index(i).Len() != innerLen {
-				return true
-			}
+		} else if slice.Index(i).Len() != innerLen {
+			return true
 		}
 		if isRagged(slice.Index(i)) {
 			return true

--- a/pgtype/bits.go
+++ b/pgtype/bits.go
@@ -41,8 +41,7 @@ func (dst *Bits) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToBitsScanner{}.Scan([]byte(src), dst)
 	}
 
@@ -131,13 +130,11 @@ func (encodePlanBitsCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 func (BitsCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case BitsScanner:
+		if _, ok := target.(BitsScanner); ok {
 			return scanPlanBinaryBitsToBitsScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case BitsScanner:
+		if _, ok := target.(BitsScanner); ok {
 			return scanPlanTextAnyToBitsScanner{}
 		}
 	}
@@ -203,7 +200,7 @@ func (scanPlanTextAnyToBitsScanner) Scan(src []byte, dst any) error {
 		if b == '1' {
 			byteIdx := i / 8
 			bitIdx := uint(i % 8)
-			buf[byteIdx] = buf[byteIdx] | (128 >> bitIdx)
+			buf[byteIdx] |= 128 >> bitIdx
 		}
 	}
 

--- a/pgtype/bool.go
+++ b/pgtype/bool.go
@@ -336,9 +336,9 @@ func planTextToBool(src []byte) (bool, error) {
 	s := string(bytes.ToLower(bytes.TrimSpace(src)))
 
 	switch {
-	case strings.HasPrefix("true", s), strings.HasPrefix("yes", s), s == "on", s == "1":
+	case strings.HasPrefix("true", s), strings.HasPrefix("yes", s), s == "on", s == "1": //nolint:gocritic // s is intentionally the prefix argument so partial inputs (t, tr, tru) also match.
 		return true, nil
-	case strings.HasPrefix("false", s), strings.HasPrefix("no", s), strings.HasPrefix("off", s), s == "0":
+	case strings.HasPrefix("false", s), strings.HasPrefix("no", s), strings.HasPrefix("off", s), s == "0": //nolint:gocritic // s is intentionally the prefix argument so partial inputs (f, fa, fal) also match.
 		return false, nil
 	default:
 		return false, fmt.Errorf("unknown boolean string representation %q", src)

--- a/pgtype/box.go
+++ b/pgtype/box.go
@@ -42,8 +42,7 @@ func (dst *Box) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToBoxScanner{}.Scan([]byte(src), dst)
 	}
 
@@ -131,13 +130,11 @@ func (encodePlanBoxCodecText) Encode(value any, buf []byte) (newBuf []byte, err 
 func (BoxCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case BoxScanner:
+		if _, ok := target.(BoxScanner); ok {
 			return scanPlanBinaryBoxToBoxScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case BoxScanner:
+		if _, ok := target.(BoxScanner); ok {
 			return scanPlanTextAnyToBoxScanner{}
 		}
 	}

--- a/pgtype/builtin_wrappers.go
+++ b/pgtype/builtin_wrappers.go
@@ -822,7 +822,7 @@ func (a *anyMultiDimSliceArray) Index(i int) any {
 	for j := len(a.dims) - 1; j >= 0; j-- {
 		dimLen := int(a.dims[j].Length)
 		indexes[j] = i % dimLen
-		i = i / dimLen
+		i /= dimLen
 	}
 
 	v := a.slice

--- a/pgtype/circle.go
+++ b/pgtype/circle.go
@@ -43,8 +43,7 @@ func (dst *Circle) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToCircleScanner{}.Scan([]byte(src), dst)
 	}
 
@@ -130,13 +129,11 @@ func (encodePlanCircleCodecText) Encode(value any, buf []byte) (newBuf []byte, e
 func (CircleCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case CircleScanner:
+		if _, ok := target.(CircleScanner); ok {
 			return scanPlanBinaryCircleToCircleScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case CircleScanner:
+		if _, ok := target.(CircleScanner); ok {
 			return scanPlanTextAnyToCircleScanner{}
 		}
 	}

--- a/pgtype/composite.go
+++ b/pgtype/composite.go
@@ -112,13 +112,11 @@ func (plan *encodePlanCompositeCodecCompositeIndexGetterToText) Encode(value any
 func (c *CompositeCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case CompositeIndexScanner:
+		if _, ok := target.(CompositeIndexScanner); ok {
 			return &scanPlanBinaryCompositeToCompositeIndexScanner{cc: c, m: m}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case CompositeIndexScanner:
+		if _, ok := target.(CompositeIndexScanner); ok {
 			return &scanPlanTextCompositeToCompositeIndexScanner{cc: c, m: m}
 		}
 	}
@@ -410,22 +408,24 @@ func (cfs *CompositeTextScanner) Next() bool {
 	case '"': // quoted value
 		cfs.rp++
 		cfs.fieldBytes = make([]byte, 0, 16)
+	quotedValue:
 		for {
 			ch := cfs.src[cfs.rp]
 
-			if ch == '"' {
+			switch ch {
+			case '"':
 				cfs.rp++
 				if cfs.src[cfs.rp] == '"' {
 					cfs.fieldBytes = append(cfs.fieldBytes, '"')
 					cfs.rp++
 				} else {
-					break
+					break quotedValue
 				}
-			} else if ch == '\\' {
+			case '\\':
 				cfs.rp++
 				cfs.fieldBytes = append(cfs.fieldBytes, cfs.src[cfs.rp])
 				cfs.rp++
-			} else {
+			default:
 				cfs.fieldBytes = append(cfs.fieldBytes, ch)
 				cfs.rp++
 			}

--- a/pgtype/convert.go
+++ b/pgtype/convert.go
@@ -8,14 +8,14 @@ func NullAssignTo(dst any) error {
 	dstPtr := reflect.ValueOf(dst)
 
 	// AssignTo dst must always be a pointer
-	if dstPtr.Kind() != reflect.Ptr {
+	if dstPtr.Kind() != reflect.Pointer {
 		return &nullAssignmentError{dst: dst}
 	}
 
 	dstVal := dstPtr.Elem()
 
 	switch dstVal.Kind() {
-	case reflect.Ptr, reflect.Slice, reflect.Map:
+	case reflect.Pointer, reflect.Slice, reflect.Map:
 		dstVal.Set(reflect.Zero(dstVal.Type()))
 		return nil
 	}
@@ -41,32 +41,32 @@ func GetAssignToDstType(dst any) (any, bool) {
 	dstPtr := reflect.ValueOf(dst)
 
 	// AssignTo dst must always be a pointer
-	if dstPtr.Kind() != reflect.Ptr {
+	if dstPtr.Kind() != reflect.Pointer {
 		return nil, false
 	}
 
 	dstVal := dstPtr.Elem()
 
 	// if dst is a pointer to pointer, allocate space try again with the dereferenced pointer
-	if dstVal.Kind() == reflect.Ptr {
+	if dstVal.Kind() == reflect.Pointer {
 		dstVal.Set(reflect.New(dstVal.Type().Elem()))
 		return dstVal.Interface(), true
 	}
 
 	// if dst is pointer to a base type that has been renamed
 	if baseValType, ok := kindTypes[dstVal.Kind()]; ok {
-		return toInterface(dstPtr, reflect.PtrTo(baseValType))
+		return toInterface(dstPtr, reflect.PointerTo(baseValType))
 	}
 
 	if dstVal.Kind() == reflect.Slice {
 		if baseElemType, ok := kindTypes[dstVal.Type().Elem().Kind()]; ok {
-			return toInterface(dstPtr, reflect.PtrTo(reflect.SliceOf(baseElemType)))
+			return toInterface(dstPtr, reflect.PointerTo(reflect.SliceOf(baseElemType)))
 		}
 	}
 
 	if dstVal.Kind() == reflect.Array {
 		if baseElemType, ok := kindTypes[dstVal.Type().Elem().Kind()]; ok {
-			return toInterface(dstPtr, reflect.PtrTo(reflect.ArrayOf(dstVal.Len(), baseElemType)))
+			return toInterface(dstPtr, reflect.PointerTo(reflect.ArrayOf(dstVal.Len(), baseElemType)))
 		}
 	}
 
@@ -76,7 +76,7 @@ func GetAssignToDstType(dst any) (any, bool) {
 			nested := dstVal.Type().Field(0).Type
 			if nested.Kind() == reflect.Array {
 				if baseElemType, ok := kindTypes[nested.Elem().Kind()]; ok {
-					return toInterface(dstPtr, reflect.PtrTo(reflect.ArrayOf(nested.Len(), baseElemType)))
+					return toInterface(dstPtr, reflect.PointerTo(reflect.ArrayOf(nested.Len(), baseElemType)))
 				}
 			}
 			if _, ok := kindTypes[nested.Kind()]; ok && dstPtr.CanInterface() {

--- a/pgtype/date.go
+++ b/pgtype/date.go
@@ -228,13 +228,11 @@ func (encodePlanDateCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 func (DateCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case DateScanner:
+		if _, ok := target.(DateScanner); ok {
 			return scanPlanBinaryDateToDateScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case DateScanner:
+		if _, ok := target.(DateScanner); ok {
 			return scanPlanTextAnyToDateScanner{}
 		}
 	}

--- a/pgtype/hstore.go
+++ b/pgtype/hstore.go
@@ -40,8 +40,7 @@ func (h *Hstore) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToHstoreScanner{}.scanString(src, h)
 	}
 
@@ -166,13 +165,11 @@ func (encodePlanHstoreCodecText) Encode(value any, buf []byte) (newBuf []byte, e
 func (HstoreCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case HstoreScanner:
+		if _, ok := target.(HstoreScanner); ok {
 			return scanPlanBinaryHstoreToHstoreScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case HstoreScanner:
+		if _, ok := target.(HstoreScanner); ok {
 			return scanPlanTextAnyToHstoreScanner{}
 		}
 	}
@@ -378,13 +375,15 @@ func (p *hstoreParser) consumeDoubleQuotedWithEscapes(firstBackslash int) (strin
 	p.pos = firstBackslash
 
 	// copy bytes until the end, unescaping backslashes
+quotedString:
 	for {
 		nextB, end := p.consume()
-		if end {
+		switch {
+		case end:
 			return "", errEOSInQuoted
-		} else if nextB == '"' {
-			break
-		} else if nextB == '\\' {
+		case nextB == '"':
+			break quotedString
+		case nextB == '\\':
 			// escape: skip the backslash and copy the char
 			nextB, end = p.consume()
 			if end {
@@ -394,7 +393,7 @@ func (p *hstoreParser) consumeDoubleQuotedWithEscapes(firstBackslash int) (strin
 				return "", fmt.Errorf("unexpected escape in quoted string: found '%#v'", nextB)
 			}
 			builder.WriteByte(nextB)
-		} else {
+		default:
 			// normal byte: copy it
 			builder.WriteByte(nextB)
 		}

--- a/pgtype/inet.go
+++ b/pgtype/inet.go
@@ -109,13 +109,11 @@ func (encodePlanInetCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 func (InetCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case NetipPrefixScanner:
+		if _, ok := target.(NetipPrefixScanner); ok {
 			return scanPlanBinaryInetToNetipPrefixScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case NetipPrefixScanner:
+		if _, ok := target.(NetipPrefixScanner); ok {
 			return scanPlanTextAnyToNetipPrefixScanner{}
 		}
 	}

--- a/pgtype/interval.go
+++ b/pgtype/interval.go
@@ -51,8 +51,7 @@ func (interval *Interval) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToIntervalScanner{}.Scan([]byte(src), interval)
 	}
 
@@ -161,13 +160,11 @@ func (encodePlanIntervalCodecText) Encode(value any, buf []byte) (newBuf []byte,
 func (IntervalCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case IntervalScanner:
+		if _, ok := target.(IntervalScanner); ok {
 			return scanPlanBinaryIntervalToIntervalScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case IntervalScanner:
+		if _, ok := target.(IntervalScanner); ok {
 			return scanPlanTextAnyToIntervalScanner{}
 		}
 	}

--- a/pgtype/json.go
+++ b/pgtype/json.go
@@ -199,10 +199,10 @@ type scanPlanJSONToJSONUnmarshal struct {
 func (s *scanPlanJSONToJSONUnmarshal) Scan(src []byte, dst any) error {
 	if src == nil {
 		dstValue := reflect.ValueOf(dst)
-		if dstValue.Kind() == reflect.Ptr {
+		if dstValue.Kind() == reflect.Pointer {
 			el := dstValue.Elem()
 			switch el.Kind() {
-			case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface:
+			case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Interface:
 				el.Set(reflect.Zero(el.Type()))
 				return nil
 			}

--- a/pgtype/json_test.go
+++ b/pgtype/json_test.go
@@ -87,11 +87,11 @@ type Issue1805 int
 
 func (i *Issue1805) Scan(src any) error {
 	var source []byte
-	switch src.(type) {
+	switch src := src.(type) {
 	case string:
-		source = []byte(src.(string))
+		source = []byte(src)
 	case []byte:
-		source = src.([]byte)
+		source = src
 	default:
 		return errors.New("unknown source type")
 	}
@@ -120,11 +120,11 @@ type Issue2146 int
 
 func (i *Issue2146) Scan(src any) error {
 	var source []byte
-	switch src.(type) {
+	switch src := src.(type) {
 	case string:
-		source = []byte(src.(string))
+		source = []byte(src)
 	case []byte:
-		source = src.([]byte)
+		source = src
 	default:
 		return errors.New("unknown source type")
 	}

--- a/pgtype/line.go
+++ b/pgtype/line.go
@@ -46,8 +46,7 @@ func (line *Line) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToLineScanner{}.Scan([]byte(src), line)
 	}
 
@@ -133,13 +132,11 @@ func (encodePlanLineCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 func (LineCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case LineScanner:
+		if _, ok := target.(LineScanner); ok {
 			return scanPlanBinaryLineToLineScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case LineScanner:
+		if _, ok := target.(LineScanner); ok {
 			return scanPlanTextAnyToLineScanner{}
 		}
 	}

--- a/pgtype/lseg.go
+++ b/pgtype/lseg.go
@@ -42,8 +42,7 @@ func (lseg *Lseg) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToLsegScanner{}.Scan([]byte(src), lseg)
 	}
 
@@ -131,13 +130,11 @@ func (encodePlanLsegCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 func (LsegCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case LsegScanner:
+		if _, ok := target.(LsegScanner); ok {
 			return scanPlanBinaryLsegToLsegScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case LsegScanner:
+		if _, ok := target.(LsegScanner); ok {
 			return scanPlanTextAnyToLsegScanner{}
 		}
 	}

--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -70,13 +70,14 @@ func (n Numeric) NumericValue() (Numeric, error) {
 
 // Float64Value implements the [Float64Valuer] interface.
 func (n Numeric) Float64Value() (Float8, error) {
-	if !n.Valid {
+	switch {
+	case !n.Valid:
 		return Float8{}, nil
-	} else if n.NaN {
+	case n.NaN:
 		return Float8{Float64: math.NaN(), Valid: true}, nil
-	} else if n.InfinityModifier == Infinity {
+	case n.InfinityModifier == Infinity:
 		return Float8{Float64: math.Inf(1), Valid: true}, nil
-	} else if n.InfinityModifier == NegativeInfinity {
+	case n.InfinityModifier == NegativeInfinity:
 		return Float8{Float64: math.Inf(-1), Valid: true}, nil
 	}
 
@@ -215,8 +216,7 @@ func (n *Numeric) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToNumericScanner{}.Scan([]byte(src), n)
 	}
 
@@ -278,12 +278,13 @@ func (n Numeric) numberTextBytes() []byte {
 	}
 
 	exp := int(n.Exp)
-	if exp > 0 {
+	switch {
+	case exp > 0:
 		buf.WriteString(intStr)
 		for range exp {
 			buf.WriteByte('0')
 		}
-	} else if exp < 0 {
+	case exp < 0:
 		if len(intStr) <= -exp {
 			buf.WriteString("0.")
 			leadingZeros := -exp - len(intStr)
@@ -297,7 +298,7 @@ func (n Numeric) numberTextBytes() []byte {
 			buf.WriteByte('.')
 			buf.WriteString(intStr[dpPos:])
 		}
-	} else {
+	default:
 		buf.WriteString(intStr)
 	}
 
@@ -362,11 +363,12 @@ func (encodePlanNumericCodecBinaryFloat64Valuer) Encode(value any, buf []byte) (
 		return nil, nil
 	}
 
-	if math.IsNaN(n.Float64) {
+	switch {
+	case math.IsNaN(n.Float64):
 		return encodeNumericBinary(Numeric{NaN: true, Valid: true}, buf)
-	} else if math.IsInf(n.Float64, 1) {
+	case math.IsInf(n.Float64, 1):
 		return encodeNumericBinary(Numeric{InfinityModifier: Infinity, Valid: true}, buf)
-	} else if math.IsInf(n.Float64, -1) {
+	case math.IsInf(n.Float64, -1):
 		return encodeNumericBinary(Numeric{InfinityModifier: NegativeInfinity, Valid: true}, buf)
 	}
 	num, exp, err := parseNumericString(strconv.FormatFloat(n.Float64, 'f', -1, 64))
@@ -397,13 +399,14 @@ func encodeNumericBinary(n Numeric, buf []byte) (newBuf []byte, err error) {
 		return nil, nil
 	}
 
-	if n.NaN {
+	switch {
+	case n.NaN:
 		buf = pgio.AppendUint64(buf, pgNumericNaN)
 		return buf, nil
-	} else if n.InfinityModifier == Infinity {
+	case n.InfinityModifier == Infinity:
 		buf = pgio.AppendUint64(buf, pgNumericPosInf)
 		return buf, nil
-	} else if n.InfinityModifier == NegativeInfinity {
+	case n.InfinityModifier == NegativeInfinity:
 		buf = pgio.AppendUint64(buf, pgNumericNegInf)
 		return buf, nil
 	}
@@ -516,13 +519,14 @@ func (encodePlanNumericCodecTextFloat64Valuer) Encode(value any, buf []byte) (ne
 		return nil, nil
 	}
 
-	if math.IsNaN(n.Float64) {
+	switch {
+	case math.IsNaN(n.Float64):
 		buf = append(buf, "NaN"...)
-	} else if math.IsInf(n.Float64, 1) {
+	case math.IsInf(n.Float64, 1):
 		buf = append(buf, "Infinity"...)
-	} else if math.IsInf(n.Float64, -1) {
+	case math.IsInf(n.Float64, -1):
 		buf = append(buf, "-Infinity"...)
-	} else {
+	default:
 		buf = append(buf, strconv.FormatFloat(n.Float64, 'f', -1, 64)...)
 	}
 	return buf, nil
@@ -549,13 +553,14 @@ func encodeNumericText(n Numeric, buf []byte) (newBuf []byte, err error) {
 		return nil, nil
 	}
 
-	if n.NaN {
+	switch {
+	case n.NaN:
 		buf = append(buf, "NaN"...)
 		return buf, nil
-	} else if n.InfinityModifier == Infinity {
+	case n.InfinityModifier == Infinity:
 		buf = append(buf, "Infinity"...)
 		return buf, nil
-	} else if n.InfinityModifier == NegativeInfinity {
+	case n.InfinityModifier == NegativeInfinity:
 		buf = append(buf, "-Infinity"...)
 		return buf, nil
 	}
@@ -615,11 +620,12 @@ func (scanPlanBinaryNumericToNumericScanner) Scan(src []byte, dst any) error {
 	dscale := int16(binary.BigEndian.Uint16(src[rp:]))
 	rp += 2
 
-	if sign == pgNumericNaNSign {
+	switch sign {
+	case pgNumericNaNSign:
 		return scanner.ScanNumeric(Numeric{NaN: true, Valid: true})
-	} else if sign == pgNumericPosInfSign {
+	case pgNumericPosInfSign:
 		return scanner.ScanNumeric(Numeric{InfinityModifier: Infinity, Valid: true})
-	} else if sign == pgNumericNegInfSign {
+	case pgNumericNegInfSign:
 		return scanner.ScanNumeric(Numeric{InfinityModifier: NegativeInfinity, Valid: true})
 	}
 
@@ -784,11 +790,12 @@ func (scanPlanTextAnyToNumericScanner) Scan(src []byte, dst any) error {
 		return scanner.ScanNumeric(Numeric{})
 	}
 
-	if string(src) == "NaN" {
+	switch string(src) {
+	case "NaN":
 		return scanner.ScanNumeric(Numeric{NaN: true, Valid: true})
-	} else if string(src) == "Infinity" {
+	case "Infinity":
 		return scanner.ScanNumeric(Numeric{InfinityModifier: Infinity, Valid: true})
-	} else if string(src) == "-Infinity" {
+	case "-Infinity":
 		return scanner.ScanNumeric(Numeric{InfinityModifier: NegativeInfinity, Valid: true})
 	}
 

--- a/pgtype/path.go
+++ b/pgtype/path.go
@@ -43,8 +43,7 @@ func (path *Path) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToPathScanner{}.Scan([]byte(src), path)
 	}
 
@@ -158,13 +157,11 @@ func (encodePlanPathCodecText) Encode(value any, buf []byte) (newBuf []byte, err
 func (PathCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case PathScanner:
+		if _, ok := target.(PathScanner); ok {
 			return scanPlanBinaryPathToPathScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case PathScanner:
+		if _, ok := target.(PathScanner); ok {
 			return scanPlanTextAnyToPathScanner{}
 		}
 	}

--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -393,13 +393,14 @@ type scanPlanSQLScanner struct {
 func (plan *scanPlanSQLScanner) Scan(src []byte, dst any) error {
 	scanner := dst.(sql.Scanner)
 
-	if src == nil {
+	switch {
+	case src == nil:
 		// This is necessary because interface value []byte:nil does not equal nil:nil for the binary format path and the
 		// text format path would be converted to empty string.
 		return scanner.Scan(nil)
-	} else if plan.formatCode == BinaryFormatCode {
+	case plan.formatCode == BinaryFormatCode:
 		return scanner.Scan(src)
-	} else {
+	default:
 		return scanner.Scan(string(src))
 	}
 }
@@ -509,9 +510,9 @@ func (plan *pointerPointerScanPlan) Scan(src []byte, dst any) error {
 // TryPointerPointerScanPlan handles a pointer to a pointer by setting the target to nil for SQL NULL and allocating and
 // scanning for non-NULL.
 func TryPointerPointerScanPlan(target any) (plan WrappedScanPlanNextSetter, nextTarget any, ok bool) {
-	if dstValue := reflect.ValueOf(target); dstValue.Kind() == reflect.Ptr {
+	if dstValue := reflect.ValueOf(target); dstValue.Kind() == reflect.Pointer {
 		elemValue := dstValue.Elem()
-		if elemValue.Kind() == reflect.Ptr {
+		if elemValue.Kind() == reflect.Pointer {
 			plan = &pointerPointerScanPlan{dstType: dstValue.Type()}
 			return plan, reflect.Zero(elemValue.Type()).Interface(), true
 		}
@@ -563,7 +564,7 @@ func TryFindUnderlyingTypeScanPlan(dst any) (plan WrappedScanPlanNextSetter, nex
 
 	dstValue := reflect.ValueOf(dst)
 
-	if dstValue.Kind() == reflect.Ptr {
+	if dstValue.Kind() == reflect.Pointer {
 		var elemValue reflect.Value
 		if dstValue.IsNil() {
 			elemValue = reflect.New(dstValue.Type().Elem()).Elem()
@@ -907,7 +908,7 @@ func (plan *pointerEmptyInterfaceScanPlan) Scan(src []byte, dst any) error {
 // TryWrapStructScanPlan tries to wrap a struct with a wrapper that implements CompositeIndexGetter.
 func TryWrapStructScanPlan(target any) (plan WrappedScanPlanNextSetter, nextValue any, ok bool) {
 	targetValue := reflect.ValueOf(target)
-	if targetValue.Kind() != reflect.Ptr {
+	if targetValue.Kind() != reflect.Pointer {
 		return nil, nil, false
 	}
 
@@ -971,7 +972,7 @@ func TryWrapPtrSliceScanPlan(target any) (plan WrappedScanPlanNextSetter, nextVa
 	}
 
 	targetType := reflect.TypeOf(target)
-	if targetType.Kind() != reflect.Ptr {
+	if targetType.Kind() != reflect.Pointer {
 		return nil, nil, false
 	}
 
@@ -1007,7 +1008,7 @@ func (plan *wrapPtrSliceReflectScanPlan) Scan(src []byte, target any) error {
 // TryWrapPtrMultiDimSliceScanPlan tries to wrap a pointer to a multi-dimension slice.
 func TryWrapPtrMultiDimSliceScanPlan(target any) (plan WrappedScanPlanNextSetter, nextValue any, ok bool) {
 	targetValue := reflect.ValueOf(target)
-	if targetValue.Kind() != reflect.Ptr {
+	if targetValue.Kind() != reflect.Pointer {
 		return nil, nil, false
 	}
 
@@ -1038,7 +1039,7 @@ func (plan *wrapPtrMultiDimSliceScanPlan) Scan(src []byte, target any) error {
 // TryWrapPtrArrayScanPlan tries to wrap a pointer to a single dimension array.
 func TryWrapPtrArrayScanPlan(target any) (plan WrappedScanPlanNextSetter, nextValue any, ok bool) {
 	targetValue := reflect.ValueOf(target)
-	if targetValue.Kind() != reflect.Ptr {
+	if targetValue.Kind() != reflect.Pointer {
 		return nil, nil, false
 	}
 
@@ -1080,8 +1081,7 @@ func (m *Map) planScan(oid uint32, formatCode int16, target any, depth int) Scan
 
 	switch formatCode {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case *string:
+		if _, ok := target.(*string); ok {
 			switch oid {
 			case TextOID, VarcharOID:
 				return scanPlanString{}
@@ -1367,7 +1367,7 @@ func TryWrapDerefPointerEncodePlan(value any) (plan WrappedEncodePlanNextSetter,
 		return nil, nil, false
 	}
 
-	if valueType := reflect.TypeOf(value); valueType != nil && valueType.Kind() == reflect.Ptr {
+	if valueType := reflect.TypeOf(value); valueType != nil && valueType.Kind() == reflect.Pointer {
 		return &derefPointerEncodePlan{}, reflect.New(valueType.Elem()).Elem().Interface(), true
 	}
 
@@ -2045,13 +2045,13 @@ func isNilDriverValuer(value any) (isNil, callNilDriverValuer bool) {
 	refVal := reflect.ValueOf(value)
 	kind := refVal.Kind()
 	switch kind {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
 		if !refVal.IsNil() {
 			return false, false
 		}
 
 		if _, ok := value.(driver.Valuer); ok {
-			if kind == reflect.Ptr {
+			if kind == reflect.Pointer {
 				// The type assertion will succeed if driver.Valuer is implemented on T or *T. Check if it is implemented on *T
 				// by checking if it is not implemented on *T.
 				return true, !refVal.Type().Elem().Implements(valuerReflectType)

--- a/pgtype/point.go
+++ b/pgtype/point.go
@@ -77,8 +77,7 @@ func (dst *Point) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToPointScanner{}.Scan([]byte(src), dst)
 	}
 
@@ -184,13 +183,11 @@ func (encodePlanPointCodecText) Encode(value any, buf []byte) (newBuf []byte, er
 func (PointCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case PointScanner:
+		if _, ok := target.(PointScanner); ok {
 			return scanPlanBinaryPointToPointScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case PointScanner:
+		if _, ok := target.(PointScanner); ok {
 			return scanPlanTextAnyToPointScanner{}
 		}
 	}

--- a/pgtype/polygon.go
+++ b/pgtype/polygon.go
@@ -42,8 +42,7 @@ func (p *Polygon) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToPolygonScanner{}.Scan([]byte(src), p)
 	}
 
@@ -143,13 +142,11 @@ func (encodePlanPolygonCodecText) Encode(value any, buf []byte) (newBuf []byte, 
 func (PolygonCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case PolygonScanner:
+		if _, ok := target.(PolygonScanner); ok {
 			return scanPlanBinaryPolygonToPolygonScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case PolygonScanner:
+		if _, ok := target.(PolygonScanner); ok {
 			return scanPlanTextAnyToPolygonScanner{}
 		}
 	}

--- a/pgtype/range.go
+++ b/pgtype/range.go
@@ -218,19 +218,21 @@ func parseUntypedBinaryRange(src []byte) (*untypedBinaryRange, error) {
 		return ubr, nil
 	}
 
-	if rangeType&lowerInclusiveMask > 0 {
+	switch {
+	case rangeType&lowerInclusiveMask > 0:
 		ubr.LowerType = Inclusive
-	} else if rangeType&lowerUnboundedMask > 0 {
+	case rangeType&lowerUnboundedMask > 0:
 		ubr.LowerType = Unbounded
-	} else {
+	default:
 		ubr.LowerType = Exclusive
 	}
 
-	if rangeType&upperInclusiveMask > 0 {
+	switch {
+	case rangeType&upperInclusiveMask > 0:
 		ubr.UpperType = Inclusive
-	} else if rangeType&upperUnboundedMask > 0 {
+	case rangeType&upperUnboundedMask > 0:
 		ubr.UpperType = Unbounded
-	} else {
+	default:
 		ubr.UpperType = Exclusive
 	}
 

--- a/pgtype/range_codec.go
+++ b/pgtype/range_codec.go
@@ -237,13 +237,11 @@ func (plan *encodePlanRangeCodecRangeValuerToText) Encode(value any, buf []byte)
 func (c *RangeCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case RangeScanner:
+		if _, ok := target.(RangeScanner); ok {
 			return &scanPlanBinaryRangeToRangeScanner{rc: c, m: m}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case RangeScanner:
+		if _, ok := target.(RangeScanner); ok {
 			return &scanPlanTextRangeToRangeScanner{rc: c, m: m}
 		}
 	}

--- a/pgtype/record_codec.go
+++ b/pgtype/record_codec.go
@@ -27,8 +27,7 @@ func (RecordCodec) PlanEncode(m *Map, oid uint32, format int16, value any) Encod
 
 func (RecordCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	if format == BinaryFormatCode {
-		switch target.(type) {
-		case CompositeIndexScanner:
+		if _, ok := target.(CompositeIndexScanner); ok {
 			return &scanPlanBinaryRecordToCompositeIndexScanner{m: m}
 		}
 	}

--- a/pgtype/tid.go
+++ b/pgtype/tid.go
@@ -53,8 +53,7 @@ func (dst *TID) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToTIDScanner{}.Scan([]byte(src), dst)
 	}
 
@@ -142,8 +141,7 @@ func (TIDCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan 
 			return scanPlanBinaryTIDToTextScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case TIDScanner:
+		if _, ok := target.(TIDScanner); ok {
 			return scanPlanTextAnyToTIDScanner{}
 		}
 	}

--- a/pgtype/time.go
+++ b/pgtype/time.go
@@ -47,8 +47,7 @@ func (t *Time) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		err := scanPlanTextAnyToTimeScanner{}.Scan([]byte(src), t)
 		if err != nil {
 			t.Microseconds = 0
@@ -148,8 +147,7 @@ func (TimeCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan
 			return scanPlanBinaryTimeToTextScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case TimeScanner:
+		if _, ok := target.(TimeScanner); ok {
 			return scanPlanTextAnyToTimeScanner{}
 		}
 	}

--- a/pgtype/timestamp.go
+++ b/pgtype/timestamp.go
@@ -218,7 +218,7 @@ func (encodePlanTimestampCodecText) Encode(value any, buf []byte) (newBuf []byte
 		s = t.Truncate(time.Microsecond).Format(pgTimestampFormat)
 
 		if bc {
-			s = s + " BC"
+			s += " BC"
 		}
 	case Infinity:
 		s = "infinity"
@@ -242,13 +242,11 @@ func discardTimeZone(t time.Time) time.Time {
 func (c *TimestampCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case TimestampScanner:
+		if _, ok := target.(TimestampScanner); ok {
 			return &scanPlanBinaryTimestampToTimestampScanner{location: c.ScanLocation}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case TimestampScanner:
+		if _, ok := target.(TimestampScanner); ok {
 			return &scanPlanTextTimestampToTimestampScanner{location: c.ScanLocation}
 		}
 	}

--- a/pgtype/timestamptz.go
+++ b/pgtype/timestamptz.go
@@ -217,7 +217,7 @@ func (encodePlanTimestamptzCodecText) Encode(value any, buf []byte) (newBuf []by
 		s = t.Format(pgTimestamptzSecondFormat)
 
 		if bc {
-			s = s + " BC"
+			s += " BC"
 		}
 	case Infinity:
 		s = "infinity"
@@ -233,13 +233,11 @@ func (encodePlanTimestamptzCodecText) Encode(value any, buf []byte) (newBuf []by
 func (c *TimestamptzCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case TimestamptzScanner:
+		if _, ok := target.(TimestamptzScanner); ok {
 			return &scanPlanBinaryTimestamptzToTimestamptzScanner{location: c.ScanLocation}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case TimestamptzScanner:
+		if _, ok := target.(TimestamptzScanner); ok {
 			return &scanPlanTextTimestamptzToTimestamptzScanner{location: c.ScanLocation}
 		}
 	}
@@ -306,11 +304,12 @@ func (plan *scanPlanTextTimestamptzToTimestamptzScanner) Scan(src []byte, dst an
 		}
 
 		var format string
-		if len(sbuf) >= 9 && (sbuf[len(sbuf)-9] == '-' || sbuf[len(sbuf)-9] == '+') {
+		switch {
+		case len(sbuf) >= 9 && (sbuf[len(sbuf)-9] == '-' || sbuf[len(sbuf)-9] == '+'):
 			format = pgTimestamptzSecondFormat
-		} else if len(sbuf) >= 6 && (sbuf[len(sbuf)-6] == '-' || sbuf[len(sbuf)-6] == '+') {
+		case len(sbuf) >= 6 && (sbuf[len(sbuf)-6] == '-' || sbuf[len(sbuf)-6] == '+'):
 			format = pgTimestamptzMinuteFormat
-		} else {
+		default:
 			format = pgTimestamptzHourFormat
 		}
 

--- a/pgtype/tsvector.go
+++ b/pgtype/tsvector.go
@@ -54,8 +54,7 @@ func (t *TSVector) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		return scanPlanTextAnyToTSVectorScanner{}.scanString(src, t)
 	}
 
@@ -294,13 +293,11 @@ func (encodePlanTSVectorCodecText) Encode(value any, buf []byte) ([]byte, error)
 func (TSVectorCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan {
 	switch format {
 	case BinaryFormatCode:
-		switch target.(type) {
-		case TSVectorScanner:
+		if _, ok := target.(TSVectorScanner); ok {
 			return scanPlanBinaryTSVectorToTSVectorScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case TSVectorScanner:
+		if _, ok := target.(TSVectorScanner); ok {
 			return scanPlanTextAnyToTSVectorScanner{}
 		}
 	}

--- a/pgtype/uuid.go
+++ b/pgtype/uuid.go
@@ -76,8 +76,7 @@ func (dst *UUID) Scan(src any) error {
 		return nil
 	}
 
-	switch src := src.(type) {
-	case string:
+	if src, ok := src.(string); ok {
 		buf, err := parseUUID(src)
 		if err != nil {
 			return err
@@ -201,8 +200,7 @@ func (UUIDCodec) PlanScan(m *Map, oid uint32, format int16, target any) ScanPlan
 			return scanPlanBinaryUUIDToTextScanner{}
 		}
 	case TextFormatCode:
-		switch target.(type) {
-		case UUIDScanner:
+		if _, ok := target.(UUIDScanner); ok {
 			return scanPlanTextAnyToUUIDScanner{}
 		}
 	}

--- a/pgtype/xml.go
+++ b/pgtype/xml.go
@@ -159,10 +159,10 @@ type scanPlanXMLToXMLUnmarshal struct {
 func (s *scanPlanXMLToXMLUnmarshal) Scan(src []byte, dst any) error {
 	if src == nil {
 		dstValue := reflect.ValueOf(dst)
-		if dstValue.Kind() == reflect.Ptr {
+		if dstValue.Kind() == reflect.Pointer {
 			el := dstValue.Elem()
 			switch el.Kind() {
-			case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface, reflect.Struct:
+			case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Interface, reflect.Struct:
 				el.Set(reflect.Zero(el.Type()))
 				return nil
 			}

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -532,20 +532,21 @@ func (p *Pool) checkConnsHealth() bool {
 	totalConns := p.Stat().TotalConns()
 	resources := p.p.AcquireAllIdle()
 	for _, res := range resources {
+		switch {
 		// We're okay going under minConns if the lifetime is up
-		if p.isExpired(res) && totalConns >= p.minConns {
+		case p.isExpired(res) && totalConns >= p.minConns:
 			atomic.AddInt64(&p.lifetimeDestroyCount, 1)
 			res.Destroy()
 			destroyed = true
 			// Since Destroy is async we manually decrement totalConns.
 			totalConns--
-		} else if res.IdleDuration() > p.maxConnIdleTime && totalConns > p.minConns {
+		case res.IdleDuration() > p.maxConnIdleTime && totalConns > p.minConns:
 			atomic.AddInt64(&p.idleDestroyCount, 1)
 			res.Destroy()
 			destroyed = true
 			// Since Destroy is async we manually decrement totalConns.
 			totalConns--
-		} else {
+		default:
 			res.ReleaseUnused()
 		}
 	}

--- a/pgxtest/pgxtest.go
+++ b/pgxtest/pgxtest.go
@@ -135,7 +135,7 @@ func RunValueRoundTripTests(
 				}
 
 				result := reflect.ValueOf(tt.Result)
-				if result.Kind() == reflect.Ptr {
+				if result.Kind() == reflect.Pointer {
 					result = result.Elem()
 				}
 


### PR DESCRIPTION
gocritic was added to the enabled linters in .golangci.yml.
This commit resolves every issue it reported across the
repository so the build stay green with the new linter on.

I think can also

Closes #2366 
