### PR TITLE
fix(pgtype): return error instead of panicking on malformed geometric text

### DIFF
--- a/pgtype/box.go
+++ b/pgtype/box.go
@@ -189,6 +189,9 @@ func (scanPlanTextAnyToBoxScanner) Scan(src []byte, dst any) error {
 
 	var end int
 	end = strings.IndexByte(str, ',')
+	if end == -1 {
+		return fmt.Errorf("invalid format for Box")
+	}
 
 	x1, err := strconv.ParseFloat(str[:end], 64)
 	if err != nil {
@@ -197,6 +200,9 @@ func (scanPlanTextAnyToBoxScanner) Scan(src []byte, dst any) error {
 
 	str = str[end+1:]
 	end = strings.IndexByte(str, ')')
+	if end == -1 {
+		return fmt.Errorf("invalid format for Box")
+	}
 
 	y1, err := strconv.ParseFloat(str[:end], 64)
 	if err != nil {
@@ -205,6 +211,9 @@ func (scanPlanTextAnyToBoxScanner) Scan(src []byte, dst any) error {
 
 	str = str[end+3:]
 	end = strings.IndexByte(str, ',')
+	if end == -1 {
+		return fmt.Errorf("invalid format for Box")
+	}
 
 	x2, err := strconv.ParseFloat(str[:end], 64)
 	if err != nil {

--- a/pgtype/circle.go
+++ b/pgtype/circle.go
@@ -200,6 +200,9 @@ func (scanPlanTextAnyToCircleScanner) Scan(src []byte, dst any) error {
 
 	str := string(src[2:])
 	end := strings.IndexByte(str, ',')
+	if end == -1 {
+		return fmt.Errorf("invalid format for Circle")
+	}
 	x, err := strconv.ParseFloat(str[:end], 64)
 	if err != nil {
 		return err
@@ -207,6 +210,9 @@ func (scanPlanTextAnyToCircleScanner) Scan(src []byte, dst any) error {
 
 	str = str[end+1:]
 	end = strings.IndexByte(str, ')')
+	if end == -1 {
+		return fmt.Errorf("invalid format for Circle")
+	}
 
 	y, err := strconv.ParseFloat(str[:end], 64)
 	if err != nil {

--- a/pgtype/geometric_malformed_test.go
+++ b/pgtype/geometric_malformed_test.go
@@ -1,0 +1,83 @@
+package pgtype_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Malformed geometric text values that are missing an expected separator must
+// return an error instead of panicking with "slice bounds out of range". The
+// text scan plans in circle.go, box.go, lseg.go, path.go and polygon.go used
+// the result of strings.IndexByte to slice without checking for -1.
+func TestGeometricScanMalformedReturnsError(t *testing.T) {
+	tests := []struct {
+		name string
+		scan func(string) error
+		src  string
+	}{
+		{"Circle", func(s string) error { var v pgtype.Circle; return v.Scan(s) }, "<(123456789>"},
+		{"Box", func(s string) error { var v pgtype.Box; return v.Scan(s) }, "(1234567890"},
+		{"Lseg", func(s string) error { var v pgtype.Lseg; return v.Scan(s) }, "[(123456789"},
+		{"Path", func(s string) error { var v pgtype.Path; return v.Scan(s) }, "((1234567"},
+		{"Polygon", func(s string) error { var v pgtype.Polygon; return v.Scan(s) }, "((1234567"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A panic here (pre-fix) fails the test.
+			if err := tt.scan(tt.src); err == nil {
+				t.Errorf("Scan(%q) = nil error, want an error", tt.src)
+			}
+		})
+	}
+}
+
+// Well-formed geometric text values still parse correctly after the guards
+// were added.
+func TestGeometricScanValid(t *testing.T) {
+	t.Run("Circle", func(t *testing.T) {
+		var v pgtype.Circle
+		if err := v.Scan("<(1.5,2.5),3.5>"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !v.Valid || v.P.X != 1.5 || v.P.Y != 2.5 || v.R != 3.5 {
+			t.Errorf("got %+v", v)
+		}
+	})
+	t.Run("Box", func(t *testing.T) {
+		var v pgtype.Box
+		if err := v.Scan("(3,4),(1,2)"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !v.Valid {
+			t.Errorf("got %+v", v)
+		}
+	})
+	t.Run("Lseg", func(t *testing.T) {
+		var v pgtype.Lseg
+		if err := v.Scan("[(1,2),(3,4)]"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !v.Valid {
+			t.Errorf("got %+v", v)
+		}
+	})
+	t.Run("Path", func(t *testing.T) {
+		var v pgtype.Path
+		if err := v.Scan("((1,2),(3,4))"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !v.Valid || len(v.P) != 2 {
+			t.Errorf("got %+v", v)
+		}
+	})
+	t.Run("Polygon", func(t *testing.T) {
+		var v pgtype.Polygon
+		if err := v.Scan("((1,2),(3,4))"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !v.Valid || len(v.P) != 2 {
+			t.Errorf("got %+v", v)
+		}
+	})
+}

--- a/pgtype/lseg.go
+++ b/pgtype/lseg.go
@@ -189,6 +189,9 @@ func (scanPlanTextAnyToLsegScanner) Scan(src []byte, dst any) error {
 
 	var end int
 	end = strings.IndexByte(str, ',')
+	if end == -1 {
+		return fmt.Errorf("invalid format for lseg")
+	}
 
 	x1, err := strconv.ParseFloat(str[:end], 64)
 	if err != nil {
@@ -197,6 +200,9 @@ func (scanPlanTextAnyToLsegScanner) Scan(src []byte, dst any) error {
 
 	str = str[end+1:]
 	end = strings.IndexByte(str, ')')
+	if end == -1 {
+		return fmt.Errorf("invalid format for lseg")
+	}
 
 	y1, err := strconv.ParseFloat(str[:end], 64)
 	if err != nil {
@@ -205,6 +211,9 @@ func (scanPlanTextAnyToLsegScanner) Scan(src []byte, dst any) error {
 
 	str = str[end+3:]
 	end = strings.IndexByte(str, ',')
+	if end == -1 {
+		return fmt.Errorf("invalid format for lseg")
+	}
 
 	x2, err := strconv.ParseFloat(str[:end], 64)
 	if err != nil {

--- a/pgtype/path.go
+++ b/pgtype/path.go
@@ -230,6 +230,9 @@ func (scanPlanTextAnyToPathScanner) Scan(src []byte, dst any) error {
 
 	for {
 		end := strings.IndexByte(str, ',')
+		if end == -1 {
+			return fmt.Errorf("invalid format for Path")
+		}
 		x, err := strconv.ParseFloat(str[:end], 64)
 		if err != nil {
 			return err
@@ -237,6 +240,9 @@ func (scanPlanTextAnyToPathScanner) Scan(src []byte, dst any) error {
 
 		str = str[end+1:]
 		end = strings.IndexByte(str, ')')
+		if end == -1 {
+			return fmt.Errorf("invalid format for Path")
+		}
 
 		y, err := strconv.ParseFloat(str[:end], 64)
 		if err != nil {

--- a/pgtype/polygon.go
+++ b/pgtype/polygon.go
@@ -211,6 +211,9 @@ func (scanPlanTextAnyToPolygonScanner) Scan(src []byte, dst any) error {
 
 	for {
 		end := strings.IndexByte(str, ',')
+		if end == -1 {
+			return fmt.Errorf("invalid format for Polygon")
+		}
 		x, err := strconv.ParseFloat(str[:end], 64)
 		if err != nil {
 			return err
@@ -218,6 +221,9 @@ func (scanPlanTextAnyToPolygonScanner) Scan(src []byte, dst any) error {
 
 		str = str[end+1:]
 		end = strings.IndexByte(str, ')')
+		if end == -1 {
+			return fmt.Errorf("invalid format for Polygon")
+		}
 
 		y, err := strconv.ParseFloat(str[:end], 64)
 		if err != nil {


### PR DESCRIPTION
## Problem

The text scan plans for `circle`, `box`, `lseg`, `path` and `polygon` parse the value by calling `strings.IndexByte` to locate a `,` or `)` separator and then slicing the string — without checking for the `-1` "not found" result. Malformed text that is missing an expected separator therefore panics with `slice bounds out of range [:-1]` instead of returning an error.

This is reachable through the public `database/sql` `Scanner` API (e.g. `Circle.Scan`, or scanning a text-format column into one of these types), so malformed/corrupt input turns into a process-crashing panic rather than a normal scan error.

Repro (panics before this change):

```go
var c pgtype.Circle
_ = c.Scan("<(123456789>") // panic: slice bounds out of range [:-1]

var b pgtype.Box
_ = b.Scan("(1234567890")  // panic

var l pgtype.Lseg
_ = l.Scan("[(123456789")  // panic

var p pgtype.Path
_ = p.Scan("((1234567")    // panic

var g pgtype.Polygon
_ = g.Scan("((1234567")    // panic
```

`point.go` already guards this correctly (it uses `strings.Cut` and returns `"invalid format for point"`); these five types were missed. This is the same class of malformed-input panic recently fixed for other types (#2507, #2519, #2520, #2522).

## Fix

Guard every `strings.IndexByte` result with an `if end == -1 { return fmt.Errorf("invalid format for <type>") }` before slicing, matching the existing `point.go` behavior. Behavior for well-formed input is unchanged; this only turns a panic into a returned error (no public API change).

## Tests

Adds (in `pgtype/geometric_malformed_test.go`, no database required):

- `TestGeometricScanMalformedReturnsError` — each of the five types returns an error (no panic) on malformed input. Fails before this change (panics), passes after.
- `TestGeometricScanValid` — well-formed values still parse correctly.

`gofmt -l -s`, `go vet ./pgtype/`, and `go build ./...` are clean.

---

> Disclosure (per CONTRIBUTING.md): this is an AI-assisted contribution. The bug was surfaced by an automated audit; the fix and tests were written with AI assistance and reviewed and verified locally (fail-before / pass-after).