### PR TITLE
pgtype: handle typed-nil driver.Valuer in array/composite codecs

### DIFF
--- a/pgtype/array_codec.go
+++ b/pgtype/array_codec.go
@@ -131,7 +131,8 @@ func (p *encodePlanArrayCodecText) Encode(value any, buf []byte) (newBuf []byte,
 
 		elem := array.Index(i)
 		var elemBuf []byte
-		if isNil, _ := isNilDriverValuer(elem); !isNil {
+		isNil, callNilDriverValuer := isNilDriverValuer(elem)
+		if !isNil {
 			elemType := reflect.TypeOf(elem)
 			if lastElemType != elemType {
 				lastElemType = elemType
@@ -141,6 +142,11 @@ func (p *encodePlanArrayCodecText) Encode(value any, buf []byte) (newBuf []byte,
 				}
 			}
 			elemBuf, err = encodePlan.Encode(elem, inElemBuf)
+			if err != nil {
+				return nil, err
+			}
+		} else if callNilDriverValuer {
+			elemBuf, err = (&encodePlanDriverValuer{m: p.m, oid: p.ac.ElementType.OID, formatCode: TextFormatCode}).Encode(elem, inElemBuf)
 			if err != nil {
 				return nil, err
 			}
@@ -195,7 +201,8 @@ func (p *encodePlanArrayCodecBinary) Encode(value any, buf []byte) (newBuf []byt
 
 		elem := array.Index(i)
 		var elemBuf []byte
-		if isNil, _ := isNilDriverValuer(elem); !isNil {
+		isNil, callNilDriverValuer := isNilDriverValuer(elem)
+		if !isNil {
 			elemType := reflect.TypeOf(elem)
 			if lastElemType != elemType {
 				lastElemType = elemType
@@ -205,6 +212,11 @@ func (p *encodePlanArrayCodecBinary) Encode(value any, buf []byte) (newBuf []byt
 				}
 			}
 			elemBuf, err = encodePlan.Encode(elem, buf)
+			if err != nil {
+				return nil, err
+			}
+		} else if callNilDriverValuer {
+			elemBuf, err = (&encodePlanDriverValuer{m: p.m, oid: p.ac.ElementType.OID, formatCode: BinaryFormatCode}).Encode(elem, buf)
 			if err != nil {
 				return nil, err
 			}

--- a/pgtype/array_codec_test.go
+++ b/pgtype/array_codec_test.go
@@ -2,12 +2,13 @@ package pgtype_test
 
 import (
 	"context"
+	"database/sql/driver"
 	"encoding/hex"
 	"reflect"
 	"strings"
 	"testing"
 
-	pgx "github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxtest"
 	"github.com/stretchr/testify/assert"
@@ -128,6 +129,29 @@ func TestArrayCodecPointerToNil(t *testing.T) {
 		).Scan(&actual)
 		require.NoError(t, err)
 		require.Equal(t, input, actual)
+	})
+}
+
+type jsonbValuerSlice []int
+
+func (v jsonbValuerSlice) Value() (driver.Value, error) {
+	if v == nil {
+		return []byte("[]"), nil
+	}
+	return []byte("[1]"), nil
+}
+
+func TestArrayCodecTypedNilElementWithValuer(t *testing.T) {
+	pgxtest.RunWithQueryExecModes(context.Background(), t, defaultConnTestRunner, pgxtest.KnownOIDQueryExecModes, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		input := []jsonbValuerSlice{nil, nil}
+		var actual []string
+		err := conn.QueryRow(
+			ctx,
+			"select $1::jsonb[]::text[]",
+			input,
+		).Scan(&actual)
+		require.NoError(t, err)
+		require.Equal(t, []string{"[]", "[]"}, actual)
 	})
 }
 

--- a/pgtype/composite.go
+++ b/pgtype/composite.go
@@ -476,17 +476,23 @@ func (b *CompositeBinaryBuilder) AppendValue(oid uint32, field any) {
 		return
 	}
 
-	if isNil, _ := isNilDriverValuer(field); isNil {
+	isNil, callNilDriverValuer := isNilDriverValuer(field)
+	if isNil && !callNilDriverValuer {
 		b.buf = pgio.AppendUint32(b.buf, oid)
 		b.buf = pgio.AppendInt32(b.buf, -1)
 		b.fieldCount++
 		return
 	}
 
-	plan := b.m.PlanEncode(oid, BinaryFormatCode, field)
-	if plan == nil {
-		b.err = fmt.Errorf("unable to encode %v into OID %d in binary format", field, oid)
-		return
+	var plan EncodePlan
+	if isNil {
+		plan = &encodePlanDriverValuer{m: b.m, oid: oid, formatCode: BinaryFormatCode}
+	} else {
+		plan = b.m.PlanEncode(oid, BinaryFormatCode, field)
+		if plan == nil {
+			b.err = fmt.Errorf("unable to encode %v into OID %d in binary format", field, oid)
+			return
+		}
 	}
 
 	b.buf = pgio.AppendUint32(b.buf, oid)
@@ -533,15 +539,21 @@ func (b *CompositeTextBuilder) AppendValue(oid uint32, field any) {
 		return
 	}
 
-	if isNil, _ := isNilDriverValuer(field); isNil {
+	isNil, callNilDriverValuer := isNilDriverValuer(field)
+	if isNil && !callNilDriverValuer {
 		b.buf = append(b.buf, ',')
 		return
 	}
 
-	plan := b.m.PlanEncode(oid, TextFormatCode, field)
-	if plan == nil {
-		b.err = fmt.Errorf("unable to encode %v into OID %d in text format", field, oid)
-		return
+	var plan EncodePlan
+	if isNil {
+		plan = &encodePlanDriverValuer{m: b.m, oid: oid, formatCode: TextFormatCode}
+	} else {
+		plan = b.m.PlanEncode(oid, TextFormatCode, field)
+		if plan == nil {
+			b.err = fmt.Errorf("unable to encode %v into OID %d in text format", field, oid)
+			return
+		}
 	}
 
 	fieldBuf, err := plan.Encode(field, b.fieldBuf[0:0])

--- a/pgtype/composite_test.go
+++ b/pgtype/composite_test.go
@@ -378,6 +378,60 @@ create type parent_with_slice as (
 	})
 }
 
+type compositeWithJsonbValuer struct {
+	Name string
+	Data jsonbValuerSlice
+}
+
+func (c compositeWithJsonbValuer) IsNull() bool { return false }
+
+func (c compositeWithJsonbValuer) Index(i int) any {
+	switch i {
+	case 0:
+		return c.Name
+	case 1:
+		return c.Data
+	default:
+		panic("invalid index")
+	}
+}
+
+func TestCompositeCodecTypedNilFieldWithValuer(t *testing.T) {
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		_, err := conn.Exec(ctx, `drop type if exists composite_with_jsonb;
+create type composite_with_jsonb as (
+	name text,
+	data jsonb
+);`)
+		require.NoError(t, err)
+		defer conn.Exec(ctx, "drop type composite_with_jsonb")
+
+		dt, err := conn.LoadType(ctx, "composite_with_jsonb")
+		require.NoError(t, err)
+		conn.TypeMap().RegisterType(dt)
+
+		formats := []struct {
+			name string
+			code int16
+		}{
+			{name: "TextFormat", code: pgx.TextFormatCode},
+			{name: "BinaryFormat", code: pgx.BinaryFormatCode},
+		}
+
+		for _, format := range formats {
+			input := compositeWithJsonbValuer{Name: "test", Data: nil}
+			var gotName, gotData string
+			err := conn.QueryRow(ctx,
+				"select (r).name, (r).data::text from (select $1::composite_with_jsonb as r) s",
+				pgx.QueryResultFormats{format.code}, input,
+			).Scan(&gotName, &gotData)
+			require.NoErrorf(t, err, "%v", format.name)
+			require.Equalf(t, "test", gotName, "%v", format.name)
+			require.Equalf(t, "[]", gotData, "%v", format.name)
+		}
+	})
+}
+
 func TestCompositeCodecDecodeValue(t *testing.T) {
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
 		_, err := conn.Exec(ctx, `drop type if exists point3d;


### PR DESCRIPTION
**Note:** This proposed fix was authored by Claude Code (Opus 4.7). I have a good understanding of the problem and the aim of the fix, but don't have a deep understanding of the surrounding code. Map.Encode already handles this issue, so the fix seemed fairly well scoped in terms of mirroring that pattern.

---

Regression introduced in v5.8.0 (1a5fa7f). The fix for #2453 routed typed-nil array elements and composite fields through the NULL path by discarding the second return value of isNilDriverValuer. For value-receiver Valuers on a typed-nil receiver the helper returns (true, true) meaning "nil but Value() is safe to call" — Map.Encode honours this; the array/composite encoders were dropping it on the floor, so a column declared NOT NULL JSONB[] that previously accepted []T{nil, nil} (because T.Value() returns []byte("[]")) now fails the insert because pgx writes {NULL,NULL}.

Mirrors the existing Map.Encode pattern at pgtype.go:1970: when isNil && callNilDriverValuer, dispatch through encodePlanDriverValuer instead of emitting NULL. The pointer-receiver-Valuer panic case from #2453 still goes through the NULL path because isNilDriverValuer returns (true, false) for it.