### PR TITLE
Return ErrTxClosed from Rollback when the connection is already closed (#2557)

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -211,6 +211,16 @@ func (tx *dbTx) Rollback(ctx context.Context) error {
 		return ErrTxClosed
 	}
 
+	// The underlying connection may have already been closed out from under the
+	// transaction (e.g. a query's context was canceled, triggering an i/o
+	// timeout that tore down the pgconn). In that case the transaction is
+	// effectively closed, so honor the documented contract and return
+	// ErrTxClosed rather than leaking the low-level "conn closed" error.
+	if tx.conn.IsClosed() {
+		tx.closed = true
+		return ErrTxClosed
+	}
+
 	_, err := tx.conn.Exec(ctx, "rollback")
 	tx.closed = true
 	if err != nil {

--- a/tx_rollback_closed_test.go
+++ b/tx_rollback_closed_test.go
@@ -1,0 +1,40 @@
+package pgx_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// When a transaction query's context is canceled mid-flight, the low-level
+// pgconn is torn down but the outer pgx.Tx state is left open. The next
+// Rollback should honor its documented contract and return an error matching
+// ErrTxClosed, rather than leaking the low-level "conn closed" error.
+//
+// Regression test for jackc/pgx#2557.
+func TestTransactionRollbackAfterCanceledQueryReturnsErrTxClosed(t *testing.T) {
+	t.Parallel()
+
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{})
+	require.NoError(t, err)
+
+	// Sleep longer than the context timeout so the query is canceled and the
+	// underlying connection is closed out from under the still-open Tx.
+	_, _ = tx.Exec(ctx, "SELECT pg_sleep(1)")
+	require.True(t, conn.IsClosed(), "expected the connection to be closed after the canceled query")
+
+	// The first rollback after the connection died must report the tx as
+	// closed (ErrTxClosed), not surface the raw "conn closed" error.
+	err = tx.Rollback(context.Background())
+	require.ErrorIs(t, err, pgx.ErrTxClosed)
+}


### PR DESCRIPTION
Fixes #2557.

### Problem

When a transaction query's context is canceled mid-flight, the low-level `pgconn.PgConn` is torn down (i/o timeout), but the outer `pgx.dbTx` state is left open (`tx.closed` stays `false`). The next `Rollback` then issues `"rollback"` on the already-dead connection and surfaces the raw `"conn closed"` error instead of `pgx.ErrTxClosed`.

This contradicts `Rollback`'s documented contract:

> Rollback will return an error where `errors.Is(ErrTxClosed)` is true if the Tx is already closed […]

A closed underlying connection means the transaction is, for all practical purposes, already closed — so callers reasonably expect `ErrTxClosed` (which they can assert on) rather than an opaque low-level error.

### Reproduction (from the issue)

```go
ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
defer cancel()

tx, _ := conn.BeginTx(ctx, pgx.TxOptions{})
_, _ = tx.Exec(ctx, "SELECT pg_sleep(1)") // canceled; pgconn is closed
err := tx.Rollback(context.Background())
// before: err == "conn closed"
// after:  errors.Is(err, pgx.ErrTxClosed) == true
```

### Fix

In `Rollback`, check `tx.conn.IsClosed()` up front. If the connection is already closed, mark the tx closed and return `ErrTxClosed`. This mirrors how `Commit` already consults connection state (`tx.conn.PgConn().TxStatus()`), and leaves the normal rollback path — including the existing "rollback failed → `die()`" handling — untouched.

### Tests

Added `TestTransactionRollbackAfterCanceledQueryReturnsErrTxClosed`, which reproduces the issue's exact scenario (cancel a `pg_sleep` query, then roll back) and asserts `errors.Is(err, pgx.ErrTxClosed)`. It fails on `master` (`conn closed`) and passes with this change. The existing transaction test suite continues to pass.
