### PR TITLE
pgproto3: hex-decode CopyData.Data in UnmarshalJSON

### DIFF
--- a/pgproto3/copy_data.go
+++ b/pgproto3/copy_data.go
@@ -54,6 +54,14 @@ func (dst *CopyData) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	dst.Data = []byte(msg.Data)
+	if msg.Data == "" {
+		dst.Data = []byte{}
+		return nil
+	}
+	b, err := hex.DecodeString(msg.Data)
+	if err != nil {
+		return err
+	}
+	dst.Data = b
 	return nil
 }

--- a/pgproto3/json_test.go
+++ b/pgproto3/json_test.go
@@ -172,6 +172,25 @@ func TestJSONUnmarshalCopyData(t *testing.T) {
 	}
 }
 
+func TestJSONRoundTripCopyData(t *testing.T) {
+	want := CopyData{
+		Data: []byte{0x00, 0x01, 0x02, 0xff, 'h', 'i'},
+	}
+
+	b, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got CopyData
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round-trip mismatch:\n want: %v\n got:  %v", want.Data, got.Data)
+	}
+}
+
 func TestJSONUnmarshalCopyInResponse(t *testing.T) {
 	data := []byte(`{"Type":"CopyBothResponse", "OverallFormat": "W"}`)
 	want := CopyBothResponse{


### PR DESCRIPTION
Spotted while reading pgproto3/copy_data.go. CopyData.MarshalJSON uses hex.EncodeToString on Data but UnmarshalJSON does

    dst.Data = []byte(msg.Data)

so any Data with non-printable bytes round-trips as the literal hex string back into the slice. e.g.

    orig := CopyData{Data: []byte{0x01, 0x02, 0xff}}
    b, _ := json.Marshal(orig)
    // b = {"Type":"CopyData","Data":"0102ff"}
    var got CopyData
    json.Unmarshal(b, &got)
    // got.Data == []byte{0x30, 0x31, 0x30, 0x32, 0x66, 0x66}

Now hex.DecodeString matches the marshal side. Kept the empty-Data shortcut so the existing TestJSONUnmarshalCopyData fixture (`{"Type":"CopyData"}` -> []byte{}) still passes. Added a round-trip test that fails on master.