### PR TITLE
fix(pgtype): JSON DecodeValue returns raw bytes for literal 'null' (#2430)

### DIFF
--- a/pgtype/json.go
+++ b/pgtype/json.go
@@ -239,5 +239,20 @@ func (c *JSONCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (a
 
 	var dst any
 	err := c.Unmarshal(src, &dst)
-	return dst, err
+	if err != nil {
+		return nil, err
+	}
+	if dst == nil {
+		// The source was non-NULL (src != nil) but unmarshaled to a Go nil — this
+		// happens for the literal JSON document `null` (and equivalent whitespace
+		// padding). Returning nil here would be indistinguishable from SQL NULL,
+		// which is what DecodeValue returns when src is nil above. Hand back a
+		// copy of the raw bytes so callers (rows.Values(), Map.Scan(&any), …) can
+		// tell the two apart — matching what DecodeDatabaseSQLValue returns to
+		// the database/sql interface for the same input. See #2430.
+		dstBuf := make([]byte, len(src))
+		copy(dstBuf, src)
+		return dstBuf, nil
+	}
+	return dst, nil
 }

--- a/pgtype/json_2430_test.go
+++ b/pgtype/json_2430_test.go
@@ -1,0 +1,84 @@
+package pgtype_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TestJSONCodecDecodeValueJSONNullLiteral guards against regression of #2430:
+// the JSON document `null` is a valid non-NULL value distinct from SQL NULL.
+// JSONCodec.DecodeValue and JSONBCodec.DecodeValue must surface that distinction
+// to callers like rows.Values() (which uses DecodeValue), instead of collapsing
+// both to Go nil.
+func TestJSONCodecDecodeValueJSONNullLiteral(t *testing.T) {
+	t.Parallel()
+
+	jsonCodec := &pgtype.JSONCodec{Marshal: json.Marshal, Unmarshal: json.Unmarshal}
+	jsonbCodec := &pgtype.JSONBCodec{Marshal: json.Marshal, Unmarshal: json.Unmarshal}
+
+	cases := []struct {
+		name   string
+		decode func([]byte) (any, error)
+		src    []byte
+		want   any
+	}{
+		// SQL NULL — src nil — must continue to return Go nil.
+		{"json/sql_null", func(b []byte) (any, error) {
+			return jsonCodec.DecodeValue(nil, 0, pgtype.TextFormatCode, b)
+		}, nil, nil},
+		{"jsonb/sql_null/text", func(b []byte) (any, error) {
+			return jsonbCodec.DecodeValue(nil, 0, pgtype.TextFormatCode, b)
+		}, nil, nil},
+
+		// JSON null literal — src non-nil — must return raw bytes (not Go nil).
+		{"json/json_null_literal", func(b []byte) (any, error) {
+			return jsonCodec.DecodeValue(nil, 0, pgtype.TextFormatCode, b)
+		}, []byte("null"), []byte("null")},
+		{"jsonb/json_null_literal/text", func(b []byte) (any, error) {
+			return jsonbCodec.DecodeValue(nil, 0, pgtype.TextFormatCode, b)
+		}, []byte("null"), []byte("null")},
+		{"jsonb/json_null_literal/binary", func(b []byte) (any, error) {
+			return jsonbCodec.DecodeValue(nil, 0, pgtype.BinaryFormatCode, b)
+		}, []byte{1, 'n', 'u', 'l', 'l'}, []byte("null")},
+
+		// Existing non-null JSON values must still unmarshal as before.
+		{"json/string", func(b []byte) (any, error) {
+			return jsonCodec.DecodeValue(nil, 0, pgtype.TextFormatCode, b)
+		}, []byte(`"hello"`), "hello"},
+		{"jsonb/number/text", func(b []byte) (any, error) {
+			return jsonbCodec.DecodeValue(nil, 0, pgtype.TextFormatCode, b)
+		}, []byte("42"), float64(42)},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.decode(tc.src)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			switch want := tc.want.(type) {
+			case nil:
+				if got != nil {
+					t.Fatalf("want nil, got %v (%T)", got, got)
+				}
+			case []byte:
+				gotBytes, ok := got.([]byte)
+				if !ok {
+					t.Fatalf("want []byte, got %T (%v)", got, got)
+				}
+				if !bytes.Equal(gotBytes, want) {
+					t.Fatalf("want %q, got %q", want, gotBytes)
+				}
+			default:
+				if got != tc.want {
+					t.Fatalf("want %v (%T), got %v (%T)", tc.want, tc.want, got, got)
+				}
+			}
+		})
+	}
+}

--- a/pgtype/jsonb.go
+++ b/pgtype/jsonb.go
@@ -125,5 +125,17 @@ func (c *JSONBCodec) DecodeValue(m *Map, oid uint32, format int16, src []byte) (
 
 	var dst any
 	err := c.Unmarshal(src, &dst)
-	return dst, err
+	if err != nil {
+		return nil, err
+	}
+	if dst == nil {
+		// See JSONCodec.DecodeValue: literal JSON `null` unmarshals to Go nil,
+		// which is indistinguishable from SQL NULL. Return the raw bytes so
+		// rows.Values() callers can tell the two apart, matching
+		// DecodeDatabaseSQLValue. See #2430.
+		dstBuf := make([]byte, len(src))
+		copy(dstBuf, src)
+		return dstBuf, nil
+	}
+	return dst, nil
 }


### PR DESCRIPTION
Fixes #2430.

## Problem

`JSONCodec.DecodeValue` and `JSONBCodec.DecodeValue` unmarshal into a Go `interface{}`, which collapses the JSON document `null` to a Go `nil`. That makes a JSON `null` literal **indistinguishable** from SQL NULL — both come out of the `rows.Values()` / `Map.Scan(&any)` pipeline as `nil`.

The vanilla `database/sql` interface does not have this problem, because `DecodeDatabaseSQLValue` returns the raw response bytes — so `QueryRow().Scan(&str)` correctly yields `"null"` for `select 'null'::json;`.

## Repro

```go
rows, _ := conn.Query(ctx, `select 'null'::json;`)
for rows.Next() {
    row, _ := rows.Values()
    fmt.Println(row)
}
// Before: [<nil>]   (looks identical to SQL NULL)
// After:  [[110 117 108 108]]   ([]byte("null"))
```

## Fix

When `src` is non-nil but `c.Unmarshal(src, &dst)` yields `dst == nil` (i.e. the JSON document was literally `null`, or `null` with whitespace), return a copy of the raw `src` bytes instead of the Go nil. SQL NULL (`src == nil`) continues to return Go nil as before.

Applied to:

- `pgtype/json.go` — `JSONCodec.DecodeValue`
- `pgtype/jsonb.go` — `JSONBCodec.DecodeValue` (same change, applied after the binary-format version byte is stripped)

## What does NOT change

Other JSON values (`"hello"`, `42`, `[1,2,3]`, `{"k":"v"}`) continue to unmarshal into Go values exactly as before. The only behavior change is the JSON-null-but-not-SQL-NULL case, and only to make it distinguishable from SQL NULL.

## Tests

`pgtype/json_2430_test.go` adds `TestJSONCodecDecodeValueJSONNullLiteral` — 7 table-driven sub-cases exercising the codec directly (no DB required):

- `json/sql_null` — SQL NULL still returns Go nil
- `jsonb/sql_null/text` — same for JSONB
- `json/json_null_literal` — JSON `null` now returns `[]byte("null")`
- `jsonb/json_null_literal/text` — JSONB `null` (text format) returns `[]byte("null")`
- `jsonb/json_null_literal/binary` — JSONB `null` (binary format) returns `[]byte("null")` after stripping the v1 header byte
- `json/string` — `"hello"` still unmarshals to Go string `"hello"`
- `jsonb/number/text` — `42` still unmarshals to Go `float64(42)`

All pass with the fix; the existing JSON tests that require a live PostgreSQL (`TestJSONCodecScanNull`, etc.) are unchanged.
