### PR TITLE
fix(pgxpool): treat MaxConnLifetime 0 as unlimited in expiry check

### DIFF
--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -461,6 +461,9 @@ func (p *Pool) Close() {
 }
 
 func (p *Pool) isExpired(res *puddle.Resource[*connResource]) bool {
+	if p.maxConnLifetime <= 0 {
+		return false
+	}
 	return time.Now().After(res.Value().maxAgeTime)
 }
 

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -1324,6 +1324,52 @@ func TestPoolAcquireDestroysExpiredIdleConn(t *testing.T) {
 	require.EqualValues(t, 1, stats.TotalConns())
 }
 
+func TestPoolAcquireUnlimitedLifetimeDoesNotExpire(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	config, err := pgxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+
+	// A MaxConnLifetime of zero means connections never expire due to age. The
+	// acquire-time expiry check must not treat such connections as expired,
+	// otherwise Acquire destroys and recreates them in a loop and ultimately fails.
+	config.MaxConnLifetime = 0
+	config.HealthCheckPeriod = 100 * time.Millisecond
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// Establish a single connection and remember its identity.
+	c, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	firstConn := c.Conn()
+	c.Release()
+	waitForReleaseToComplete()
+
+	require.EqualValues(t, 1, pool.Stat().TotalConns())
+
+	// Give the background health check several chances to (wrongly) reap the conn.
+	time.Sleep(500 * time.Millisecond)
+
+	// Re-acquiring must succeed and hand back the very same connection: it was
+	// neither expired at acquire time nor destroyed by the health check.
+	for range 5 {
+		c, err = pool.Acquire(ctx)
+		require.NoError(t, err)
+		require.Same(t, firstConn, c.Conn())
+		c.Release()
+		waitForReleaseToComplete()
+	}
+
+	stats := pool.Stat()
+	require.EqualValues(t, 0, stats.MaxLifetimeDestroyCount())
+	require.EqualValues(t, 1, stats.TotalConns())
+}
+
 func TestPoolAcquirePingTimeout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

When `MaxConnLifetime == 0` (whose documented and conventional meaning is "unlimited lifetime", consistent with `database/sql.SetConnMaxLifetime(0)`), `Pool.Acquire` always fails with:

```text
too many failed attempts acquiring connection
```

Instead of returning a connection, it repeatedly creates and destroys connections until the retry limit is reached.

## Root Cause

Commit `20578f57` ("feat: check if conn is expired before acquire") introduced an `isExpired` check in `Acquire`.

At connection creation time, `maxAgeTime` is computed as:

```go
maxAgeTime = time.Now().Add(MaxConnLifetime).Add(jitter)
```

When `MaxConnLifetime == 0`, `maxAgeTime` is effectively the connection creation timestamp. As a result, the expiration check:

```go
time.Now().After(maxAgeTime)
```

becomes true almost immediately.

Consequently, every newly created connection is considered expired as soon as it is acquired. `Acquire` destroys the connection, creates a new one, and repeats this process up to `maxConns + 1` times before eventually returning:

```text
too many failed attempts acquiring connection
```

The same `isExpired` logic is also used by the background health checker (`checkConnsHealth`), causing idle connections to be destroyed immediately as well. This behavior contradicts the expected semantics of `MaxConnLifetime == 0`, which should represent an unlimited lifetime.

## Fix

Treat non-positive values of `MaxConnLifetime` as meaning "unlimited" by guarding the `isExpired` function, which is the single source of truth used by both `Acquire` and `checkConnsHealth`.

With this change, connections are never considered expired due to age when `MaxConnLifetime <= 0`, restoring the behavior that existed before the regression and ensuring that `MaxConnLifetime == 0` consistently means unlimited lifetime.