### PR TITLE
pgtype: validate bit/varbit binary bitLen against actual data bytes

### DIFF
--- a/pgtype/bits.go
+++ b/pgtype/bits.go
@@ -174,6 +174,11 @@ func (scanPlanBinaryBitsToBitsScanner) Scan(src []byte, dst any) error {
 
 	bitLen := int32(binary.BigEndian.Uint32(src))
 	rp := 4
+
+	if bitLen < 0 || (int(bitLen)+7)/8 != len(src[rp:]) {
+		return fmt.Errorf("invalid length for bit/varbit: bitLen=%d dataBytes=%d", bitLen, len(src[rp:]))
+	}
+
 	buf := make([]byte, len(src[rp:]))
 	copy(buf, src[rp:])
 


### PR DESCRIPTION

`scanPlanBinaryBitsToBitsScanner.Scan` reads the server-supplied `bitLen`
from the first four bytes of a binary `bit`/`varbit` message but never
checks that it is consistent with the number of data bytes that follow.
A server can therefore send a message whose declared bit count exceeds
the payload length — for example `bitLen = 1 000 000` with only 10 data
bytes — and the decoder accepts it without error.

The inconsistency becomes a panic the moment the resulting `Bits` value
is text-encoded. `encodePlanBitsCodecText.Encode` iterates `bits.Len`
times and accesses `bits.Bytes[i/8]` on every iteration:

```go
for i := int32(0); i < bits.Len; i++ {
    if bits.Bytes[i/8]&bitMask > 0 { // index out of range
```

When `bits.Len > len(bits.Bytes)*8` this is an unconditional
index-out-of-range panic — no special trigger needed beyond receiving
and then re-encoding the value.

This is the same length-prefix-vs-remaining-bytes pattern addressed for
hstore (F05), array element length (F06), array element count (F07), and
range/multirange/tsvector (F11). `bit`/`varbit` was overlooked in that
series.

## Fix

Reject messages where `bitLen` is negative or where the ceil-rounded
byte count does not match the actual data byte count:

```go
if bitLen < 0 || (int(bitLen)+7)/8 != len(src[rp:]) {
    return fmt.Errorf("invalid length for bit/varbit: bitLen=%d dataBytes=%d",
        bitLen, len(src[rp:]))
}
```

The cast to `int` before adding 7 prevents int32 overflow for values
near `math.MaxInt32`.

## Testing

Build a synthetic binary `varbit` message with a mismatched header and
confirm the decoder returns an error instead of producing a `Bits` value
that panics on encode.
