### PR TITLE
pgconn: skip pgpass file read when password is already set

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -483,14 +483,13 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 	config.Fallbacks = fallbacks[1:]
 	config.SSLNegotiation = settings["sslnegotiation"]
 
-	passfile, err := pgpassfile.ReadPassfile(settings["passfile"])
-	if err == nil {
-		if config.Password == "" {
+	if config.Password == "" {
+		passfile, err := pgpassfile.ReadPassfile(settings["passfile"])
+		if err == nil {
 			host := config.Host
 			if network, _ := NetworkAddress(config.Host, config.Port); network == "unix" {
 				host = "localhost"
 			}
-
 			config.Password = passfile.FindPassword(host, strconv.Itoa(int(config.Port)), config.Database, config.User)
 		}
 	}


### PR DESCRIPTION
## Problem

SELinux raises an AVC denial when pgx reads the pgpass file, even when
a password is explicitly provided and the file would be ignored anyway.

## Fix

Skip reading the pgpass file entirely when `config.Password` is already
set, avoiding the unnecessary syscall.
