### PR TITLE
Keep connections alive after BEGIN statement for non-FATAL errors

### DIFF
--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -1060,11 +1060,8 @@ func TestConnReleaseWhenBeginFail(t *testing.T) {
 	tx, err := db.BeginTx(ctx, pgx.TxOptions{
 		IsoLevel: pgx.TxIsoLevel("foo"),
 	})
-	assert.Error(t, err)
-	if !assert.Zero(t, tx) {
-		err := tx.Rollback(ctx)
-		assert.NoError(t, err)
-	}
+	require.Error(t, err)
+	require.Zero(t, tx)
 
 	require.EqualValues(t, 1, db.Stat().TotalConns())
 

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -1075,6 +1075,40 @@ func TestConnReleaseWhenBeginFail(t *testing.T) {
 	require.EqualValues(t, 1, n)
 }
 
+func TestConnDestroyedWhenBeginFailsFatally(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	controllerConn, err := pgx.Connect(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	defer controllerConn.Close(ctx)
+	pgxtest.SkipCockroachDB(t, controllerConn, "Server does not support pg_terminate_backend() (https://github.com/cockroachdb/cockroach/issues/35897)")
+
+	db, err := pgxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// The BEGIN terminates its own backend, so it fails with a fatal error and
+	// the connection is destroyed rather than released back to the pool.
+	tx, err := db.BeginTx(ctx, pgx.TxOptions{BeginQuery: "select pg_terminate_backend(pg_backend_pid())"})
+	assert.Error(t, err)
+	if !assert.Zero(t, tx) {
+		err := tx.Rollback(ctx)
+		assert.NoError(t, err)
+	}
+
+	for range 1000 {
+		if db.Stat().TotalConns() == 0 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	assert.EqualValues(t, 0, db.Stat().TotalConns())
+}
+
 func TestTxBeginFuncNestedTransactionCommit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -1066,14 +1066,13 @@ func TestConnReleaseWhenBeginFail(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	for range 1000 {
-		if db.Stat().TotalConns() == 0 {
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
+	// The invalid BEGIN fails with a non-fatal error, so the connection stays
+	// usable and is released back to the pool rather than destroyed.
+	assert.EqualValues(t, 1, db.Stat().TotalConns())
 
-	assert.EqualValues(t, 0, db.Stat().TotalConns())
+	var n int
+	require.NoError(t, db.QueryRow(ctx, "select 1").Scan(&n))
+	require.EqualValues(t, 1, n)
 }
 
 func TestTxBeginFuncNestedTransactionCommit(t *testing.T) {

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -1066,7 +1066,7 @@ func TestConnReleaseWhenBeginFail(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.EqualValues(t, 1, db.Stat().TotalConns())
+	require.EqualValues(t, 1, db.Stat().TotalConns())
 
 	var n int
 	require.NoError(t, db.QueryRow(ctx, "select 1").Scan(&n))
@@ -1089,11 +1089,8 @@ func TestConnDestroyedWhenBeginFailsFatally(t *testing.T) {
 	defer db.Close()
 
 	tx, err := db.BeginTx(ctx, pgx.TxOptions{BeginQuery: "select pg_terminate_backend(pg_backend_pid())"})
-	assert.Error(t, err)
-	if !assert.Zero(t, tx) {
-		err := tx.Rollback(ctx)
-		assert.NoError(t, err)
-	}
+	require.Error(t, err)
+	require.Zero(t, tx)
 
 	for range 1000 {
 		if db.Stat().TotalConns() == 0 {
@@ -1102,7 +1099,7 @@ func TestConnDestroyedWhenBeginFailsFatally(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	assert.EqualValues(t, 0, db.Stat().TotalConns())
+	require.EqualValues(t, 0, db.Stat().TotalConns())
 }
 
 func TestTxBeginFuncNestedTransactionCommit(t *testing.T) {

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -1066,8 +1066,6 @@ func TestConnReleaseWhenBeginFail(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	// The invalid BEGIN fails with a non-fatal error, so the connection stays
-	// usable and is released back to the pool rather than destroyed.
 	assert.EqualValues(t, 1, db.Stat().TotalConns())
 
 	var n int
@@ -1090,8 +1088,6 @@ func TestConnDestroyedWhenBeginFailsFatally(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	// The BEGIN terminates its own backend, so it fails with a fatal error and
-	// the connection is destroyed rather than released back to the pool.
 	tx, err := db.BeginTx(ctx, pgx.TxOptions{BeginQuery: "select pg_terminate_backend(pg_backend_pid())"})
 	assert.Error(t, err)
 	if !assert.Zero(t, tx) {

--- a/tx.go
+++ b/tx.go
@@ -100,9 +100,11 @@ func (c *Conn) Begin(ctx context.Context) (Tx, error) {
 func (c *Conn) BeginTx(ctx context.Context, txOptions TxOptions) (Tx, error) {
 	_, err := c.Exec(ctx, txOptions.beginSQL())
 	if err != nil {
-		// begin should never fail unless there is an underlying connection issue or
-		// a context timeout. In either case, the connection is possibly broken.
-		c.die()
+		// begin kills the connection upon receiving fatal or panic errors, but does not otherwise as the connection should be reusable
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || isConnectionFatal(pgErr) {
+			c.die()
+		}
 		return nil, err
 	}
 
@@ -110,6 +112,14 @@ func (c *Conn) BeginTx(ctx context.Context, txOptions TxOptions) (Tx, error) {
 		conn:        c,
 		commitQuery: txOptions.CommitQuery,
 	}, nil
+}
+
+func isConnectionFatal(pgErr *pgconn.PgError) bool {
+	severity := pgErr.SeverityUnlocalized
+	if severity == "" {
+		severity = pgErr.Severity
+	}
+	return severity == "FATAL" || severity == "PANIC"
 }
 
 // Tx represents a database transaction.

--- a/tx.go
+++ b/tx.go
@@ -100,7 +100,8 @@ func (c *Conn) Begin(ctx context.Context) (Tx, error) {
 func (c *Conn) BeginTx(ctx context.Context, txOptions TxOptions) (Tx, error) {
 	_, err := c.Exec(ctx, txOptions.beginSQL())
 	if err != nil {
-		// begin kills the connection upon receiving fatal or panic errors, but does not otherwise as the connection should be reusable
+		// begin kills the connection upon receiving fatal, panic or non PGError errors,
+		// but does not otherwise as the connection should be reusable.
 		var pgErr *pgconn.PgError
 		if !errors.As(err, &pgErr) || isConnectionFatal(pgErr) {
 			c.die()

--- a/tx_test.go
+++ b/tx_test.go
@@ -643,3 +643,47 @@ func TestTxSendBatchClosed(t *testing.T) {
 	_, err = br.Query()
 	require.Error(t, err)
 }
+
+func TestBeginTxNonFatalErrorKeepsConnAlive(t *testing.T) {
+	t.Parallel()
+
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	pgxtest.SkipCockroachDB(t, conn, "Server returns a different severity/error for an invalid BEGIN")
+
+	ctx := context.Background()
+
+	_, err := conn.BeginTx(ctx, pgx.TxOptions{BeginQuery: "begin transaction isolation level nonsense"})
+	require.Error(t, err)
+
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr))
+	require.NotEqual(t, "FATAL", pgErr.SeverityUnlocalized)
+
+	require.False(t, conn.IsClosed())
+
+	var n int
+	require.NoError(t, conn.QueryRow(ctx, "select 1").Scan(&n))
+	require.Equal(t, 1, n)
+}
+
+func TestBeginTxFatalErrorKillsConn(t *testing.T) {
+	t.Parallel()
+
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	pgxtest.SkipCockroachDB(t, conn, "Server does not support pg_terminate_backend()")
+
+	ctx := context.Background()
+
+	_, err := conn.BeginTx(ctx, pgx.TxOptions{BeginQuery: "select pg_terminate_backend(pg_backend_pid())"})
+	require.Error(t, err)
+
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr))
+	require.Equal(t, "FATAL", pgErr.SeverityUnlocalized)
+
+	require.True(t, conn.IsClosed())
+}


### PR DESCRIPTION
## Problem
For more context, see: #2583 

`Conn.BeginTx` calls `c.die()` on **any** error from `BEGIN`, unconditionally destroying the connection:

```go
_, err := c.Exec(ctx, txOptions.beginSQL())
if err != nil {
    c.die()
    return nil, err
}
```

The assumption ("begin should never fail unless the connection is broken") is true for connecting directly to postgres, but with a connection pooler in between, there are errors that should not kill the connection, as it is reusable, for instance errors due to load shedding.

## Change

Only `die()` when the connection is actually compromised due to:

- non-`PgError` (transport error / context cancellation) 
- `FATAL`/`PANIC` `PgError` (server tearing the session down) 

## Tests

- `TestBeginTxNonFatalErrorKeepsConnAlive` — a BEGIN failing with a non-FATAL error leaves `IsClosed() == false` and the connection still answers `select 1`.
- `TestBeginTxFatalErrorKillsConn` — a BEGIN that terminates its own backend (`pg_terminate_backend(pg_backend_pid())`) returns a `FATAL` error and the connection is closed.
- `pgxpool.TestConnReleaseWhenBeginFail` — updated: a recoverable BEGIN failure now releases the connection back to the pool **alive** (TotalConns stays 1, reusable) instead of destroying it.
- `pgxpool.TestConnDestroyedWhenBeginFailsFatally` — a BEGIN that terminates its own backend fails fatally, so the pool destroys the connection (TotalConns drops to 0) instead of reusing it.

