### PR TITLE
Call TraceQueryEnd during Exec errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -475,6 +475,9 @@ func (c *Conn) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.C
 	}
 
 	if err := c.deallocateInvalidatedCachedStatements(ctx); err != nil {
+		if c.queryTracer != nil {
+			c.queryTracer.TraceQueryEnd(ctx, c, TraceQueryEndData{Err: err})
+		}
 		return pgconn.CommandTag{}, err
 	}
 


### PR DESCRIPTION
We should make every effort to call `TraceQueryEnd` after calling `TraceQueryStart`. `Conn.Query` handles this case but not `Conn.Exec`: https://github.com/jackc/pgx/blob/7fd58a74a192bae9637be6560758cae844c0e95f/conn.go#L756-L761