### PR TITLE
tx: regression test for Rollback after mid-query connection close (#2557)

### DIFF
--- a/tx_test.go
+++ b/tx_test.go
@@ -643,3 +643,33 @@ func TestTxSendBatchClosed(t *testing.T) {
 	_, err = br.Query()
 	require.Error(t, err)
 }
+
+// When a query is cancelled mid-flight the underlying connection is closed, but
+// the Tx handle has not been finalized. The first Rollback then fails to send
+// ROLLBACK over the dead connection. That error must be matchable as
+// pgconn.ErrConnClosed (transport gone) rather than ErrTxClosed (handle already
+// finalized), so callers can tell the two apart. A second Rollback returns
+// ErrTxClosed. See https://github.com/jackc/pgx/issues/2557.
+func TestTxRollbackOnClosedConnReturnsErrConnClosed(t *testing.T) {
+	t.Parallel()
+
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	tx, err := conn.Begin(context.Background())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err = tx.Exec(ctx, "select pg_sleep(5)")
+	require.Error(t, err)
+	require.True(t, conn.IsClosed())
+
+	err = tx.Rollback(context.Background())
+	require.ErrorIs(t, err, pgconn.ErrConnClosed)
+	require.NotErrorIs(t, err, pgx.ErrTxClosed)
+
+	err = tx.Rollback(context.Background())
+	require.ErrorIs(t, err, pgx.ErrTxClosed)
+}


### PR DESCRIPTION
Follow-up to #2559. That PR added pgconn.ErrConnClosed and a pgconn-level test, but #2557 was filed against the pgx.Tx layer and there's no test covering that path.

This adds one: begin a tx, cancel an Exec mid-flight so the underlying conn closes, then assert the first Rollback is errors.Is(err, pgconn.ErrConnClosed) and not ErrTxClosed, and a second Rollback returns ErrTxClosed. No production code change.

Tested against Postgres 17 with -race, -count=20, no flakes.
