### PR TITLE
fix(pgtype): return error instead of panicking on malformed interval text

### DIFF
--- a/pgtype/interval.go
+++ b/pgtype/interval.go
@@ -232,7 +232,7 @@ func (scanPlanTextAnyToIntervalScanner) Scan(src []byte, dst any) error {
 		}
 
 		var negative bool
-		if timeParts[0][0] == '-' {
+		if len(timeParts[0]) > 0 && timeParts[0][0] == '-' {
 			negative = true
 			timeParts[0] = timeParts[0][1:]
 		}

--- a/pgtype/interval_malformed_test.go
+++ b/pgtype/interval_malformed_test.go
@@ -1,0 +1,19 @@
+package pgtype_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// A malformed interval whose time component has an empty hours segment
+// (for example ":05:06") must return an error instead of panicking with an
+// index out of range on timeParts[0][0].
+func TestIntervalScanMalformedTimeReturnsError(t *testing.T) {
+	for _, src := range []string{":05:06", "1 day :30:00"} {
+		var v pgtype.Interval
+		if err := v.Scan(src); err == nil {
+			t.Errorf("Scan(%q): expected error, got nil", src)
+		}
+	}
+}


### PR DESCRIPTION
`scanPlanTextAnyToIntervalScanner.Scan` reads `timeParts[0][0]` to check for a
leading `-` without first confirming the hours segment is non-empty.

An interval text value whose time component begins with a colon, for example
`:05:06`, splits into `["", "05", "06"]`, so `timeParts[0]` is empty and the
byte access panics:

```
runtime error: index out of range [0] with length 0
```

`pgtype.Interval` implements `database/sql.Scanner`, so this is reachable from
any code that scans a string into it.

## Fix

Guard the byte access. When the hours segment is empty, the value falls
through to `strconv.ParseInt`, which already returns a `bad interval hour
format` error. This is the same "return an error instead of panicking on
malformed text" handling that #2566 added for the geometric types.

## Testing

Added `TestIntervalScanMalformedTimeReturnsError`, which scans `:05:06` and
`1 day :30:00`. Without the guard both panic; with it both return an error.
The test needs no database.
