### PR TITLE
rows: restore case-insensitive db tag matching (#2296)

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -843,7 +843,7 @@ func fieldPosByName(fldDescs []pgconn.FieldDescription, field string, normalize 
 				return i
 			}
 		} else {
-			if desc.Name == field {
+			if strings.EqualFold(desc.Name, field) {
 				return i
 			}
 		}

--- a/rows_test.go
+++ b/rows_test.go
@@ -702,6 +702,24 @@ func TestRowToStructByNameDbTags(t *testing.T) {
 	})
 }
 
+// A db tag must match its column case-insensitively. PostgreSQL folds unquoted
+// identifiers to lower case, so a column aliased `as Region` comes back as
+// "region" and has to match a `db:"Region"` tag. See
+// https://github.com/jackc/pgx/issues/2296.
+func TestRowToStructByNameDbTagsCaseInsensitive(t *testing.T) {
+	type record struct {
+		Region string `db:"Region"`
+	}
+
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		rows, _ := conn.Query(ctx, `select 'east' as Region`)
+		slice, err := pgx.CollectRows(rows, pgx.RowToStructByName[record])
+		require.NoError(t, err)
+		require.Len(t, slice, 1)
+		assert.Equal(t, "east", slice[0].Region)
+	})
+}
+
 func TestRowToStructByNameEmbeddedStruct(t *testing.T) {
 	type Name struct {
 		Last  string `db:"last_name"`


### PR DESCRIPTION
Fixes #2296.

#2085 fixed the underscore collision (account_id vs account__id) by no longer stripping underscores for db-tagged fields, but in the same change it switched tag matching from strings.EqualFold to an exact desc.Name == field. That made db tags case-sensitive. PostgreSQL folds unquoted identifiers to lower case, so a column aliased `as Region` comes back as "region" and no longer matches a `db:"Region"` tag.

This restores EqualFold for the tagged path (still without underscore stripping), so the #2085 collision stays fixed while case-insensitive matching works again. Added a test; the existing TestRowToStructByNameDbTags collision test still passes.
