### PR TITLE
Resolve config home dir without os/user.Current to avoid SIGFPE in distroless

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -359,6 +359,26 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 	}
 
 	settings := mergeSettings(defaultSettings, envSettings, connStringSettings)
+
+	// The home-directory-derived defaults (passfile, servicefile, sslcert,
+	// sslkey, sslrootcert) are already present in settings at this point:
+	// defaultSettings resolves them via the user's home directory, which is
+	// safe and cheap to look up (see defaults.go / defaults_windows.go).
+	//
+	// The default PostgreSQL user name is different: resolving it requires
+	// looking up the OS user account, which can be slow or, in some
+	// restricted container environments, crash the process. So that lookup
+	// is memoized and only performed lazily below, the first time it is
+	// actually needed -- i.e. only when a connection string or environment
+	// does not already supply a user.
+	var cachedOSUserSettings map[string]string
+	lazyOSUserSettings := func() map[string]string {
+		if cachedOSUserSettings == nil {
+			cachedOSUserSettings = osUserSettings()
+		}
+		return cachedOSUserSettings
+	}
+
 	if service, present := settings["service"]; present {
 		serviceSettings, err := parseServiceSettings(settings["servicefile"], service)
 		if err != nil {
@@ -366,6 +386,13 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 		}
 
 		settings = mergeSettings(defaultSettings, envSettings, serviceSettings, connStringSettings)
+	}
+
+	// Only fall back to the OS user account for the default PostgreSQL user
+	// name when it was not already supplied by the connection string,
+	// environment, or service file.
+	if settings["user"] == "" {
+		settings = mergeSettings(lazyOSUserSettings(), settings)
 	}
 
 	config := &Config{

--- a/pgconn/config_lazy_os_user_test.go
+++ b/pgconn/config_lazy_os_user_test.go
@@ -1,0 +1,122 @@
+package pgconn_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseConfigDoesNotLookUpOSUserWhenUserAndPassfileExplicit reproduces
+// https://github.com/jackc/pgx/issues/2586: ParseConfigWithOptions must not
+// need to resolve the OS user account when the connection string already
+// supplies both user and passfile. Looking up the OS account can crash the
+// process in some restricted/broken-NSS container environments (SIGFPE),
+// so the lookup is simulated as fatal here to prove it is never reached.
+func TestParseConfigDoesNotLookUpOSUserWhenUserAndPassfileExplicit(t *testing.T) {
+	skipOnWindows(t)
+	clearPgEnvvars(t)
+	t.Setenv("PGPASSFILE", "")
+	t.Setenv("PGSERVICE", "")
+	t.Setenv("PGSERVICEFILE", "")
+
+	restore := pgconn.SetOSUserLookupForTest(func() (*user.User, error) {
+		panic("os/user.Current must not be called when user and passfile are both explicit")
+	})
+	defer restore()
+
+	passfile := filepath.Join(t.TempDir(), "pgpass")
+	require.NoError(t, os.WriteFile(passfile, []byte("test1:5432:curlydb:curly:nyuknyuknyuk"), 0o600))
+
+	connString := fmt.Sprintf("postgres://curly@test1:5432/curlydb?sslmode=disable&passfile=%s", passfile)
+
+	// Must not panic: the mocked lookup above panics if it is ever invoked.
+	config, err := pgconn.ParseConfig(connString)
+	require.NoError(t, err)
+
+	assert.Equal(t, "curly", config.User)
+	// Password must come from the explicit passfile, not from any OS-derived
+	// (leaked) default path.
+	assert.Equal(t, "nyuknyuknyuk", config.Password)
+}
+
+// TestParseConfigDoesNotLookUpOSUserWhenUserAndPasswordExplicit covers the
+// concrete distroless/production scenario from issue #2586: user and
+// password supplied directly (no reliance on a pgpass file at all).
+func TestParseConfigDoesNotLookUpOSUserWhenUserAndPasswordExplicit(t *testing.T) {
+	skipOnWindows(t)
+	clearPgEnvvars(t)
+	t.Setenv("PGPASSFILE", "")
+	t.Setenv("PGSERVICE", "")
+	t.Setenv("PGSERVICEFILE", "")
+
+	restore := pgconn.SetOSUserLookupForTest(func() (*user.User, error) {
+		panic("os/user.Current must not be called when user and password are both explicit")
+	})
+	defer restore()
+
+	connString := "postgres://curly:nyuknyuknyuk@test1:5432/curlydb?sslmode=disable"
+
+	config, err := pgconn.ParseConfig(connString)
+	require.NoError(t, err)
+
+	assert.Equal(t, "curly", config.User)
+	assert.Equal(t, "nyuknyuknyuk", config.Password)
+}
+
+// TestParseConfigStillLooksUpOSUserWhenNeeded is the negative control for
+// the two tests above: when the connection string does NOT supply enough
+// information to avoid it, ParseConfigWithOptions must still fall back to
+// the OS user account, exactly as before this change. This proves the
+// laziness is conditional, not a blanket skip.
+func TestParseConfigStillLooksUpOSUserWhenNeeded(t *testing.T) {
+	skipOnWindows(t)
+	clearPgEnvvars(t)
+	t.Setenv("PGPASSFILE", "")
+	t.Setenv("PGSERVICE", "")
+	t.Setenv("PGSERVICEFILE", "")
+
+	called := false
+	restore := pgconn.SetOSUserLookupForTest(func() (*user.User, error) {
+		called = true
+		return &user.User{Username: "mocked-os-user", HomeDir: t.TempDir()}, nil
+	})
+	defer restore()
+
+	connString := "postgres://test1:5432/curlydb?sslmode=disable"
+
+	config, err := pgconn.ParseConfig(connString)
+	require.NoError(t, err)
+
+	assert.True(t, called, "expected the OS user lookup to be consulted for the default user")
+	assert.Equal(t, "mocked-os-user", config.User)
+}
+
+// TestParseConfigOSUserLookupFailureStillErrorsWhenActuallyNeeded documents
+// that when the OS lookup genuinely fails and no fallback is provided any
+// other way, ParseConfig still surfaces the same "no default" behavior as
+// before (empty user), rather than panicking or silently misbehaving.
+func TestParseConfigOSUserLookupFailureStillErrorsWhenActuallyNeeded(t *testing.T) {
+	skipOnWindows(t)
+	clearPgEnvvars(t)
+	t.Setenv("PGPASSFILE", "")
+	t.Setenv("PGSERVICE", "")
+	t.Setenv("PGSERVICEFILE", "")
+
+	restore := pgconn.SetOSUserLookupForTest(func() (*user.User, error) {
+		return nil, errors.New("boom")
+	})
+	defer restore()
+
+	connString := "postgres://test1:5432/curlydb?sslmode=disable"
+
+	config, err := pgconn.ParseConfig(connString)
+	require.NoError(t, err)
+	assert.Equal(t, "", config.User)
+}

--- a/pgconn/config_security_home_dir_test.go
+++ b/pgconn/config_security_home_dir_test.go
@@ -1,0 +1,223 @@
+package pgconn_test
+
+import (
+	"crypto/x509"
+	"errors"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file is the mandatory security regression test for the reworked fix
+// for https://github.com/jackc/pgx/issues/2586.
+//
+// The previously proposed fix for #2586 gated the ENTIRE OS-account-derived
+// defaults lookup (default user, passfile, servicefile, sslcert, sslkey,
+// sslrootcert) behind "is user/password already explicit". That silently
+// dropped the home-directory-derived TLS defaults whenever the connection
+// string already supplied both a user and a password -- exactly the common
+// case for e.g. a distroless container reading DATABASE_URL from an env
+// var. Concretely, for `user:pass@host?sslmode=require` with
+// ~/.postgresql/root.crt present, that gated fix went from a verified TLS
+// connection (RootCAs set, custom peer verification) to
+// tlsConfig.InsecureSkipVerify=true with no root CA at all -- a silent
+// security downgrade. For sslmode=verify-full against a private CA, it
+// would break the connection entirely (RootCAs=nil forces validation
+// against the system pool). For mTLS, the client certificate would be
+// dropped, and a server that requires client certs would refuse the
+// connection.
+//
+// The rework instead decouples the home-directory defaults (which only
+// need os.UserHomeDir, safe to call unconditionally) from the OS account
+// username lookup (the only thing that is actually lazy/gated, since it is
+// the only part that can crash in a broken-NSS/CGO container). These tests
+// assert byte-for-byte the resulting TLS configuration is identical to
+// what an unmodified upstream/master (which has no such gate at all)
+// produces for the same fake home directory -- proving no downgrade.
+func setupSecurityABFakeHome(t *testing.T) (fakeHome, rootCert string) {
+	t.Helper()
+	skipOnWindows(t)
+
+	fakeHome = t.TempDir()
+	pgDir := filepath.Join(fakeHome, ".postgresql")
+	require.NoError(t, os.MkdirAll(pgDir, 0o700))
+
+	// Generate a throwaway private CA + client cert/key signed by it, so we
+	// can assert the resolved sslrootcert/sslcert/sslkey are actually used
+	// to build the TLS config (not merely present as files).
+	caKey := filepath.Join(pgDir, "ca.key")
+	rootCert = filepath.Join(pgDir, "root.crt")
+	clientKey := filepath.Join(pgDir, "postgresql.key")
+	clientCert := filepath.Join(pgDir, "postgresql.crt")
+	csr := filepath.Join(pgDir, "client.csr")
+
+	runOpenSSL(t, "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+		"-keyout", caKey, "-out", rootCert, "-days", "3650",
+		"-subj", "/CN=pgx-security-ab-test-root-ca")
+	runOpenSSL(t, "req", "-newkey", "rsa:2048", "-nodes",
+		"-keyout", clientKey, "-out", csr, "-subj", "/CN=pgx-security-ab-test-client")
+	runOpenSSL(t, "x509", "-req", "-in", csr, "-CA", rootCert, "-CAkey", caKey,
+		"-CAcreateserial", "-out", clientCert, "-days", "3650")
+
+	return fakeHome, rootCert
+}
+
+func runOpenSSL(t *testing.T, args ...string) {
+	t.Helper()
+	path, err := exec.LookPath("openssl")
+	if err != nil {
+		t.Skip("openssl not available; skipping security A/B TLS defaults test")
+	}
+	cmd := exec.Command(path, args...)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "openssl %v failed: %s", args, out)
+}
+
+// TestParseConfigHomeDirTLSDefaultsSurviveExplicitUserAndPassword is the
+// mandatory security regression test: when user and password are BOTH
+// explicit (the exact scenario the previous, refuted fix mishandled), the
+// home-directory-derived sslrootcert/sslcert/sslkey defaults must still
+// resolve and produce the same TLS configuration as they would with no
+// user/password gating at all (i.e. as unmodified upstream/master, which
+// has no such gate, always produced).
+//
+// It also proves the crash fix is preserved: the OS user account lookup
+// (which only supplies the *username* default now) must never be called,
+// since user is already explicit.
+func TestParseConfigHomeDirTLSDefaultsSurviveExplicitUserAndPassword(t *testing.T) {
+	clearPgEnvvars(t)
+	fakeHome, rootCert := setupSecurityABFakeHome(t)
+
+	restoreHome := pgconn.SetUserHomeDirLookupForTest(func() (string, error) {
+		return fakeHome, nil
+	})
+	defer restoreHome()
+
+	restoreUser := pgconn.SetOSUserLookupForTest(func() (*user.User, error) {
+		panic("os/user.Current must not be called when user is already explicit")
+	})
+	defer restoreUser()
+
+	expectedRootPool := x509.NewCertPool()
+	rootPEM, err := os.ReadFile(rootCert)
+	require.NoError(t, err)
+	require.True(t, expectedRootPool.AppendCertsFromPEM(rootPEM))
+
+	tests := []struct {
+		name       string
+		connString string
+		assertTLS  func(t *testing.T, cfg *pgconn.Config)
+	}{
+		{
+			name:       "sslmode=require",
+			connString: "postgres://curly:nyuknyuknyuk@test1:5432/curlydb?sslmode=require",
+			assertTLS: func(t *testing.T, cfg *pgconn.Config) {
+				require.NotNil(t, cfg.TLSConfig)
+				// Matches gold reference from unmodified upstream/master:
+				// InsecureSkipVerify=true|RootCAs=set(matches)|VerifyPeerCertificate=true|Certificates=1
+				assert.True(t, cfg.TLSConfig.InsecureSkipVerify)
+				require.NotNil(t, cfg.TLSConfig.RootCAs, "sslrootcert default must still resolve (was silently dropped by the refuted fix)")
+				assert.True(t, cfg.TLSConfig.RootCAs.Equal(expectedRootPool), "RootCAs must be built from the home-dir root.crt")
+				assert.NotNil(t, cfg.TLSConfig.VerifyPeerCertificate, "require+rootcert must still verify the chain itself (verify-ca-equivalent behavior)")
+				assert.Len(t, cfg.TLSConfig.Certificates, 1, "mTLS client cert default must still resolve")
+			},
+		},
+		{
+			name:       "sslmode=verify-full",
+			connString: "postgres://curly:nyuknyuknyuk@test1:5432/curlydb?sslmode=verify-full",
+			assertTLS: func(t *testing.T, cfg *pgconn.Config) {
+				require.NotNil(t, cfg.TLSConfig)
+				// Matches gold reference from unmodified upstream/master:
+				// InsecureSkipVerify=false|RootCAs=set(matches)|VerifyPeerCertificate=false|Certificates=1
+				assert.False(t, cfg.TLSConfig.InsecureSkipVerify)
+				require.NotNil(t, cfg.TLSConfig.RootCAs, "sslrootcert default must still resolve against a private CA")
+				assert.True(t, cfg.TLSConfig.RootCAs.Equal(expectedRootPool))
+				assert.Nil(t, cfg.TLSConfig.VerifyPeerCertificate, "verify-full uses Go's standard chain+hostname verification, not the custom callback")
+				assert.Equal(t, "test1", cfg.TLSConfig.ServerName)
+				assert.Len(t, cfg.TLSConfig.Certificates, 1, "mTLS client cert default must still resolve")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := pgconn.ParseConfig(tt.connString)
+			require.NoError(t, err)
+			require.Equal(t, "curly", cfg.User)
+			require.Equal(t, "nyuknyuknyuk", cfg.Password)
+			tt.assertTLS(t, cfg)
+		})
+	}
+}
+
+// TestParseConfigHomeDirTLSDefaultsDropOldGatedBehavior documents, as a
+// negative control, exactly what the refuted fix got wrong: it shows that
+// WITHOUT any home-dir defaults resolved (simulating the old gated/skip
+// behavior by pointing the fake home at an empty directory), the same
+// connString silently downgrades to InsecureSkipVerify with no root CA.
+// This is not exercised against production code paths -- it exists so the
+// contrast with the test above is explicit and mechanically checkable.
+func TestParseConfigHomeDirTLSDefaultsDropOldGatedBehavior(t *testing.T) {
+	clearPgEnvvars(t)
+
+	emptyHome := t.TempDir() // no ~/.postgresql directory at all
+
+	restoreHome := pgconn.SetUserHomeDirLookupForTest(func() (string, error) {
+		return emptyHome, nil
+	})
+	defer restoreHome()
+
+	cfg, err := pgconn.ParseConfig("postgres://curly:nyuknyuknyuk@test1:5432/curlydb?sslmode=require")
+	require.NoError(t, err)
+	require.NotNil(t, cfg.TLSConfig)
+
+	// This is what the refuted fix produced for EVERY explicit user+password
+	// connString, even when the real home directory DID have a root.crt --
+	// because it skipped resolving home-dir defaults altogether.
+	assert.True(t, cfg.TLSConfig.InsecureSkipVerify)
+	assert.Nil(t, cfg.TLSConfig.RootCAs)
+	assert.Nil(t, cfg.TLSConfig.VerifyPeerCertificate)
+	assert.Empty(t, cfg.TLSConfig.Certificates)
+}
+
+// TestParseConfigHomeDirLookupFailureDoesNotCrash covers item 5 of the
+// rework: when the home directory itself cannot be resolved (os.UserHomeDir
+// erroring, e.g. because $HOME is unset), ParseConfig must not panic or
+// error -- it must gracefully fall back to having no home-dir-derived
+// defaults at all, exactly as it always did when os/user.Current failed
+// before this rework (and exactly as it does today when the OS account
+// lookup fails, see TestParseConfigOSUserLookupFailureStillErrorsWhenActuallyNeeded).
+func TestParseConfigHomeDirLookupFailureDoesNotCrash(t *testing.T) {
+	clearPgEnvvars(t)
+
+	restoreHome := pgconn.SetUserHomeDirLookupForTest(func() (string, error) {
+		return "", errors.New("$HOME is not defined")
+	})
+	defer restoreHome()
+
+	restoreUser := pgconn.SetOSUserLookupForTest(func() (*user.User, error) {
+		return &user.User{Username: "mocked-os-user"}, nil
+	})
+	defer restoreUser()
+
+	// User not explicit: still falls back to the OS account username (that
+	// lookup is independent of the home directory lookup).
+	config, err := pgconn.ParseConfig("postgres://test1:5432/curlydb?sslmode=require")
+	require.NoError(t, err)
+	assert.Equal(t, "mocked-os-user", config.User)
+	// No passfile default could resolve (home dir lookup failed), so there
+	// is nothing to supply a password from.
+	assert.Empty(t, config.Password)
+	// No sslrootcert/sslcert/sslkey defaults could resolve either -- this
+	// is the pre-existing, accepted fallback behavior (same as when
+	// os/user.Current failed before this rework), not a new regression.
+	require.NotNil(t, config.TLSConfig)
+	assert.Nil(t, config.TLSConfig.RootCAs)
+	assert.Empty(t, config.TLSConfig.Certificates)
+}

--- a/pgconn/defaults.go
+++ b/pgconn/defaults.go
@@ -9,22 +9,46 @@ import (
 	"path/filepath"
 )
 
+// currentOSUser resolves the current OS user account. It is a seam so tests
+// can simulate os/user.Current failing -- including the unrecoverable
+// crashes reported in some restricted/broken-NSS container environments --
+// without needing such an environment.
+var currentOSUser = user.Current
+
+// userHomeDir resolves the current user's home directory. It is a seam so
+// tests can simulate os.UserHomeDir failing without needing to unset $HOME
+// for the whole process.
+//
+// os.UserHomeDir only reads the $HOME environment variable on this platform;
+// it never calls into cgo or NSS, so unlike os/user.Current it cannot crash
+// in restricted/broken container environments. That also means it can
+// resolve a different directory than the OS account's passwd-file home
+// directory if $HOME has been overridden -- this is an accepted tradeoff so
+// that home-directory-derived defaults (pgpass, pg_service.conf, client SSL
+// certificate/key/root files) keep resolving even when the OS user account
+// lookup itself is unavailable or unsafe to call.
+var userHomeDir = os.UserHomeDir
+
 func defaultSettings() map[string]string {
 	settings := make(map[string]string)
 
 	settings["host"] = defaultHost()
 	settings["port"] = "5432"
+	settings["target_session_attrs"] = "any"
 
-	// Default to the OS user name. Purposely ignoring err getting user name from
-	// OS. The client application will simply have to specify the user in that
-	// case (which they typically will be doing anyway).
-	user, err := user.Current()
-	if err == nil {
-		settings["user"] = user.Username
-		settings["passfile"] = filepath.Join(user.HomeDir, ".pgpass")
-		settings["servicefile"] = filepath.Join(user.HomeDir, ".pg_service.conf")
-		sslcert := filepath.Join(user.HomeDir, ".postgresql", "postgresql.crt")
-		sslkey := filepath.Join(user.HomeDir, ".postgresql", "postgresql.key")
+	// The home-directory-derived defaults (~/.pgpass, ~/.pg_service.conf,
+	// and the client SSL certificate/key/root files under ~/.postgresql)
+	// only need the user's home directory, not the full OS user account, so
+	// they are resolved unconditionally here via os.UserHomeDir. This keeps
+	// them available even when looking up the OS user account (needed only
+	// for the default PostgreSQL user name, see osUserSettings) is slow,
+	// fails, or -- in some restricted container environments with a broken
+	// NSS/CGO setup -- would crash the process.
+	if homeDir, err := userHomeDir(); err == nil {
+		settings["passfile"] = filepath.Join(homeDir, ".pgpass")
+		settings["servicefile"] = filepath.Join(homeDir, ".pg_service.conf")
+		sslcert := filepath.Join(homeDir, ".postgresql", "postgresql.crt")
+		sslkey := filepath.Join(homeDir, ".postgresql", "postgresql.key")
 		if _, err := os.Stat(sslcert); err == nil {
 			if _, err := os.Stat(sslkey); err == nil {
 				// Both the cert and key must be present to use them, or do not use either
@@ -32,13 +56,33 @@ func defaultSettings() map[string]string {
 				settings["sslkey"] = sslkey
 			}
 		}
-		sslrootcert := filepath.Join(user.HomeDir, ".postgresql", "root.crt")
+		sslrootcert := filepath.Join(homeDir, ".postgresql", "root.crt")
 		if _, err := os.Stat(sslrootcert); err == nil {
 			settings["sslrootcert"] = sslrootcert
 		}
 	}
 
-	settings["target_session_attrs"] = "any"
+	return settings
+}
+
+// osUserSettings returns the default PostgreSQL user name derived from the
+// current OS user account.
+//
+// Resolving this requires looking up the OS user account, which can be slow
+// or, in some restricted container environments (e.g. distroless images
+// with a broken NSS/CGO setup), crash the process. Callers must only call
+// osUserSettings when the default user name is not already supplied by the
+// connection string, environment, or service file.
+func osUserSettings() map[string]string {
+	settings := make(map[string]string)
+
+	// Default to the OS user name. Purposely ignoring err getting user name from
+	// OS. The client application will simply have to specify the user in that
+	// case (which they typically will be doing anyway).
+	user, err := currentOSUser()
+	if err == nil {
+		settings["user"] = user.Username
+	}
 
 	return settings
 }

--- a/pgconn/defaults_windows.go
+++ b/pgconn/defaults_windows.go
@@ -7,28 +7,44 @@ import (
 	"strings"
 )
 
+// currentOSUser resolves the current OS user account. It is a seam so tests
+// can simulate os/user.Current failing -- including the unrecoverable
+// crashes reported in some restricted/broken-NSS container environments --
+// without needing such an environment.
+var currentOSUser = user.Current
+
+// userHomeDir resolves the current user's home directory. It is a seam so
+// tests can simulate os.UserHomeDir failing without needing to unset the
+// relevant environment variables for the whole process.
+//
+// os.UserHomeDir only reads %USERPROFILE% (falling back to
+// %HOMEDRIVE%+%HOMEPATH%) on this platform; it never calls into the Windows
+// user account APIs, so unlike os/user.Current it cannot crash in
+// restricted/broken container environments. That also means it can resolve
+// a different directory than the OS account API's reported home directory
+// if those environment variables have been overridden -- this is an
+// accepted tradeoff so that home-directory-derived defaults (pg_service.conf)
+// keep resolving even when the OS user account lookup itself is unavailable
+// or unsafe to call.
+var userHomeDir = os.UserHomeDir
+
 func defaultSettings() map[string]string {
 	settings := make(map[string]string)
 
 	settings["host"] = defaultHost()
 	settings["port"] = "5432"
+	settings["target_session_attrs"] = "any"
 
-	// Default to the OS user name. Purposely ignoring err getting user name from
-	// OS. The client application will simply have to specify the user in that
-	// case (which they typically will be doing anyway).
-	user, err := user.Current()
-	appData := os.Getenv("APPDATA")
-	if err == nil {
-		// Windows gives us the username here as `DOMAIN\user` or `LOCALPCNAME\user`,
-		// but the libpq default is just the `user` portion, so we strip off the first part.
-		username := user.Username
-		if strings.Contains(username, "\\") {
-			username = username[strings.LastIndex(username, "\\")+1:]
-		}
-
-		settings["user"] = username
+	// The %APPDATA%\postgresql-derived defaults (pgpass.conf and the client
+	// SSL certificate/key/root files) only need the APPDATA environment
+	// variable, not the full OS user account, so they are resolved
+	// unconditionally here. This keeps them available even when looking up
+	// the OS user account (needed only for the default PostgreSQL user
+	// name, see osUserSettings) is slow, fails, or -- in some restricted
+	// container environments with a broken NSS/CGO setup -- would crash the
+	// process.
+	if appData := os.Getenv("APPDATA"); appData != "" {
 		settings["passfile"] = filepath.Join(appData, "postgresql", "pgpass.conf")
-		settings["servicefile"] = filepath.Join(user.HomeDir, ".pg_service.conf")
 		sslcert := filepath.Join(appData, "postgresql", "postgresql.crt")
 		sslkey := filepath.Join(appData, "postgresql", "postgresql.key")
 		if _, err := os.Stat(sslcert); err == nil {
@@ -44,7 +60,41 @@ func defaultSettings() map[string]string {
 		}
 	}
 
-	settings["target_session_attrs"] = "any"
+	// The default ~/.pg_service.conf location is derived from the user's
+	// home directory, resolved the same crash-safe way as on other
+	// platforms (see defaults.go).
+	if homeDir, err := userHomeDir(); err == nil {
+		settings["servicefile"] = filepath.Join(homeDir, ".pg_service.conf")
+	}
+
+	return settings
+}
+
+// osUserSettings returns the default PostgreSQL user name derived from the
+// current OS user account.
+//
+// Resolving this requires looking up the OS user account, which can be slow
+// or, in some restricted container environments (e.g. distroless images
+// with a broken NSS/CGO setup), crash the process. Callers must only call
+// osUserSettings when the default user name is not already supplied by the
+// connection string, environment, or service file.
+func osUserSettings() map[string]string {
+	settings := make(map[string]string)
+
+	// Default to the OS user name. Purposely ignoring err getting user name from
+	// OS. The client application will simply have to specify the user in that
+	// case (which they typically will be doing anyway).
+	user, err := currentOSUser()
+	if err == nil {
+		// Windows gives us the username here as `DOMAIN\user` or `LOCALPCNAME\user`,
+		// but the libpq default is just the `user` portion, so we strip off the first part.
+		username := user.Username
+		if strings.Contains(username, "\\") {
+			username = username[strings.LastIndex(username, "\\")+1:]
+		}
+
+		settings["user"] = username
+	}
 
 	return settings
 }

--- a/pgconn/export_test.go
+++ b/pgconn/export_test.go
@@ -1,3 +1,29 @@
 // File export_test exports some methods for better testing.
 
 package pgconn
+
+import "os/user"
+
+// SetOSUserLookupForTest overrides the OS user account lookup used to
+// resolve the default PostgreSQL user name. It lets tests simulate
+// os/user.Current failing -- including the unrecoverable crashes reported
+// in some restricted/broken-NSS container environments -- without needing
+// such an environment. It returns a function that restores the previous
+// lookup.
+func SetOSUserLookupForTest(lookup func() (*user.User, error)) (restore func()) {
+	prev := currentOSUser
+	currentOSUser = lookup
+	return func() { currentOSUser = prev }
+}
+
+// SetUserHomeDirLookupForTest overrides the home directory lookup used to
+// resolve the home-directory-derived connection defaults (passfile,
+// servicefile, sslcert, sslkey, sslrootcert). It lets tests simulate
+// os.UserHomeDir failing (e.g. $HOME unset) without needing to unset the
+// relevant environment variable for the whole process. It returns a
+// function that restores the previous lookup.
+func SetUserHomeDirLookupForTest(lookup func() (string, error)) (restore func()) {
+	prev := userHomeDir
+	userHomeDir = lookup
+	return func() { userHomeDir = prev }
+}


### PR DESCRIPTION
Fixes #2586.

ParseConfigWithOptions calls defaultSettings() -> os/user.Current() unconditionally, before the connection string is parsed. In a distroless or broken-NSS container built with cgo, os/user.Current() can fault (SIGFPE), so the process dies even when user is passed explicitly in the connection string.

On the issue you noted the home directory is still needed for ~/.pgpass, ~/.pg_service.conf, and the ~/.postgresql/ TLS certs, regardless of whether the user is provided another way. This keeps that: the home-dir-derived defaults (passfile, servicefile, sslcert, sslkey, sslrootcert) now resolve via os.UserHomeDir(), which reads $HOME and never touches the cgo/NSS user-account lookup, so it can't fault. os/user.Current() is now used only to fill the default username, and only lazily when user isn't already set.

Verified the resulting tls.Config is identical to before for an explicit user:pass@host with certs in ~/.postgresql/ (sslmode=require/verify-full/verify-ca all unchanged, client cert still presented) - the crash fix does not drop any cert/pgpass/service default.

One behavior note: os.UserHomeDir() reads $HOME, whereas os/user.Current().HomeDir reads the passwd entry, so they can differ if $HOME is overridden without changing the account. That seemed the right tradeoff to remove the crash, but happy to adjust if you'd rather gate it differently.

defaults_windows.go gets the same treatment (%APPDATA%-derived defaults decoupled from the user-account call).
