### PR TITLE
Quote array elements with internal whitespace to match PostgreSQL `array_out` text encoding

### DIFF
--- a/pgtype/array.go
+++ b/pgtype/array.go
@@ -377,7 +377,7 @@ func isSpace(ch byte) bool {
 }
 
 func quoteArrayElementIfNeeded(src string) string {
-	if src == "" || (len(src) == 4 && strings.EqualFold(src, "null")) || isSpace(src[0]) || isSpace(src[len(src)-1]) || strings.ContainsAny(src, `{},"\`) {
+	if src == "" || (len(src) == 4 && strings.EqualFold(src, "null")) || strings.ContainsAny(src, " \t\n\r\v\f") || strings.ContainsAny(src, `{},"\`) {
 		return quoteArrayElement(src)
 	}
 	return src

--- a/pgtype/array_codec_test.go
+++ b/pgtype/array_codec_test.go
@@ -86,6 +86,12 @@ func TestArrayCodecFlatArrayString(t *testing.T) {
 	})
 }
 
+func TestArrayCodecEncodeTextArrayQuotesInternalWhitespace(t *testing.T) {
+	buf, err := pgtype.NewMap().Encode(pgtype.TextArrayOID, pgtype.TextFormatCode, []string{"has space", "two words", "nospaces"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, `{"has space","two words",nospaces}`, string(buf))
+}
+
 func TestArrayCodecArray(t *testing.T) {
 	ctr := defaultConnTestRunner
 	ctr.AfterConnect = func(ctx context.Context, t testing.TB, conn *pgx.Conn) {


### PR DESCRIPTION
We're working on a server that speaks the Postgres wire protocol and are using `pgtype` codecs to encode the results we return to clients. While on the input side, Postgres itself parses array elements with space like `{elt with space, abc, ...}` with no problem, Postgres [array_out](https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/arrayfuncs.c#L1158-L1160) quotes any array element that contains a space, and Postgres clients might rely on this behavior to correctly parse array values. One example is `pgjdbc`'s  `PgArray.getArray()`, which collapses the unquoted element's spaces.

It would be good to make array codec behavior consistent with Postgres `array_out` for the postgres-compatible server use case even though it's stricter than necessary for encoding input parameters. 
