### PR TITLE
fix: correct typos in comments and string literals

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -745,7 +745,7 @@ type QueryRewriter interface {
 // collected before processing rather than processed while receiving each row. This avoids the possibility of the
 // application processing rows from a query that the server rejected. The CollectRows function is useful here.
 //
-// An implementor of QueryRewriter may be passed as the first element of args. It can rewrite the sql and change or
+// An implementer of QueryRewriter may be passed as the first element of args. It can rewrite the sql and change or
 // replace args. For example, NamedArgs is QueryRewriter that implements named arguments.
 //
 // For extra control over how the query is executed, the types QueryExecMode, QueryResultFormats, and

--- a/internal/stmtcache/lru_cache.go
+++ b/internal/stmtcache/lru_cache.go
@@ -62,7 +62,7 @@ func (c *LRUCache) Put(sd *pgconn.StatementDescription) {
 		return
 	}
 
-	// The statement may have been invalidated but not yet handled. Do not readd it to the cache.
+	// The statement may have been invalidated but not yet handled. Do not re-add it to the cache.
 	if _, invalidated := c.invalidSet[sd.SQL]; invalidated {
 		return
 	}

--- a/stdlib/sql_test.go
+++ b/stdlib/sql_test.go
@@ -1189,7 +1189,7 @@ func TestConnQueryRowConstraintErrors(t *testing.T) {
 		_, err = db.Exec(`create function test_trigger() returns trigger language plpgsql as $$
 		begin
 		if new.n = 4 then
-			raise exception 'n cant be 4!';
+			raise exception 'n can''t be 4!';
 		end if;
 		return new;
 	end$$`)


### PR DESCRIPTION
Fix three typos found by codespell:

- `conn.go`: `implementor` → `implementer`
- `internal/stmtcache/lru_cache.go`: `readd` → `re-add`
- `stdlib/sql_test.go`: `cant` → `can't` (also fixes PL/pgSQL single-quote escaping inside the raise exception message)