### PR TITLE
Encode numeric Infinity/-Infinity in JSON instead of 0

### DIFF
--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -242,8 +242,13 @@ func (n Numeric) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 
-	if n.NaN {
+	switch {
+	case n.NaN:
 		return []byte(`"NaN"`), nil
+	case n.InfinityModifier == Infinity:
+		return []byte(`"Infinity"`), nil
+	case n.InfinityModifier == NegativeInfinity:
+		return []byte(`"-Infinity"`), nil
 	}
 
 	return n.numberTextBytes(), nil
@@ -257,6 +262,14 @@ func (n *Numeric) UnmarshalJSON(src []byte) error {
 	}
 	if bytes.Equal(src, []byte(`"NaN"`)) {
 		*n = Numeric{NaN: true, Valid: true}
+		return nil
+	}
+	if bytes.Equal(src, []byte(`"Infinity"`)) {
+		*n = Numeric{InfinityModifier: Infinity, Valid: true}
+		return nil
+	}
+	if bytes.Equal(src, []byte(`"-Infinity"`)) {
+		*n = Numeric{InfinityModifier: NegativeInfinity, Valid: true}
 		return nil
 	}
 	return scanPlanTextAnyToNumericScanner{}.Scan(src, n)

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -245,6 +245,31 @@ func TestNumericMarshalJSON(t *testing.T) {
 	})
 }
 
+func TestNumericMarshalJSONInfinity(t *testing.T) {
+	// PostgreSQL renders numeric infinity in JSON as the quoted strings
+	// "Infinity"/"-Infinity" (like to_json('infinity'::numeric)), matching the
+	// existing "NaN" handling. Previously these marshaled to 0, silently
+	// corrupting the value.
+	for _, tt := range []struct {
+		name string
+		num  pgtype.Numeric
+		want string
+	}{
+		{"Infinity", pgtype.Numeric{InfinityModifier: pgtype.Infinity, Valid: true}, `"Infinity"`},
+		{"-Infinity", pgtype.Numeric{InfinityModifier: pgtype.NegativeInfinity, Valid: true}, `"-Infinity"`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.num)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(got))
+
+			var back pgtype.Numeric
+			require.NoError(t, back.UnmarshalJSON(got))
+			require.Equal(t, tt.num, back)
+		})
+	}
+}
+
 func TestNumericUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -262,6 +287,18 @@ func TestNumericUnmarshalJSON(t *testing.T) {
 			name:    "NaN",
 			want:    &pgtype.Numeric{Valid: true, NaN: true},
 			src:     []byte(`"NaN"`),
+			wantErr: false,
+		},
+		{
+			name:    "Infinity",
+			want:    &pgtype.Numeric{Valid: true, InfinityModifier: pgtype.Infinity},
+			src:     []byte(`"Infinity"`),
+			wantErr: false,
+		},
+		{
+			name:    "-Infinity",
+			want:    &pgtype.Numeric{Valid: true, InfinityModifier: pgtype.NegativeInfinity},
+			src:     []byte(`"-Infinity"`),
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
## Bug

`pgtype.Numeric.MarshalJSON` silently marshals `±Infinity` as `0`, corrupting the value:

```go
json.Marshal(pgtype.Numeric{InfinityModifier: pgtype.Infinity, Valid: true})        // "0"   (want "Infinity")
json.Marshal(pgtype.Numeric{InfinityModifier: pgtype.NegativeInfinity, Valid: true}) // "0"   (want "-Infinity")
```

`MarshalJSON` special-cases `NaN` (→ `"NaN"`) but for infinity falls through to `numberTextBytes()`, which renders an empty `big.Int` as `0`. So an infinite numeric round-trips as a finite `0`.

PostgreSQL renders numeric infinity in JSON as a quoted string, exactly like NaN:

```sql
SELECT to_json('infinity'::numeric);   -- "Infinity"
SELECT to_json('-infinity'::numeric);  -- "-Infinity"
SELECT to_json('nan'::numeric);        -- "NaN"
```

and the text codec (`encodeNumericText`) already emits `Infinity`/`-Infinity`. Only the JSON path was missing it.

## Fix

Handle infinity symmetrically with NaN in both directions:

- `MarshalJSON`: emit `"Infinity"` / `"-Infinity"` for `InfinityModifier == Infinity` / `NegativeInfinity`.
- `UnmarshalJSON`: parse `"Infinity"` / `"-Infinity"` back into the corresponding `InfinityModifier`.

## Testing

- `TestNumericMarshalJSONInfinity` (DB-free): asserts the two values marshal to `"Infinity"`/`"-Infinity"` and round-trip. Fails on the current code (`0`), passes with the fix.
- Extended the existing DB-free `TestNumericUnmarshalJSON` table with `"Infinity"` and `"-Infinity"` cases.

`gofmt -s` and `go build ./...` are clean. (The DB-backed `TestNumericMarshalJSON` continues to assert equality with `to_json`; adding an Inf row there would also pass now, but it requires a live server, so the new coverage is DB-free.)
