### PR TITLE
Fix infinite loop decoding binary numeric zero with ndigits > 0

### DIFF
--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -687,7 +687,7 @@ func (scanPlanBinaryNumericToNumericScanner) Scan(src []byte, dst any) error {
 
 	reduced := &big.Int{}
 	remainder := &big.Int{}
-	if exp >= 0 {
+	if exp >= 0 && accum.Sign() != 0 {
 		for {
 			reduced.DivMod(accum, big10, remainder)
 			if remainder.Sign() != 0 {

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	pgx "github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -145,6 +146,42 @@ func TestNumericCodecInfinity(t *testing.T) {
 		{Param: pgtype.Numeric{InfinityModifier: pgtype.Infinity, Valid: true}, Result: new(string), Test: isExpectedEq("Infinity")},
 		{Param: pgtype.Numeric{InfinityModifier: pgtype.NegativeInfinity, Valid: true}, Result: new(string), Test: isExpectedEq("-Infinity")},
 	})
+}
+
+// TestNumericBinaryDecodeUnnormalizedZero ensures the binary decoder does not
+// hang on a zero value encoded with ndigits > 0. PostgreSQL always normalizes
+// zero to ndigits == 0, but other servers speaking the same wire protocol
+// (e.g. CockroachDB) and connection poolers may send an unnormalized zero. The
+// trailing-zero reduction loop divided such a value by 10 forever because
+// 0 % 10 == 0, spinning the CPU indefinitely.
+func TestNumericBinaryDecodeUnnormalizedZero(t *testing.T) {
+	// ndigits=1, weight=0, sign=0 (positive), dscale=0, single base-10000 digit = 0.
+	src := []byte{
+		0x00, 0x01, // ndigits
+		0x00, 0x00, // weight
+		0x00, 0x00, // sign
+		0x00, 0x00, // dscale
+		0x00, 0x00, // digit[0]
+	}
+
+	done := make(chan error, 1)
+	var n pgtype.Numeric
+	go func() {
+		plan := pgtype.NumericCodec{}.PlanScan(nil, pgtype.NumericOID, pgtype.BinaryFormatCode, &n)
+		require.NotNil(t, plan)
+		done <- plan.Scan(src, &n)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+		require.True(t, n.Valid)
+		require.False(t, n.NaN)
+		require.Equal(t, pgtype.Finite, n.InfinityModifier)
+		require.Equal(t, 0, n.Int.Sign())
+	case <-time.After(5 * time.Second):
+		t.Fatal("decoding unnormalized zero did not terminate (infinite loop)")
+	}
 }
 
 func TestNumericFloat64Valuer(t *testing.T) {


### PR DESCRIPTION
## Problem

Decoding a binary `numeric` whose value is zero but is encoded with `ndigits > 0` causes `scanPlanBinaryNumericToNumericScanner.Scan` to spin forever, pinning a CPU and never returning.

After accumulating the digits, the decoder strips trailing base-10 zeros:

```go
if exp >= 0 {
    for {
        reduced.DivMod(accum, big10, remainder)
        if remainder.Sign() != 0 {
            break
        }
        accum.Set(reduced)
        exp++
    }
}
```

When `accum == 0`, `0 % 10 == 0` on every iteration, so the loop never breaks.

PostgreSQL itself always normalizes zero to `ndigits == 0` (caught earlier by the `if ndigits == 0` fast path), so this never triggers against a stock PG server. But the binary wire format permits an unnormalized zero (`ndigits >= 1` with all-zero digit words), and other servers speaking the same protocol — CockroachDB, and some connection poolers — can send it. A single such value read from the database freezes the client.

## Fix

Skip the reduction loop when the accumulated value is zero:

```go
if exp >= 0 && accum.Sign() != 0 {
```

Zero needs no trailing-zero stripping, so this is both correct and sufficient.

## Test

`TestNumericBinaryDecodeUnnormalizedZero` decodes the wire bytes for an unnormalized zero (`ndigits=1, weight=0, sign=0, dscale=0, digit=0`) inside a goroutine guarded by a 5s timeout. It times out (fails) on the current code and returns `0` immediately with the fix. No database connection required.
