### PR TITLE
Fix nil pointer panic in Numeric.Int64Value when Int is nil

### DIFF
--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -149,6 +149,10 @@ func (n *Numeric) ScanScientific(src string) error {
 }
 
 func (n *Numeric) toBigInt() (*big.Int, error) {
+	if n.Int == nil {
+		return big.NewInt(0), nil
+	}
+
 	if n.Exp == 0 {
 		return n.Int, nil
 	}

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -171,6 +171,25 @@ func TestNumericFloat64Valuer(t *testing.T) {
 	assert.True(t, f.Valid)
 }
 
+func TestNumericInt64Valuer(t *testing.T) {
+	for i, tt := range []struct {
+		n pgtype.Numeric
+		i pgtype.Int8
+	}{
+		{mustParseNumeric(t, "1"), pgtype.Int8{Int64: 1, Valid: true}},
+		{mustParseNumeric(t, "-99999999999"), pgtype.Int8{Int64: -99999999999, Valid: true}},
+		{mustParseNumeric(t, "0"), pgtype.Int8{Int64: 0, Valid: true}},
+		// A valid Numeric with a nil Int is zero, matching Float64Value, Value,
+		// and MarshalJSON. Int64Value used to dereference the nil Int and panic.
+		{pgtype.Numeric{Valid: true}, pgtype.Int8{Int64: 0, Valid: true}},
+		{pgtype.Numeric{}, pgtype.Int8{}},
+	} {
+		v, err := tt.n.Int64Value()
+		assert.NoErrorf(t, err, "%d", i)
+		assert.Equalf(t, tt.i, v, "%d", i)
+	}
+}
+
 func TestNumericCodecFuzz(t *testing.T) {
 	skipCockroachDB(t, "server formats numeric text format differently")
 


### PR DESCRIPTION
Numeric.Int64Value panics with a nil pointer dereference when the Numeric is valid but its Int field is nil.

The other methods that read a Numeric already treat a nil Int as zero. Float64Value returns 0, Value returns "0", and MarshalJSON returns 0. Int64Value is the exception. It goes through toBigInt, which returns the nil Int unchanged when Exp is 0, and then IsInt64 dereferences it.

pgtype.Numeric{Valid: true} is an easy way to end up here, since that's a fairly normal way to build a zero value.

```go
n := pgtype.Numeric{Valid: true}
n.Float64Value() // 0, ok
n.MarshalJSON()  // "0", ok
n.Int64Value()   // panic: nil pointer dereference
```

I put the guard in toBigInt so it returns zero when Int is nil, which makes all four methods agree. That also covers uint64Wrapper and uintWrapper ScanNumeric, which reach toBigInt the same way and would panic on a valid-but-nil Numeric too.

The test sits next to the existing Float64Value one in numeric_test.go. It panics on master and passes with the change. No database needed.
