### PR TITLE
Show sslmode=verify-full, not sslmode=verify-ca, in example config

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -237,10 +237,10 @@ func NetworkAddress(host string, port uint16) (network, address string) {
 // to only read from the environment. If a password is not supplied it will attempt to read the .pgpass file.
 //
 //	# Example Keyword/Value
-//	user=jack password=secret host=pg.example.com port=5432 dbname=mydb sslmode=verify-ca
+//	user=jack password=secret host=pg.example.com port=5432 dbname=mydb sslmode=verify-full
 //
 //	# Example URL
-//	postgres://jack:secret@pg.example.com:5432/mydb?sslmode=verify-ca
+//	postgres://jack:secret@pg.example.com:5432/mydb?sslmode=verify-full
 //
 // The returned *Config may be modified. However, it is strongly recommended that any configuration that can be done
 // through the connection string be done there. In particular the fields Host, Port, TLSConfig, and Fallbacks can be

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -352,10 +352,10 @@ func NewWithConfig(ctx context.Context, config *Config) (*Pool, error) {
 // See Config for definitions of these arguments.
 //
 //	# Example Keyword/Value
-//	user=jack password=secret host=pg.example.com port=5432 dbname=mydb sslmode=verify-ca pool_max_conns=10 pool_max_conn_lifetime=1h30m
+//	user=jack password=secret host=pg.example.com port=5432 dbname=mydb sslmode=verify-full pool_max_conns=10 pool_max_conn_lifetime=1h30m
 //
 //	# Example URL
-//	postgres://jack:secret@pg.example.com:5432/mydb?sslmode=verify-ca&pool_max_conns=10&pool_max_conn_lifetime=1h30m
+//	postgres://jack:secret@pg.example.com:5432/mydb?sslmode=verify-full&pool_max_conns=10&pool_max_conn_lifetime=1h30m
 func ParseConfig(connString string) (*Config, error) {
 	connConfig, err := pgx.ParseConfig(connString)
 	if err != nil {


### PR DESCRIPTION
The example configuration shown in the documentation sets `sslmode=verify-ca` without setting `sslrootcert` to a private CA.

That is insecure:
https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS

When the default public CAs are used the client must set `sslmode=verify-full` to verify that the host name in the server certificate matches the name in the `host` configuration parameter.