### PR TITLE
Return an error instead of panicking on truncated binary multirange

### DIFF
--- a/pgtype/multirange.go
+++ b/pgtype/multirange.go
@@ -207,6 +207,9 @@ func (c *MultirangeCodec) PlanScan(m *Map, oid uint32, format int16, target any)
 func (c *MultirangeCodec) decodeBinary(m *Map, multirangeOID uint32, src []byte, multirange MultirangeSetter) error {
 	rp := 0
 
+	if len(src[rp:]) < 4 {
+		return fmt.Errorf("multirange too short for element count: %d bytes", len(src[rp:]))
+	}
 	elementCount := int(binary.BigEndian.Uint32(src[rp:]))
 	rp += 4
 

--- a/pgtype/multirange_malformed_test.go
+++ b/pgtype/multirange_malformed_test.go
@@ -1,0 +1,44 @@
+package pgtype_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// A binary multirange value shorter than the 4-byte element-count header must
+// return an error instead of panicking with "index out of range". decodeBinary
+// already guards the per-element length prefixes and the element count against
+// the remaining bytes, but it read the leading count without a length check, so
+// a truncated server message of 1-3 bytes panicked.
+func TestMultirangeBinaryDecodeTruncatedReturnsError(t *testing.T) {
+	m := pgtype.NewMap()
+
+	for _, src := range [][]byte{
+		{},
+		{0x00},
+		{0x00, 0x00},
+		{0x00, 0x00, 0x00},
+	} {
+		var v pgtype.Multirange[pgtype.Range[pgtype.Int4]]
+		plan := m.PlanScan(pgtype.Int4multirangeOID, pgtype.BinaryFormatCode, &v)
+		// A panic here (pre-fix) fails the test.
+		if err := plan.Scan(src, &v); err == nil {
+			t.Errorf("Scan(% x) = nil error, want an error", src)
+		}
+	}
+}
+
+// A well-formed empty multirange (element count 0) still decodes without error.
+func TestMultirangeBinaryDecodeEmpty(t *testing.T) {
+	m := pgtype.NewMap()
+
+	var v pgtype.Multirange[pgtype.Range[pgtype.Int4]]
+	plan := m.PlanScan(pgtype.Int4multirangeOID, pgtype.BinaryFormatCode, &v)
+	if err := plan.Scan([]byte{0x00, 0x00, 0x00, 0x00}, &v); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(v) != 0 {
+		t.Errorf("got %+v, want an empty multirange", v)
+	}
+}


### PR DESCRIPTION
Decoding a binary multirange value panics with an index-out-of-range if the payload is shorter than the 4-byte element-count header.

MultirangeCodec.decodeBinary reads the leading element count with binary.BigEndian.Uint32(src) before checking that at least four bytes are present. A truncated or malformed server message of one to three bytes gets past the nil check in the scan plan and reaches that read, so it panics instead of returning an error.

The rest of the function already guards against short input. It checks the element count against the remaining length, and for every element it checks that four bytes are left for the length prefix and that the prefix does not run past the buffer. The very first read was just missed. The array codec handles the same situation by returning "array header too short", so this brings multirange in line with that.

The fix adds the length check before the read and returns an error the same way the surrounding code does.

The test decodes binary multiranges of length 0 through 3 and asserts an error rather than a panic, plus a well-formed empty multirange to show the count-zero path still works. Both run without a database. The truncated case panics on master and passes with the change.
