### PR TITLE
Support any amount of pointer indirection for scanning

### DIFF
--- a/pgtype/pgtype.go
+++ b/pgtype/pgtype.go
@@ -510,11 +510,11 @@ func (plan *pointerPointerScanPlan) Scan(src []byte, dst any) error {
 // TryPointerPointerScanPlan handles a pointer to a pointer by setting the target to nil for SQL NULL and allocating and
 // scanning for non-NULL.
 func TryPointerPointerScanPlan(target any) (plan WrappedScanPlanNextSetter, nextTarget any, ok bool) {
-	if dstValue := reflect.ValueOf(target); dstValue.Kind() == reflect.Pointer {
-		elemValue := dstValue.Elem()
-		if elemValue.Kind() == reflect.Pointer {
-			plan = &pointerPointerScanPlan{dstType: dstValue.Type()}
-			return plan, reflect.Zero(elemValue.Type()).Interface(), true
+	if dstType := reflect.TypeOf(target); dstType.Kind() == reflect.Pointer {
+		elemType := dstType.Elem()
+		if elemType.Kind() == reflect.Pointer {
+			plan = &pointerPointerScanPlan{dstType: dstType}
+			return plan, reflect.Zero(elemType).Interface(), true
 		}
 	}
 

--- a/pgtype/pgtype_test.go
+++ b/pgtype/pgtype_test.go
@@ -330,6 +330,65 @@ func TestPointerPointerStructScan(t *testing.T) {
 	require.Equal(t, 1, c.ID)
 }
 
+func TestPointerDoublePointerStructScan(t *testing.T) {
+	m := pgtype.NewMap()
+	type composite struct {
+		ID **int
+	}
+
+	int4Type, _ := m.TypeForOID(pgtype.Int4OID)
+	pgt := &pgtype.Type{
+		Codec: &pgtype.CompositeCodec{
+			Fields: []pgtype.CompositeCodecField{
+				{
+					Name: "id",
+					Type: int4Type,
+				},
+			},
+		},
+		Name: "composite",
+		OID:  215333,
+	}
+	m.RegisterType(pgt)
+
+	var c *composite
+	plan := m.PlanScan(pgt.OID, pgtype.TextFormatCode, &c)
+	err := plan.Scan([]byte("(1)"), &c)
+	require.NoError(t, err)
+	require.Equal(t, 1, **c.ID)
+}
+
+func TestPointerDoublePointerStructScannerScan(t *testing.T) {
+	m := pgtype.NewMap()
+	type composite struct {
+		ID **sql.NullInt64
+	}
+
+	int4Type, _ := m.TypeForOID(pgtype.Int4OID)
+	pgt := &pgtype.Type{
+		Codec: &pgtype.CompositeCodec{
+			Fields: []pgtype.CompositeCodecField{
+				{
+					Name: "id",
+					Type: int4Type,
+				},
+			},
+		},
+		Name: "composite",
+		OID:  215333,
+	}
+	m.RegisterType(pgt)
+
+	var c *composite
+	plan := m.PlanScan(pgt.OID, pgtype.TextFormatCode, &c)
+	err := plan.Scan([]byte("(1)"), &c)
+	require.NoError(t, err)
+	require.Equal(t, sql.NullInt64{
+		Int64: 1,
+		Valid: true,
+	}, **c.ID)
+}
+
 // https://github.com/jackc/pgx/issues/1263
 func TestMapScanPtrToPtrToSlice(t *testing.T) {
 	m := pgtype.NewMap()

--- a/rows_test.go
+++ b/rows_test.go
@@ -667,6 +667,72 @@ func TestRowToStructByName(t *testing.T) {
 	})
 }
 
+func TestRowToStructByNameDoublePointer(t *testing.T) {
+	type person struct {
+		Last      string
+		First     **string
+		Age       int32
+		AccountID string
+	}
+
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		rows, _ := conn.Query(ctx, `select 'John' as first, 'Smith' as last, n as age, 'd5e49d3f' as account_id from generate_series(0, 9) n`)
+		slice, err := pgx.CollectRows(rows, pgx.RowToStructByName[person])
+		assert.NoError(t, err)
+
+		assert.Len(t, slice, 10)
+		for i := range slice {
+			assert.Equal(t, "Smith", slice[i].Last)
+			assert.Equal(t, "John", **slice[i].First)
+			assert.EqualValues(t, i, slice[i].Age)
+			assert.Equal(t, "d5e49d3f", slice[i].AccountID)
+		}
+
+		// check missing fields in a returned row
+		rows, _ = conn.Query(ctx, `select 'Smith' as last, n as age from generate_series(0, 9) n`)
+		_, err = pgx.CollectRows(rows, pgx.RowToStructByName[person])
+		assert.ErrorContains(t, err, "cannot find field First in returned row")
+
+		// check missing field in a destination struct
+		rows, _ = conn.Query(ctx, `select 'John' as first, 'Smith' as last, n as age, 'd5e49d3f' as account_id, null as ignore from generate_series(0, 9) n`)
+		_, err = pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[person])
+		assert.ErrorContains(t, err, "struct doesn't have corresponding row field ignore")
+	})
+}
+
+func TestRowToStructByNameTriplePointer(t *testing.T) {
+	type person struct {
+		Last      string
+		First     ***string
+		Age       int32
+		AccountID string
+	}
+
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		rows, _ := conn.Query(ctx, `select 'John' as first, 'Smith' as last, n as age, 'd5e49d3f' as account_id from generate_series(0, 9) n`)
+		slice, err := pgx.CollectRows(rows, pgx.RowToStructByName[person])
+		assert.NoError(t, err)
+
+		assert.Len(t, slice, 10)
+		for i := range slice {
+			assert.Equal(t, "Smith", slice[i].Last)
+			assert.Equal(t, "John", ***slice[i].First)
+			assert.EqualValues(t, i, slice[i].Age)
+			assert.Equal(t, "d5e49d3f", slice[i].AccountID)
+		}
+
+		// check missing fields in a returned row
+		rows, _ = conn.Query(ctx, `select 'Smith' as last, n as age from generate_series(0, 9) n`)
+		_, err = pgx.CollectRows(rows, pgx.RowToStructByName[person])
+		assert.ErrorContains(t, err, "cannot find field First in returned row")
+
+		// check missing field in a destination struct
+		rows, _ = conn.Query(ctx, `select 'John' as first, 'Smith' as last, n as age, 'd5e49d3f' as account_id, null as ignore from generate_series(0, 9) n`)
+		_, err = pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[person])
+		assert.ErrorContains(t, err, "struct doesn't have corresponding row field ignore")
+	})
+}
+
 func TestRowToStructByNameDbTags(t *testing.T) {
 	type person struct {
 		Last             string `db:"last_name"`

--- a/rows_test.go
+++ b/rows_test.go
@@ -687,6 +687,18 @@ func TestRowToStructByNameDoublePointer(t *testing.T) {
 			assert.EqualValues(t, i, slice[i].Age)
 			assert.Equal(t, "d5e49d3f", slice[i].AccountID)
 		}
+
+		rows, _ = conn.Query(ctx, `select NULL as first, 'Smith' as last, n as age, 'd5e49d3f' as account_id from generate_series(0, 9) n`)
+		slice, err = pgx.CollectRows(rows, pgx.RowToStructByName[person])
+		assert.NoError(t, err)
+
+		assert.Len(t, slice, 10)
+		for i := range slice {
+			assert.Equal(t, "Smith", slice[i].Last)
+			assert.Nil(t, slice[i].First)
+			assert.EqualValues(t, i, slice[i].Age)
+			assert.Equal(t, "d5e49d3f", slice[i].AccountID)
+		}
 	})
 }
 
@@ -707,6 +719,18 @@ func TestRowToStructByNameTriplePointer(t *testing.T) {
 		for i := range slice {
 			assert.Equal(t, "Smith", slice[i].Last)
 			assert.Equal(t, "John", ***slice[i].First)
+			assert.EqualValues(t, i, slice[i].Age)
+			assert.Equal(t, "d5e49d3f", slice[i].AccountID)
+		}
+
+		rows, _ = conn.Query(ctx, `select NULL as first, 'Smith' as last, n as age, 'd5e49d3f' as account_id from generate_series(0, 9) n`)
+		slice, err = pgx.CollectRows(rows, pgx.RowToStructByName[person])
+		assert.NoError(t, err)
+
+		assert.Len(t, slice, 10)
+		for i := range slice {
+			assert.Equal(t, "Smith", slice[i].Last)
+			assert.Nil(t, slice[i].First)
 			assert.EqualValues(t, i, slice[i].Age)
 			assert.Equal(t, "d5e49d3f", slice[i].AccountID)
 		}

--- a/rows_test.go
+++ b/rows_test.go
@@ -687,16 +687,6 @@ func TestRowToStructByNameDoublePointer(t *testing.T) {
 			assert.EqualValues(t, i, slice[i].Age)
 			assert.Equal(t, "d5e49d3f", slice[i].AccountID)
 		}
-
-		// check missing fields in a returned row
-		rows, _ = conn.Query(ctx, `select 'Smith' as last, n as age from generate_series(0, 9) n`)
-		_, err = pgx.CollectRows(rows, pgx.RowToStructByName[person])
-		assert.ErrorContains(t, err, "cannot find field First in returned row")
-
-		// check missing field in a destination struct
-		rows, _ = conn.Query(ctx, `select 'John' as first, 'Smith' as last, n as age, 'd5e49d3f' as account_id, null as ignore from generate_series(0, 9) n`)
-		_, err = pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[person])
-		assert.ErrorContains(t, err, "struct doesn't have corresponding row field ignore")
 	})
 }
 
@@ -720,16 +710,6 @@ func TestRowToStructByNameTriplePointer(t *testing.T) {
 			assert.EqualValues(t, i, slice[i].Age)
 			assert.Equal(t, "d5e49d3f", slice[i].AccountID)
 		}
-
-		// check missing fields in a returned row
-		rows, _ = conn.Query(ctx, `select 'Smith' as last, n as age from generate_series(0, 9) n`)
-		_, err = pgx.CollectRows(rows, pgx.RowToStructByName[person])
-		assert.ErrorContains(t, err, "cannot find field First in returned row")
-
-		// check missing field in a destination struct
-		rows, _ = conn.Query(ctx, `select 'John' as first, 'Smith' as last, n as age, 'd5e49d3f' as account_id, null as ignore from generate_series(0, 9) n`)
-		_, err = pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[person])
-		assert.ErrorContains(t, err, "struct doesn't have corresponding row field ignore")
 	})
 }
 


### PR DESCRIPTION
The library supports scanning to:

```go
type User struct {
    Name *string
}
```

but not to

```go
type User struct {
    Name **string
}
```

or

```go
type User struct {
    Name ***string
}
```

It seems to be that the intent of the user, when wanting to scan this data type, is the same as the first one.
This is very useful for example for using reflection to detect if fields from a left join are missing. Otherwise, we can't differentiate NULLs from "not set because of a join".

The change seems very simple and don't trigger any test, don't know if I'm missing anything.

Fixes #1000 