### PR TITLE
docs: use https for postgresql.org documentation links

### DIFF
--- a/large_objects.go
+++ b/large_objects.go
@@ -16,7 +16,7 @@ var maxLargeObjectMessageLength = 1024*1024*1024 - 1024
 // LargeObjects is a structure used to access the large objects API. It is only valid within the transaction where it
 // was created.
 //
-// For more details see: http://www.postgresql.org/docs/current/static/largeobjects.html
+// For more details see: https://www.postgresql.org/docs/current/static/largeobjects.html
 type LargeObjects struct {
 	tx Tx
 }

--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -278,7 +278,7 @@ func NetworkAddress(host string, port uint16) (network, address string) {
 //	PGMINPROTOCOLVERSION
 //	PGMAXPROTOCOLVERSION
 //
-// See http://www.postgresql.org/docs/current/static/libpq-envars.html for details on the meaning of environment variables.
+// See https://www.postgresql.org/docs/current/static/libpq-envars.html for details on the meaning of environment variables.
 //
 // See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS for parameter key word names. They are
 // usually but not always the environment variable name downcased and without the "PG" prefix.
@@ -288,7 +288,7 @@ func NetworkAddress(host string, port uint16) (network, address string) {
 // ParseConfig tries to match libpq behavior with regard to PGSSLMODE. This includes defaulting to "prefer" behavior if
 // not set.
 //
-// See http://www.postgresql.org/docs/current/static/libpq-ssl.html#LIBPQ-SSL-PROTECTION for details on what level of
+// See https://www.postgresql.org/docs/current/static/libpq-ssl.html#LIBPQ-SSL-PROTECTION for details on what level of
 // security each sslmode provides.
 //
 // The sslmode "prefer" (the default), sslmode "allow", and multiple hosts are implemented via the Fallbacks field of

--- a/pgconn/errors.go
+++ b/pgconn/errors.go
@@ -27,7 +27,7 @@ func Timeout(err error) bool {
 }
 
 // PgError represents an error reported by the PostgreSQL server. See
-// http://www.postgresql.org/docs/current/static/protocol-error-fields.html for
+// https://www.postgresql.org/docs/current/static/protocol-error-fields.html for
 // detailed field description.
 type PgError struct {
 	Severity            string


### PR DESCRIPTION
## Summary
Godoc links still pointed at `http://www.postgresql.org`. Switch them to `https://`.

## Test plan
- docs only