### PR TITLE
Fix Scan's handling of type that implements RowScanner and CompositeIndexGetter

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -243,19 +243,18 @@ func (rows *baseRows) Scan(dest ...any) error {
 		return err
 	}
 
-	if len(dest) == 1 {
-		if rc, ok := dest[0].(RowScanner); ok {
-			err := rc.ScanRow(rows)
-			if err != nil {
-				rows.fatal(err)
-			}
+	if len(fieldDescriptions) != len(dest) {
+		rc, hasRowScanner := dest[0].(RowScanner)
+		if !hasRowScanner || len(dest) != 1 {
+			err := fmt.Errorf("number of field descriptions must equal number of destinations, got %d and %d", len(fieldDescriptions), len(dest))
+			rows.fatal(err)
 			return err
 		}
-	}
 
-	if len(fieldDescriptions) != len(dest) {
-		err := fmt.Errorf("number of field descriptions must equal number of destinations, got %d and %d", len(fieldDescriptions), len(dest))
-		rows.fatal(err)
+		err := rc.ScanRow(rows)
+		if err != nil {
+			rows.fatal(err)
+		}
 		return err
 	}
 

--- a/rows.go
+++ b/rows.go
@@ -232,6 +232,23 @@ func (rows *baseRows) Next() bool {
 	}
 }
 
+func isRegisteredAsComposite(typeMap *pgtype.Map, oid uint32) bool {
+	// Types registered with an appropriate codec can be inferred to be a composite.
+	// In the case we don't know it's a composite then we don't scan it as one.
+	// That's consistent with the requirement that composites need to be registered in the type map.
+	dt, ok := typeMap.TypeForOID(oid)
+	if !ok {
+		return false
+	}
+
+	switch dt.Codec.(type) {
+	case pgtype.RecordCodec, *pgtype.CompositeCodec:
+		return true
+	default:
+		return false
+	}
+}
+
 func (rows *baseRows) Scan(dest ...any) error {
 	m := rows.typeMap
 	fieldDescriptions := rows.FieldDescriptions()
@@ -243,18 +260,26 @@ func (rows *baseRows) Scan(dest ...any) error {
 		return err
 	}
 
-	if len(fieldDescriptions) != len(dest) {
-		rc, hasRowScanner := dest[0].(RowScanner)
-		if !hasRowScanner || len(dest) != 1 {
-			err := fmt.Errorf("number of field descriptions must equal number of destinations, got %d and %d", len(fieldDescriptions), len(dest))
-			rows.fatal(err)
-			return err
+	if len(dest) == 1 {
+		if rc, ok := dest[0].(RowScanner); ok {
+			// Generally the documented behavior is to invoke the RowScanner when there is only one destination.
+			// As a special case if the returned field is a composite then we use the normal Scan logic.
+			// See https://github.com/jackc/pgx/issues/2609
+			_, canCompositeScan := dest[0].(pgtype.CompositeIndexScanner)
+			isComposite := len(fieldDescriptions) > 0 && isRegisteredAsComposite(m, fieldDescriptions[0].DataTypeOID)
+			if !canCompositeScan || !isComposite {
+				err := rc.ScanRow(rows)
+				if err != nil {
+					rows.fatal(err)
+				}
+				return err
+			}
 		}
+	}
 
-		err := rc.ScanRow(rows)
-		if err != nil {
-			rows.fatal(err)
-		}
+	if len(fieldDescriptions) != len(dest) {
+		err := fmt.Errorf("number of field descriptions must equal number of destinations, got %d and %d", len(fieldDescriptions), len(dest))
+		rows.fatal(err)
 		return err
 	}
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -54,6 +54,57 @@ func TestRowScannerErrorIsFatalToRows(t *testing.T) {
 	})
 }
 
+type testCompositeWithRowScanner struct {
+	name string
+	age  int32
+}
+
+func (rs *testCompositeWithRowScanner) ScanRow(rows pgx.Rows) error {
+	return rows.Scan(&rs.name, &rs.age)
+}
+
+func (value *testCompositeWithRowScanner) ScanNull() error {
+	return fmt.Errorf("cannot scan NULL into %s", "Result")
+}
+
+func (value *testCompositeWithRowScanner) ScanIndex(i int) any {
+	switch i {
+	case 0:
+		return &value.name
+	case 1:
+		return &value.age
+	default:
+		panic(fmt.Errorf("%s unknown field requested - %d is out of bounds", "testCompositeWithRowScanner", i))
+	}
+}
+
+// https://github.com/jackc/pgx/issues/2609
+func TestScanOnRowCompositeWithRowScanner(t *testing.T) {
+	t.Parallel()
+
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		_, err := conn.Exec(ctx, `create type ct_test as (a text, b int4);`)
+		require.NoError(t, err)
+		defer conn.Exec(ctx, "drop type ct_test")
+
+		dt, err := conn.LoadType(ctx, "ct_test")
+		require.NoError(t, err)
+		conn.TypeMap().RegisterType(dt)
+
+		var s testCompositeWithRowScanner
+
+		// When returned as a composite scanning works
+		err = conn.QueryRow(ctx, "select ROW('Adam',72)::ct_test").Scan(&s)
+		require.NoError(t, err)
+		require.Equal(t, testCompositeWithRowScanner{name: "Adam", age: 72}, s)
+
+		// When returned as multiple columns RowScanner still works
+		err = conn.QueryRow(ctx, "select 'Adam', 72").Scan(&s)
+		require.NoError(t, err)
+		require.Equal(t, testCompositeWithRowScanner{name: "Adam", age: 72}, s)
+	})
+}
+
 func TestForEachRow(t *testing.T) {
 	t.Parallel()
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -37,6 +37,28 @@ func TestRowScanner(t *testing.T) {
 	})
 }
 
+type testRowScannerSingleColumn struct {
+	name   string
+	wasRun bool `db:"-"`
+}
+
+func (rs *testRowScannerSingleColumn) ScanRow(rows pgx.Rows) error {
+	rs.wasRun = true
+	return rows.Scan(&rs.name)
+}
+
+func TestRowScannerSingleColumn(t *testing.T) {
+	t.Parallel()
+
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		var s testRowScannerSingleColumn
+		err := conn.QueryRow(ctx, "select 'Adam' as name").Scan(&s)
+		require.NoError(t, err)
+		require.Equal(t, "Adam", s.name)
+		require.True(t, s.wasRun)
+	})
+}
+
 type testErrRowScanner string
 
 func (ers *testErrRowScanner) ScanRow(rows pgx.Rows) error {

--- a/rows_test.go
+++ b/rows_test.go
@@ -120,6 +120,11 @@ func TestScanOnRowCompositeWithRowScanner(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, testCompositeWithRowScanner{name: "Adam", age: 72}, s)
 
+		// When returned as an anonymous record type scanning works
+		err = conn.QueryRow(ctx, "select ROW('Adam',72)").Scan(&s)
+		require.NoError(t, err)
+		require.Equal(t, testCompositeWithRowScanner{name: "Adam", age: 72}, s)
+
 		// When returned as multiple columns RowScanner still works
 		err = conn.QueryRow(ctx, "select 'Adam', 72").Scan(&s)
 		require.NoError(t, err)

--- a/rows_test.go
+++ b/rows_test.go
@@ -480,6 +480,19 @@ func ExampleRowToAddrOf() {
 	// 5
 }
 
+func TestRowToMapSingleColumn(t *testing.T) {
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		rows, _ := conn.Query(ctx, `select 'Joe' as name from generate_series(0, 9) n`)
+		slice, err := pgx.CollectRows(rows, pgx.RowToMap)
+		require.NoError(t, err)
+
+		assert.Len(t, slice, 10)
+		for i := range slice {
+			assert.Equal(t, "Joe", slice[i]["name"])
+		}
+	})
+}
+
 func TestRowToMap(t *testing.T) {
 	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
 		rows, _ := conn.Query(ctx, `select 'Joe' as name, n as age from generate_series(0, 9) n`)


### PR DESCRIPTION
This fixes issue #2609 