### PR TITLE
fix: return error from ConnectConfig when config is nil

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -153,6 +153,9 @@ func ConnectWithOptions(ctx context.Context, connString string, options ParseCon
 // ConnectConfig establishes a connection with a PostgreSQL server with a configuration struct.
 // connConfig must have been created by [ParseConfig].
 func ConnectConfig(ctx context.Context, connConfig *ConnConfig) (*Conn, error) {
+	if connConfig == nil {
+		return nil, errors.New("pgx: ConnectConfig requires a non-nil *ConnConfig")
+	}
 	// In general this improves safety. In particular avoid the config.Config.OnNotification mutation from affecting other
 	// connections with the same config. See https://github.com/jackc/pgx/issues/618.
 	connConfig = connConfig.Copy()

--- a/conn_test.go
+++ b/conn_test.go
@@ -1698,3 +1698,9 @@ func TestErrNoRows(t *testing.T) {
 
 	require.ErrorIs(t, pgx.ErrNoRows, sql.ErrNoRows, "pgx.ErrNowRows must match sql.ErrNoRows")
 }
+
+
+func TestConnectConfigNil(t *testing.T) {
+	_, err := pgx.ConnectConfig(context.Background(), nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
`ConnectConfig(ctx, nil)` paniced inside `connConfig.Copy()`.

Return `pgx: ConnectConfig requires a non-nil *ConnConfig` instead.

Note: a non-nil but manually constructed `ConnConfig` still panics as before (`config must be created by ParseConfig`).

## Test plan
- [x] Unit test for nil config