### PR TITLE
fix: trim surrounding space in ParseConfig connection strings

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -329,6 +329,9 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 	defaultSettings := defaultSettings()
 	envSettings := parseEnvSettings()
 
+	// Allow surrounding space from config files and env expansion.
+	connString = strings.TrimSpace(connString)
+
 	connStringSettings := make(map[string]string)
 	if connString != "" {
 		var err error

--- a/pgconn/config_trim_test.go
+++ b/pgconn/config_trim_test.go
@@ -1,0 +1,18 @@
+package pgconn_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestParseConfigTrimSpace(t *testing.T) {
+	// keyword/value form without connecting
+	cfg, err := pgconn.ParseConfig("  host=localhost port=5432 dbname=postgres user=u  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Host != "localhost" {
+		t.Fatalf("host=%q", cfg.Host)
+	}
+}


### PR DESCRIPTION
## What

`ParseConfig` / `ParseConfigWithOptions` trim surrounding space on the connection string before parsing.

## Why

Env vars and config files often leave padded DSN values.

## Test

- `TestParseConfigTrimSpace`