### PR TITLE
Fix LoadTypes overwriting box/point codecs with a bogus ArrayCodec

### DIFF
--- a/derived_types.go
+++ b/derived_types.go
@@ -64,9 +64,12 @@ UNION ALL
 -- As can be seen, there are 3 ways this can occur (the last of which
 -- is due to being a composite class, where the composite fields are children)
 pc(parent, child) AS (
+    -- typtype = 'b' AND typelem != 0 is not sufficient to identify an array type: some
+    -- scalar types (box, point, line, lseg, name, ...) also set typelem to describe their
+    -- internal C representation. typcategory = 'A' is the reliable "is an array" signal.
     SELECT parent.oid, parent.typelem
     FROM pg_type parent
-    WHERE parent.typtype = 'b' AND parent.typelem != 0
+    WHERE parent.typtype = 'b' AND parent.typelem != 0 AND parent.typcategory = 'A'
 UNION ALL
     SELECT parent.oid, parent.typbasetype
     FROM pg_type parent
@@ -135,7 +138,11 @@ SELECT typname,
 	parts = append(parts, `
     LEFT OUTER JOIN composite USING (oid)
     LEFT OUTER JOIN pg_namespace ON (pg_type.typnamespace = pg_namespace.oid)
-    WHERE NOT (typtype = 'b' AND typelem = 0)`)
+    -- Only emit typtype = 'b' rows that are true arrays (typcategory = 'A'). Other base
+    -- types, including ones with a non-zero typelem for non-array reasons (box, point,
+    -- line, lseg, name, ...), already have a codec registered and must not be re-emitted,
+    -- or LoadTypes will overwrite their correct codec with a bogus ArrayCodec.
+    WHERE NOT (typtype = 'b' AND NOT (typelem != 0 AND typcategory = 'A'))`)
 	parts = append(parts, `
     GROUP BY typname, pg_namespace.nspname, typtype, typbasetype, typelem, pg_type.oid, pg_range.rngsubtype,`)
 	if supportsMultirange {

--- a/derived_types_test.go
+++ b/derived_types_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,5 +37,47 @@ create type dtype_test as (
 		require.Equal(t, types[3].Name, "_anotheruint64")
 		require.Equal(t, types[4].Name, "public.dtype_test")
 		require.Equal(t, types[5].Name, "dtype_test")
+	})
+}
+
+// https://github.com/jackc/pgx/issues/2608
+func TestLoadTypesDoesNotOverwriteBuiltinCodecsForGeometricFields(t *testing.T) {
+	skipCockroachDB(t, "Server does not support composite types (see https://github.com/cockroachdb/cockroach/issues/27792)")
+
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		_, err := conn.Exec(ctx, `
+drop type if exists dtype_geometric_test;
+
+create type dtype_geometric_test as (
+  m_id int4,
+  m_area box
+);`)
+		require.NoError(t, err)
+		defer conn.Exec(ctx, "drop type dtype_geometric_test")
+
+		types, err := conn.LoadTypes(ctx, []string{"dtype_geometric_test"})
+		require.NoError(t, err)
+
+		// box and point are base types that set typelem to describe their internal
+		// representation, not to mark themselves as arrays. LoadTypes must not treat
+		// them as arrays and must not re-register them, or it clobbers their existing
+		// built-in codec with a bogus ArrayCodec (see issue #2608).
+		for _, typ := range types {
+			require.NotContains(t, []string{"box", "pg_catalog.box", "point", "pg_catalog.point"}, typ.Name)
+		}
+
+		conn.TypeMap().RegisterTypes(types)
+
+		var id int32
+		area := pgtype.Box{P: [2]pgtype.Vec2{{X: 1, Y: 2}, {X: 3, Y: 4}}, Valid: true}
+
+		err = conn.QueryRow(ctx, "select $1::dtype_geometric_test",
+			pgtype.CompositeFields{int32(1), area},
+		).Scan(
+			pgtype.CompositeFields{&id, &area},
+		)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, id)
+		require.True(t, area.Valid)
 	})
 }


### PR DESCRIPTION
Fixes #2608.

## The bug

`LoadTypes` decides whether a `pg_type` row is an array by checking `typtype = 'b' AND typelem != 0`. That's not actually what `typelem` means for every base type. A handful of built-in scalars set `typelem` to describe their internal C representation, not because they're arrays:

```
oid  | typname | typtype | typelem | typcategory
-----+---------+---------+---------+------------
 600 | point   | b       |     701 | G   -- typelem = float8
 603 | box     | b       |     600 | G   -- typelem = point
 601 | lseg    | b       |     600 | G
 628 | line    | b       |     701 | G
  19 | name    | b       |      18 | S
```

So loading any composite type that has a `box` or `point` column pulls `box`/`point` themselves into the query's result set (because they get walked into the dependency graph as a field type), and `LoadTypes`'s switch on `typtype` reclassifies them as arrays and re-registers them in the `TypeMap` with a synthetic `ArrayCodec`, overwriting their real built-in codec. Scanning that field afterwards fails with `cannot scan []uint8`.

`typcategory = 'A'` is the actual, reliable signal for "this is an array type" (every true array — `_box`, `_int4`, etc. — has it; `box`/`point`/`line`/`lseg`/`name` don't). I used that instead of the `typelem != 0` heuristic in both the `pc` CTE (which builds the array → element dependency edges) and the final `WHERE`.

## Testing

Reproduced against the exact repro from the issue against Postgres 17, confirmed it fails the same way (`can't scan into dest[1] (col: m_area): cannot scan []uint8`), applied the fix, confirmed the round trip works, and added `TestLoadTypesDoesNotOverwriteBuiltinCodecsForGeometricFields` in `derived_types_test.go`, which fails on master and passes with this change. Ran the full suite (`go test ./...`), `goimports -l .`, and `golangci-lint run ./...` — all clean, no regressions (aside from one pre-existing, unrelated timezone-formatting failure in `TestConnCopyWithAllQueryExecModes` that reproduces on master too, before this change).

## AI disclosure

Per CONTRIBUTING.md: this fix was produced by Claude Code (Claude Sonnet 5), working from the issue text and a live Postgres 17 instance — it found the `pg_type` discrepancy shown above, wrote the fix and the regression test, and ran the full suite/lint. I've reviewed the diff and the reasoning above; it's a small, self-contained change and I'm glad to answer questions or make adjustments a maintainer asks for.
