### PR TITLE
stdlib: Add the GetTxFromDriverTx method

### DIFF
--- a/stdlib/sql.go
+++ b/stdlib/sql.go
@@ -907,3 +907,10 @@ type wrapTx struct {
 func (wtx wrapTx) Commit() error { return wtx.tx.Commit(wtx.ctx) }
 
 func (wtx wrapTx) Rollback() error { return wtx.tx.Rollback(wtx.ctx) }
+
+func GetTxFromDriverTx(driverTx driver.Tx) (pgx.Tx, bool) {
+	if wtx, ok := driverTx.(wrapTx); ok {
+		return wtx.tx, true
+	}
+	return nil, false
+}


### PR DESCRIPTION
In the compatibility mode of the database/sql standard library, obtain pgx.Tx