### PR TITLE
perf(pgtype): reuse backing arrays during row scans

### DIFF
--- a/pgtype/array.go
+++ b/pgtype/array.go
@@ -440,7 +440,15 @@ func (a *FlatArray[T]) SetDimensions(dimensions []ArrayDimension) error {
 	}
 
 	elementCount := cardinality(dimensions)
-	*a = make(FlatArray[T], elementCount)
+	if *a != nil && elementCount <= cap(*a) {
+		if elementCount > len(*a) {
+			*a = (*a)[:elementCount]
+		}
+		clear(*a)
+		*a = (*a)[:elementCount]
+	} else {
+		*a = make(FlatArray[T], elementCount)
+	}
 	return nil
 }
 

--- a/pgtype/array_test.go
+++ b/pgtype/array_test.go
@@ -5,6 +5,180 @@ import (
 	"testing"
 )
 
+func TestFlatArraySetDimensions(t *testing.T) {
+	t.Run("NULL array", func(t *testing.T) {
+		value := 1
+		storage := FlatArray[*int]{&value}
+		backing := storage
+
+		err := backing.SetDimensions(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if backing != nil {
+			t.Fatalf("expected nil array, got %v", backing)
+		}
+		// Setting the destination to nil must not mutate storage that may still be referenced by an alias.
+		if storage[0] != &value {
+			t.Fatal("cleared aliased storage while setting a NULL array")
+		}
+	})
+
+	t.Run("empty array from nil", func(t *testing.T) {
+		var backing FlatArray[int]
+
+		err := backing.SetDimensions([]ArrayDimension{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// A non-NULL empty PostgreSQL array must remain distinguishable from NULL.
+		if backing == nil {
+			t.Fatal("expected empty array to be non-nil")
+		}
+		if len(backing) != 0 {
+			t.Fatalf("expected length 0, got %d", len(backing))
+		}
+	})
+
+	t.Run("empty array reuses and clears storage", func(t *testing.T) {
+		storage := FlatArray[int]{1, 2}
+		backing := storage
+
+		err := backing.SetDimensions([]ArrayDimension{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if backing == nil || len(backing) != 0 {
+			t.Fatalf("expected non-nil empty array, got %#v", backing)
+		}
+		if storage[0] != 0 || storage[1] != 0 {
+			t.Fatalf("expected removed elements to be cleared, got %v", storage)
+		}
+	})
+
+	t.Run("same length reuses and clears storage", func(t *testing.T) {
+		backing := FlatArray[int]{1, 2}
+		originalElement := &backing[0]
+
+		err := backing.SetDimensions([]ArrayDimension{{Length: 2, LowerBound: 1}})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if originalElement != &backing[0] {
+			t.Fatal("expected existing capacity to be reused")
+		}
+		if !reflect.DeepEqual(backing, FlatArray[int]{0, 0}) {
+			t.Fatalf("expected elements to be cleared, got %v", backing)
+		}
+	})
+
+	t.Run("grow within capacity", func(t *testing.T) {
+		first, second, third, outsideDestination := 1, 2, 3, 4
+		storage := FlatArray[*int]{&first, &second, &third, &outsideDestination}
+		// Expose only the first two elements while retaining capacity for all four. Growing backing to three elements should
+		// reuse storage and clear the resized destination without touching storage[3], which may belong to another slice.
+		backing := storage[:2]
+		originalElement := &backing[0]
+
+		err := backing.SetDimensions([]ArrayDimension{{Length: 3, LowerBound: 1}})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(backing) != 3 {
+			t.Fatalf("expected length 3, got %d", len(backing))
+		}
+		if originalElement != &backing[0] {
+			t.Fatal("expected existing capacity to be reused")
+		}
+		for i, element := range backing {
+			if element != nil {
+				t.Fatalf("expected element %d to be cleared, got %v", i, element)
+			}
+		}
+		if storage[3] != &outsideDestination {
+			t.Fatal("cleared an element outside the resized destination")
+		}
+	})
+
+	t.Run("shrink within capacity", func(t *testing.T) {
+		first, second, third, outsideDestination := 1, 2, 3, 4
+		storage := FlatArray[*int]{&first, &second, &third, &outsideDestination}
+		backing := storage[:3]
+		originalElement := &backing[0]
+
+		err := backing.SetDimensions([]ArrayDimension{{Length: 1, LowerBound: 1}})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(backing) != 1 {
+			t.Fatalf("expected length 1, got %d", len(backing))
+		}
+		if originalElement != &backing[0] {
+			t.Fatal("expected existing capacity to be reused")
+		}
+		// Clear the full old destination so truncated pointer-bearing elements do not retain references.
+		for i, element := range storage[:3] {
+			if element != nil {
+				t.Fatalf("expected old element %d to be cleared, got %v", i, element)
+			}
+		}
+		if storage[3] != &outsideDestination {
+			t.Fatal("cleared an element outside the old destination")
+		}
+	})
+
+	t.Run("insufficient capacity allocates", func(t *testing.T) {
+		value := 1
+		storage := FlatArray[*int]{&value}
+		backing := storage[:1:1]
+		originalElement := &backing[0]
+
+		err := backing.SetDimensions([]ArrayDimension{{Length: 2, LowerBound: 1}})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(backing) != 2 {
+			t.Fatalf("expected length 2, got %d", len(backing))
+		}
+		if originalElement == &backing[0] {
+			t.Fatal("expected a new allocation when capacity is insufficient")
+		}
+		if backing[0] != nil || backing[1] != nil {
+			t.Fatalf("expected new elements to be cleared, got %v", backing)
+		}
+		// Allocating a replacement must not mutate storage retained by an alias.
+		if storage[0] != &value {
+			t.Fatal("cleared aliased storage while allocating a replacement")
+		}
+	})
+
+	t.Run("multidimensional cardinality", func(t *testing.T) {
+		var backing FlatArray[int]
+
+		err := backing.SetDimensions([]ArrayDimension{
+			{Length: 2, LowerBound: -1},
+			{Length: 3, LowerBound: 4},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(backing) != 6 {
+			t.Fatalf("expected flattened length 6, got %d", len(backing))
+		}
+		if !reflect.DeepEqual(backing, FlatArray[int]{0, 0, 0, 0, 0, 0}) {
+			t.Fatalf("expected elements to be cleared, got %v", backing)
+		}
+	})
+}
+
 func TestParseUntypedTextArray(t *testing.T) {
 	tests := []struct {
 		source string


### PR DESCRIPTION
Change pgtype to reuse the backing FlatArray instead of allocating a new one for each scanned row. Also added a new regression suite covering NULL and empty arrays, same-size reuse, growth, shrinking, insufficient capacity, multidimensional arrays, pointer clearing, and shared backing-array safety.

On benchmarks, I see around 11% reduction in allocations without any drop in latency

```
╰─$ PGX_TEST_DATABASE='postgres://localhost/pgx_test?sslmode=disable' \                                                                                                                                  
PGX_BENCH_SELECT_ROWS_COUNTS=1000 \
go test . \
  -run '^$' \
  -bench '^BenchmarkSelectRowsScanSimple/1000_rows$' \
  -benchmem \
  -count=10 \
  -benchtime=1s \
  | tee after.txt
goos: darwin
goarch: arm64
pkg: github.com/jackc/pgx/v5
cpu: Apple M1 Max
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2052	    582045 ns/op	  192734 B/op	    8013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2071	    569935 ns/op	  192728 B/op	    8013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2095	    568978 ns/op	  192731 B/op	    8013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2076	    569634 ns/op	  192728 B/op	    8013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2106	    567637 ns/op	  192728 B/op	    8013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2103	    568345 ns/op	  192728 B/op	    8013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2089	    567701 ns/op	  192728 B/op	    8013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2080	    570823 ns/op	  192728 B/op	    8013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2079	    572151 ns/op	  192728 B/op	    8013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2102	    570255 ns/op	  192728 B/op	    8013 allocs/op
PASS
ok  	github.com/jackc/pgx/v5	12.468s
╰─$ PGX_TEST_DATABASE='postgres://localhost/pgx_test?sslmode=disable' \
PGX_BENCH_SELECT_ROWS_COUNTS=1000 \
go test . \
  -run '^$' \
  -bench '^BenchmarkSelectRowsScanSimple/1000_rows$' \
  -benchmem \
  -count=10 \
  -benchtime=1s \
  | tee before.txt
goos: darwin
goarch: arm64
pkg: github.com/jackc/pgx/v5
cpu: Apple M1 Max
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2031	    586575 ns/op	  240734 B/op	    9013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2083	    585537 ns/op	  240728 B/op	    9013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    1978	    582112 ns/op	  240728 B/op	    9013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2083	    579414 ns/op	  240728 B/op	    9013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2049	    585219 ns/op	  240728 B/op	    9013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2072	    579867 ns/op	  240728 B/op	    9013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2067	    580290 ns/op	  240728 B/op	    9013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    1714	    621764 ns/op	  240728 B/op	    9013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2071	    581672 ns/op	  240729 B/op	    9013 allocs/op
BenchmarkSelectRowsScanSimple/1000_rows-10         	    2041	    573091 ns/op	  240731 B/op	    9013 allocs/op
PASS
ok  	github.com/jackc/pgx/v5	12.230s
╰─$ benchstat before.txt after.txt
goos: darwin
goarch: arm64
pkg: github.com/jackc/pgx/v5
cpu: Apple M1 Max
                                  │ before.txt  │             after.txt              │
                                  │   sec/op    │   sec/op     vs base               │
SelectRowsScanSimple/1000_rows-10   581.9µ ± 1%   569.8µ ± 0%  -2.08% (p=0.000 n=10)

                                  │  before.txt  │              after.txt               │
                                  │     B/op     │     B/op      vs base                │
SelectRowsScanSimple/1000_rows-10   235.1Ki ± 0%   188.2Ki ± 0%  -19.94% (p=0.000 n=10)

                                  │ before.txt  │              after.txt              │
                                  │  allocs/op  │  allocs/op   vs base                │
SelectRowsScanSimple/1000_rows-10   9.013k ± 0%   8.013k ± 0%  -11.10% (p=0.000 n=10)
```

I used Codex to write the tests and for experimenting with a number of edge cases.