### PR TITLE
pgxpool: accept pool_ping_timeout in the connection string

### DIFF
--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -344,10 +344,12 @@ func NewWithConfig(ctx context.Context, config *Config) (*Pool, error) {
 //
 //   - pool_max_conns: integer greater than 0 (default 4)
 //   - pool_min_conns: integer 0 or greater (default 0)
+//   - pool_min_idle_conns: integer 0 or greater (default 0)
 //   - pool_max_conn_lifetime: duration string (default 1 hour)
 //   - pool_max_conn_idle_time: duration string (default 30 minutes)
 //   - pool_health_check_period: duration string (default 1 minute)
 //   - pool_max_conn_lifetime_jitter: duration string (default 0)
+//   - pool_ping_timeout: duration string (default 0, meaning no timeout)
 //
 // See Config for definitions of these arguments.
 //
@@ -446,6 +448,18 @@ func ParseConfig(connString string) (*Config, error) {
 			return nil, pgconn.NewParseConfigError(connString, "cannot parse pool_max_conn_lifetime_jitter", err)
 		}
 		config.MaxConnLifetimeJitter = d
+	}
+
+	if s, ok := config.ConnConfig.Config.RuntimeParams["pool_ping_timeout"]; ok {
+		delete(connConfig.Config.RuntimeParams, "pool_ping_timeout")
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return nil, pgconn.NewParseConfigError(connString, "cannot parse pool_ping_timeout", err)
+		}
+		if d < 0 {
+			return nil, pgconn.NewParseConfigError(connString, "pool_ping_timeout must not be negative", nil)
+		}
+		config.PingTimeout = d
 	}
 
 	return config, nil

--- a/pgxpool/pool_test.go
+++ b/pgxpool/pool_test.go
@@ -53,6 +53,35 @@ func TestParseConfigExtractsPoolArguments(t *testing.T) {
 	assert.NotContains(t, config.ConnConfig.Config.RuntimeParams, "pool_min_conns")
 }
 
+func TestParseConfigExtractsPingTimeout(t *testing.T) {
+	t.Parallel()
+
+	config, err := pgxpool.ParseConfig("pool_ping_timeout=250ms")
+	require.NoError(t, err)
+	assert.Equal(t, 250*time.Millisecond, config.PingTimeout)
+
+	// Anything left in RuntimeParams is sent to the server as a startup parameter, which makes every connection fail
+	// with "unrecognized configuration parameter".
+	assert.NotContains(t, config.ConnConfig.Config.RuntimeParams, "pool_ping_timeout")
+}
+
+func TestParseConfigPingTimeoutDefaultsToZero(t *testing.T) {
+	t.Parallel()
+
+	config, err := pgxpool.ParseConfig("")
+	require.NoError(t, err)
+	assert.Zero(t, config.PingTimeout)
+}
+
+func TestParseConfigRejectsInvalidPingTimeout(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range []string{"abc", "250", "-1s"} {
+		_, err := pgxpool.ParseConfig("pool_ping_timeout=" + v)
+		assert.Errorf(t, err, "pool_ping_timeout=%s should be rejected", v)
+	}
+}
+
 func TestConstructorIgnoresContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Every pool setting on `pgxpool.Config` has a matching `pool_*` connection string key, except `PingTimeout`. `ParseConfig` didn't know the key, so `pgx.ParseConfig` left it in `RuntimeParams` and it got sent to the server as a startup parameter. Postgres then refused every connection in the pool:

```
failed to connect to `user=pgx_md5 database=pgx_test`:
  127.0.0.1:55432 (127.0.0.1): server error: FATAL: unrecognized configuration parameter "pool_ping_timeout" (SQLSTATE 42704)
```

So it's not that the key was ignored. Setting it broke the pool outright, and there was no way to bound the ping from a URL at all.

That matters for #1889. `Acquire` pings a connection that has been idle for a second or more, and with `PingTimeout` at 0 that ping inherits the caller's context. If the caller passes a context with no deadline and the network path has gone away without an RST, which is what the reporters see on Aurora and behind PrivateLink, the read blocks for as long as the socket stays open and `Acquire` never returns. `PingTimeout` is the existing mitigation for that. It was only reachable if you built the config in Go, and most people configure a pool from a URL.

What changed:

- `ParseConfig` consumes `pool_ping_timeout` as a duration string and rejects negative values.
- The default is unchanged. Zero still means no timeout, so nothing moves for existing users.
- Documented `pool_min_idle_conns` on `ParseConfig` too. It's been supported since `MinIdleConns` was added but was never in the list.

I stopped at making the knob reachable rather than picking a non-zero default. A default would change behaviour for everyone and that's your call, not mine. Happy to follow up with one if you want it.

Verified against Postgres 17 in Docker, macOS arm64, Go 1.26.5.

New and existing ping-timeout tests:

```
$ PGX_TEST_DATABASE="postgres://pgx_md5:secret@127.0.0.1:55432/pgx_test" \
    go test ./pgxpool/ -run 'TestParseConfig|TestPoolAcquirePingTimeout' -v
--- PASS: TestParseConfigExtractsPingTimeout (0.00s)
--- PASS: TestParseConfigPingTimeoutDefaultsToZero (0.00s)
--- PASS: TestParseConfigExtractsPoolArguments (0.00s)
--- PASS: TestParseConfigRejectsInvalidPingTimeout (0.00s)
--- PASS: TestPoolAcquirePingTimeout (6.02s)
PASS
ok  	github.com/jackc/pgx/v5/pgxpool	6.225s
```

Whole package:

```
$ PGX_TEST_DATABASE="postgres://pgx_md5:secret@127.0.0.1:55432/pgx_test" go test ./pgxpool/
ok  	github.com/jackc/pgx/v5/pgxpool	6.245s
```

The new tests fail on unpatched `pool.go`:

```
--- FAIL: TestParseConfigExtractsPingTimeout (0.00s)
    map[string]string{"pool_ping_timeout":"250ms"} should not contain "pool_ping_timeout"
--- FAIL: TestParseConfigRejectsInvalidPingTimeout (0.00s)
    pool_ping_timeout=abc should be rejected
    pool_ping_timeout=250 should be rejected
    pool_ping_timeout=-1s should be rejected
```

`go vet ./pgxpool/` and `gofmt -l pgxpool/` are both clean. Diff is two files, no lockfile or generated churn.

---

## Reviewer notes (not for the PR body)

- The `FATAL: unrecognized configuration parameter` output above is real. I reproduced it with a scratch module against the real server on unpatched code, then confirmed it goes away with the patch.
- I deliberately did not add an integration test that puts the key in `PGX_TEST_DATABASE`. CI sets that variable in keyword/value form in one job and as a URI in another, so appending a parameter is not format-safe. The parse-level assertion that the key leaves `RuntimeParams` is what actually prevents the failure, and `TestPoolAcquirePingTimeout` already covers the behaviour once `PingTimeout` is set.
- Governance check: the last 20 merged PRs on `jackc/pgx` are all from non-maintainers.
- No PR references issue #1889.
