### PR TITLE
fix: handle context cancellation race condition in pgxpool

### DIFF
--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -619,6 +619,13 @@ func (p *Pool) Acquire(ctx context.Context) (c *Conn, err error) {
 			return nil, err
 		}
 
+		// Handle race condition: If the connection is assigned to this waiter at the exact
+		// moment the waiter's context is canceled, we must safely return it to the idle pool.
+		if ctx.Err() != nil {
+			res.Release()
+			return nil, ctx.Err()
+		}
+
 		cr := res.Value()
 
 		// Destroy expired connections before doing any further work (such as

--- a/pgxpool/repro_test.go
+++ b/pgxpool/repro_test.go
@@ -1,0 +1,55 @@
+package pgxpool_test
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcquireContextCancelRace(t *testing.T) {
+	t.Parallel()
+
+	connString := os.Getenv("PGX_TEST_DATABASE")
+	if connString == "" {
+		t.Skip("PGX_TEST_DATABASE is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	config, err := pgxpool.ParseConfig(connString)
+	require.NoError(t, err)
+	config.MaxConns = 5
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			
+			timeout := time.Duration(rand.Intn(5)+1) * time.Millisecond
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			if conn, err := pool.Acquire(ctx); err == nil {
+				time.Sleep(2 * time.Millisecond)
+				conn.Release()
+			}
+		}()
+	}
+
+	wg.Wait()
+	time.Sleep(100 * time.Millisecond)
+
+	require.Equal(t, int32(0), pool.Stat().AcquiredConns())
+}


### PR DESCRIPTION
### Description
This PR addresses a critical race condition in `pgxpool.Acquire()`. 

Previously, if a connection was assigned to a waiting caller at the exact millisecond that the caller's context was canceled (e.g., via a timeout), the connection would be leaked because it was never returned to the idle pool.

This patch adds a safety check immediately after acquiring the resource. If `ctx.Err() != nil`, it safely calls `res.Release()` to return the connection back to the pool before bubbling the context error up to the caller.

### Changes Made
- Added context cancellation check in `Acquire()`
- Safely releases resources back to the pool to prevent connection leakage under heavy concurrency.
