### PR TITLE
pgconn: make connection close single-shot and concurrency-safe

### DIFF
--- a/pgconn/cleanup_single_shot_test.go
+++ b/pgconn/cleanup_single_shot_test.go
@@ -1,0 +1,72 @@
+package pgconn
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// https://github.com/jackc/pgx/issues/2622
+//
+// The status guard around cleanupDone used to be a non-atomic test-and-set,
+// so two close paths (Close, asyncClose, receiveMessage's OnPgError branch,
+// CopyFrom's buffering-receive error branch) could both pass it and both call
+// close(cleanupDone), panicking with "close of closed channel".
+//
+// These test the mechanism the fix relies on directly: exactly one goroutine
+// can win markClosed, and finishCleanup is safe to call from any number of
+// goroutines at once.
+func TestMarkClosedIsSingleShot(t *testing.T) {
+	t.Parallel()
+
+	pgConn := &PgConn{cleanupDone: make(chan struct{})}
+
+	const callers = 128
+	results := make(chan bool, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- pgConn.markClosed()
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	won := 0
+	for r := range results {
+		if r {
+			won++
+		}
+	}
+
+	require.Equal(t, 1, won, "exactly one goroutine must be reported as the closer")
+	require.False(t, pgConn.markClosed(), "markClosed must report false once already closed")
+	require.True(t, pgConn.IsClosed(), "connection must be reported closed after markClosed")
+}
+
+func TestFinishCleanupIsSingleShot(t *testing.T) {
+	t.Parallel()
+
+	pgConn := &PgConn{cleanupDone: make(chan struct{})}
+
+	const callers = 128
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Must not panic by closing the channel more than once.
+			pgConn.finishCleanup()
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case <-pgConn.cleanupDone:
+	default:
+		t.Fatal("cleanupDone must be closed after finishCleanup")
+	}
+}

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -116,6 +116,13 @@ type PgConn struct {
 	// cleanupOnce guarantees cleanupDone is closed exactly once, no matter how
 	// many close paths run concurrently.
 	cleanupOnce sync.Once
+
+	// slowWriteTimerMux serializes the slow write timer lifecycle across
+	// enter/exitPotentialWriteReadDeadlock pairs. Concurrent flushes (for
+	// example CopyFrom completing its final flush while Close tears the
+	// connection down) would otherwise both arm the single shared timer and
+	// trip the "slow write timer already active" panic.
+	slowWriteTimerMux sync.Mutex
 }
 
 // Connect establishes a connection to a PostgreSQL server using the environment and connString (in URL or keyword/value
@@ -851,16 +858,24 @@ func (pgConn *PgConn) IsBusy() bool {
 
 // lock locks the connection.
 func (pgConn *PgConn) lock() error {
-	switch pgConn.status.Load() {
-	case connStatusBusy:
-		return &connLockError{status: "conn busy"} // This only should be possible in case of an application bug.
-	case connStatusClosed:
-		return &connLockError{status: "conn closed"}
-	case connStatusUninitialized:
-		return &connLockError{status: "conn uninitialized"}
+	for {
+		switch pgConn.status.Load() {
+		case connStatusBusy:
+			return &connLockError{status: "conn busy"} // This only should be possible in case of an application bug.
+		case connStatusClosed:
+			return &connLockError{status: "conn closed"}
+		case connStatusUninitialized:
+			return &connLockError{status: "conn uninitialized"}
+		}
+		// CAS so only one caller wins when the connection is acquired from
+		// multiple goroutines (e.g. a CopyFrom on the raw connection racing
+		// a rollback triggered by database/sql). A plain store here would let
+		// two lockers both think they own the connection and the second
+		// unlock would panic.
+		if pgConn.status.CompareAndSwap(uint32(connStatusIdle), uint32(connStatusBusy)) {
+			return nil
+		}
 	}
-	pgConn.status.Store(uint32(connStatusBusy))
-	return nil
 }
 
 func (pgConn *PgConn) unlock() {
@@ -1544,6 +1559,9 @@ func (pgConn *PgConn) CopyFrom(ctx context.Context, r io.Reader, sql string) (Co
 					pgConn.conn.Close()
 					pgConn.finishCleanup()
 				}
+				// Stop the copy writer goroutine so it does not keep writing
+				// to the connection while the teardown proceeds.
+				close(abortCopyChan)
 				return CommandTag{}, normalizeTimeoutError(ctx, err)
 			}
 			// peekMessage never returns err in the bufferingReceive mode - it only forwards the bufferingReceive variables.
@@ -2144,6 +2162,12 @@ func (pgConn *PgConn) enterPotentialWriteReadDeadlock() {
 	//
 	// In addition, on Windows the default timer resolution is 15.6ms. So setting the timer to less than that is
 	// ineffective.
+	//
+	// The mutex makes the enter/exit pair single-flight. flushWithPotentialWriteReadDeadlock and the batch write path
+	// balance each enter with a deferred exit, and normal usage has only one flush in progress at a time, so in
+	// practice the mutex is uncontended. When close paths do overlap with an in-flight flush (e.g. CopyFrom finishing
+	// while Close tears down), the second flush waits instead of double-arming the timer and panicking.
+	pgConn.slowWriteTimerMux.Lock()
 	if pgConn.slowWriteTimer.Reset(15 * time.Millisecond) {
 		panic("BUG: slow write timer already active")
 	}
@@ -2151,6 +2175,7 @@ func (pgConn *PgConn) enterPotentialWriteReadDeadlock() {
 
 // exitPotentialWriteReadDeadlock must be called after a call to enterPotentialWriteReadDeadlock.
 func (pgConn *PgConn) exitPotentialWriteReadDeadlock() {
+	defer pgConn.slowWriteTimerMux.Unlock()
 	if !pgConn.slowWriteTimer.Stop() {
 		// The timer starts its function in a separate goroutine. It is necessary to ensure the background reader has
 		// started before calling Stop. Otherwise, the background reader may not be stopped. That on its own is not a

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -866,6 +866,11 @@ func (pgConn *PgConn) lock() error {
 			return &connLockError{status: "conn closed"}
 		case connStatusUninitialized:
 			return &connLockError{status: "conn uninitialized"}
+		case connStatusConnecting:
+			// Not ready can not be locked; this also guarantees the loop below
+			// always terminates even if lock were somehow called before the
+			// connection finished connecting.
+			return &connLockError{status: "conn not ready"}
 		}
 		// CAS so only one caller wins when the connection is acquired from
 		// multiple goroutines (e.g. a CopyFrom on the raw connection racing

--- a/pgconn/pgconn.go
+++ b/pgconn/pgconn.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5/internal/iobufpool"
@@ -91,7 +92,11 @@ type PgConn struct {
 
 	config *Config
 
-	status byte // One of connStatus* constants
+	// status is stored atomically because the close paths (Close, asyncClose,
+	// receiveMessage's OnPgError branch, and CopyFrom's buffering-receive error
+	// branch) can run concurrently and must agree on which goroutine performs
+	// the cleanup.
+	status atomic.Uint32 // One of connStatus* constants
 
 	bufferingReceive    bool
 	bufferingReceiveMux sync.Mutex
@@ -108,6 +113,9 @@ type PgConn struct {
 	fieldDescriptions [16]FieldDescription
 
 	cleanupDone chan struct{}
+	// cleanupOnce guarantees cleanupDone is closed exactly once, no matter how
+	// many close paths run concurrently.
+	cleanupOnce sync.Once
 }
 
 // Connect establishes a connection to a PostgreSQL server using the environment and connString (in URL or keyword/value
@@ -382,7 +390,7 @@ func connectOne(ctx context.Context, config *Config, connectConfig *connectOneCo
 	defer pgConn.contextWatcher.Unwatch()
 
 	pgConn.parameterStatuses = make(map[string]string)
-	pgConn.status = connStatusConnecting
+	pgConn.status.Store(uint32(connStatusConnecting))
 	pgConn.bgReader = bgreader.New(pgConn.conn)
 	pgConn.slowWriteTimer = time.AfterFunc(time.Duration(math.MaxInt64),
 		func() {
@@ -502,7 +510,7 @@ func connectOne(ctx context.Context, config *Config, connectConfig *connectOneCo
 			}
 			clientFinishedAuth = true
 		case *pgproto3.ReadyForQuery:
-			pgConn.status = connStatusIdle
+			pgConn.status.Store(uint32(connStatusIdle))
 			// The connect-phase deadline-only watcher is no longer needed; replace
 			// it with the application-supplied watcher so subsequent operations
 			// (including any queries run by ValidateConnect) use it.
@@ -660,7 +668,7 @@ func (pgConn *PgConn) peekMessage() (pgproto3.BackendMessage, error) {
 
 // receiveMessage receives a message without setting up context cancellation
 func (pgConn *PgConn) receiveMessage() (pgproto3.BackendMessage, error) {
-	if pgConn.status == connStatusClosed {
+	if pgConn.status.Load() == uint32(connStatusClosed) {
 		return nil, &connLockError{status: "conn closed"}
 	}
 
@@ -678,9 +686,10 @@ func (pgConn *PgConn) receiveMessage() (pgproto3.BackendMessage, error) {
 	case *pgproto3.ErrorResponse:
 		err := ErrorResponseToPgError(msg)
 		if pgConn.config.OnPgError != nil && !pgConn.config.OnPgError(pgConn, err) {
-			pgConn.status = connStatusClosed
-			pgConn.conn.Close() // Ignore error as the connection is already broken and there is already an error to return.
-			close(pgConn.cleanupDone)
+			if pgConn.markClosed() {
+				pgConn.conn.Close() // Ignore error as the connection is already broken and there is already an error to return.
+				pgConn.finishCleanup()
+			}
 			return nil, err
 		}
 	case *pgproto3.NoticeResponse:
@@ -730,16 +739,32 @@ func (pgConn *PgConn) Frontend() *pgproto3.Frontend {
 	return pgConn.frontend
 }
 
+// markClosed atomically transitions the connection to connStatusClosed and
+// reports whether the calling goroutine is the one that performed that
+// transition. Only the goroutine for which markClosed returns true is
+// responsible for closing the underlying connection and running cleanup, so
+// concurrent close paths never double-close.
+func (pgConn *PgConn) markClosed() bool {
+	return pgConn.status.Swap(uint32(connStatusClosed)) != uint32(connStatusClosed)
+}
+
+// finishCleanup closes the cleanupDone channel exactly once, regardless of how
+// many close paths run concurrently.
+func (pgConn *PgConn) finishCleanup() {
+	pgConn.cleanupOnce.Do(func() {
+		close(pgConn.cleanupDone)
+	})
+}
+
 // Close closes a connection. It is safe to call Close on an already closed connection. Close attempts a clean close by
 // sending the exit message to PostgreSQL. However, this could block so ctx is available to limit the time to wait. The
 // underlying net.Conn.Close() will always be called regardless of any other errors.
 func (pgConn *PgConn) Close(ctx context.Context) error {
-	if pgConn.status == connStatusClosed {
+	if !pgConn.markClosed() {
 		return nil
 	}
-	pgConn.status = connStatusClosed
 
-	defer close(pgConn.cleanupDone)
+	defer pgConn.finishCleanup()
 	defer pgConn.conn.Close()
 
 	if ctx != context.Background() {
@@ -768,13 +793,12 @@ func (pgConn *PgConn) Close(ctx context.Context) error {
 // asyncClose marks the connection as closed and asynchronously sends a cancel query message and closes the underlying
 // connection.
 func (pgConn *PgConn) asyncClose() {
-	if pgConn.status == connStatusClosed {
+	if !pgConn.markClosed() {
 		return
 	}
-	pgConn.status = connStatusClosed
 
 	go func() {
-		defer close(pgConn.cleanupDone)
+		defer pgConn.finishCleanup()
 		defer pgConn.conn.Close()
 
 		deadline := time.Now().Add(time.Second * 15)
@@ -817,17 +841,17 @@ func (pgConn *PgConn) CleanupDone() chan (struct{}) {
 //
 // CleanupDone() can be used to determine if all cleanup has been completed.
 func (pgConn *PgConn) IsClosed() bool {
-	return pgConn.status < connStatusIdle
+	return pgConn.status.Load() < uint32(connStatusIdle)
 }
 
 // IsBusy reports if the connection is busy.
 func (pgConn *PgConn) IsBusy() bool {
-	return pgConn.status == connStatusBusy
+	return pgConn.status.Load() == uint32(connStatusBusy)
 }
 
 // lock locks the connection.
 func (pgConn *PgConn) lock() error {
-	switch pgConn.status {
+	switch pgConn.status.Load() {
 	case connStatusBusy:
 		return &connLockError{status: "conn busy"} // This only should be possible in case of an application bug.
 	case connStatusClosed:
@@ -835,14 +859,14 @@ func (pgConn *PgConn) lock() error {
 	case connStatusUninitialized:
 		return &connLockError{status: "conn uninitialized"}
 	}
-	pgConn.status = connStatusBusy
+	pgConn.status.Store(uint32(connStatusBusy))
 	return nil
 }
 
 func (pgConn *PgConn) unlock() {
-	switch pgConn.status {
+	switch pgConn.status.Load() {
 	case connStatusBusy:
-		pgConn.status = connStatusIdle
+		pgConn.status.Store(uint32(connStatusIdle))
 	case connStatusClosed:
 	default:
 		panic("BUG: cannot unlock unlocked connection") // This should only be possible if there is a bug in this package.
@@ -1516,9 +1540,10 @@ func (pgConn *PgConn) CopyFrom(ctx context.Context, r io.Reader, sql string) (Co
 			// the goroutine. So instead check pgConn.bufferingReceiveErr which will have been set by the signalMessage. If an
 			// error is found then forcibly close the connection without sending the Terminate message.
 			if err := pgConn.bufferingReceiveErr; err != nil {
-				pgConn.status = connStatusClosed
-				pgConn.conn.Close()
-				close(pgConn.cleanupDone)
+				if pgConn.markClosed() {
+					pgConn.conn.Close()
+					pgConn.finishCleanup()
+				}
 				return CommandTag{}, normalizeTimeoutError(ctx, err)
 			}
 			// peekMessage never returns err in the bufferingReceive mode - it only forwards the bufferingReceive variables.
@@ -2200,7 +2225,7 @@ func (pgConn *PgConn) Hijack() (*HijackedConn, error) {
 	if err := pgConn.lock(); err != nil {
 		return nil, err
 	}
-	pgConn.status = connStatusClosed
+	pgConn.status.Store(uint32(connStatusClosed))
 
 	return &HijackedConn{
 		Conn:              pgConn.conn,
@@ -2234,10 +2259,9 @@ func Construct(hc *HijackedConn) (*PgConn, error) {
 		config:            hc.Config,
 		customData:        hc.CustomData,
 
-		status: connStatusIdle,
-
 		cleanupDone: make(chan struct{}),
 	}
+	pgConn.status.Store(uint32(connStatusIdle))
 
 	pgConn.contextWatcher = ctxwatch.NewContextWatcher(hc.Config.BuildContextWatcherHandler(pgConn))
 	pgConn.bgReader = bgreader.New(pgConn.conn)


### PR DESCRIPTION
Fixes #2622 and, along the way, the same "BUG:" panic family reported in #2332 and #2553. These let a connection torn down from two paths at once panic and kill the whole process instead of failing gracefully.

## The problem

`PgConn.cleanupDone` was closed from four places: `Close`, `asyncClose`, the `receiveMessage` OnPgError branch, and CopyFrom's buffering-receive error branch. Each was guarded only by a plain read-then-write of `PgConn.status`, a plain `byte` field with no synchronization. Two goroutines could both pass the guard and both close the channel, which panics with "close of closed channel". The reproducer in #2622 (a COPY streaming on a raw connection while the transaction context is cancelled) hits this reliably on master.

While testing that reproducer against a live PostgreSQL I found the same teardown scenario trips two more defensive panics in the same class:

- "slow write timer already active": the final COPY flush and the Close teardown flush can overlap within the 15ms window and both arm the single shared slow write timer. #2332 reports this panic under a heavy CopyFrom workload.
- "cannot unlock unlocked connection": `lock()` used a plain store for the busy transition, so two callers could both conclude they owned the connection and the second unlock would have nothing to unlock.

## The fix

Four changes, split into logical commits:

1. **Make closing single-shot.** `markClosed()` transitions the connection to closed with an atomic swap so exactly one goroutine is the closer, and `cleanupDone` is closed through a `sync.Once` (`finishCleanup`). All four close paths now go through these two helpers.
2. **Serialize the slow write timer.** `enter`/`exitPotentialWriteReadDeadlock` now hold a small mutex across the enter/write/exit lifecycle, so concurrent flushes queue instead of double-arming the timer and panicking. In normal use the mutex is uncontended since only one flush is in progress at a time.
3. **Make `lock()` a compare-and-swap** and reject locking a connection that is still connecting. Only one caller wins the busy transition, which makes the double-unlock unreachable.
4. **CopyFrom now closes `abortCopyChan` on the buffering-receive error path**, so the copy writer goroutine stops writing to the connection while teardown proceeds. That path was the only early-return path missing the close the others already did.

The `status` field is now an `atomic.Uint32`. This is not cosmetic: it removes the data race on the guard itself, makes the single-closer swap possible, and lets `IsClosed` and lock/unlock work while close paths run. Every read and write site was converted to Load/Store or CAS.

## Testing

- The reproducer from #2622: on master it panics with "close of closed channel". With this change it runs to completion, printing "survived", repeatedly and across 32, 48 and 64 workers against PostgreSQL 18.
- The full `pgconn` test suite passes against a live PostgreSQL 18.
- The full `pgconn` suite passes under `-race` (Go 1.26, Linux).
- New unit tests assert `markClosed` reports a single winner under concurrency and that `finishCleanup` never closes the channel twice.

## Known limitation

Under `-race` the #2622 reproducer still reports a handful of data races inside the `pgproto3` wire buffer (`Frontend.Send`, `Frontend.Flush`) and on `pgConn.txStatus`. These only appear because the reproducer drives one connection from two goroutines at once (a CopyFrom on the raw connection obtained via `sql.Conn.Raw`, racing the rollback database/sql spawns on a cancelled context). They do not panic and the run completes, but they are real unsynchronized accesses, so I documented them in #2623 with the details rather than silently bundling a larger frontend change into this PR.
