### PR TITLE
pgconn: use the default port for a URL host that omits its port

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -474,12 +474,23 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 	hosts := strings.Split(settings["host"], ",")
 	ports := strings.Split(settings["port"], ",")
 
+	// A host whose port was omitted arrives here as an empty port element. libpq
+	// resolves it to the default port (PGPORT or the compiled-in default), not to
+	// another host's port.
+	defaultPort := envSettings["port"]
+	if defaultPort == "" {
+		defaultPort = defaultSettings["port"]
+	}
+
 	for i, host := range hosts {
 		var portStr string
 		if i < len(ports) {
 			portStr = ports[i]
 		} else {
 			portStr = ports[0]
+		}
+		if portStr == "" {
+			portStr = defaultPort
 		}
 
 		port, err := parsePort(portStr)
@@ -668,31 +679,43 @@ func parseURLSettings(connString string) (map[string]string, error) {
 	}
 
 	// Handle multiple host:port's in url.Host by splitting them into host,host,host and port,port,port.
+	// The host and port lists are kept positionally aligned: a host that omits
+	// its port contributes an empty port element rather than being skipped, so a
+	// later host's port is never shifted onto an earlier host. Empty ports are
+	// resolved to the default port when the fallbacks are built, matching libpq.
 	var hosts []string
 	var ports []string
+	anyPort := false
 	for host := range strings.SplitSeq(parsedURL.Host, ",") {
 		if host == "" {
 			continue
 		}
 		if isIPOnly(host) {
 			hosts = append(hosts, strings.Trim(host, "[]"))
+			ports = append(ports, "")
 			continue
 		}
 		h, p, err := net.SplitHostPort(host)
 		if err != nil {
 			return nil, fmt.Errorf("failed to split host:port in '%s', err: %w", host, err)
 		}
+		if p != "" {
+			anyPort = true
+		}
 		if h != "" {
 			hosts = append(hosts, h)
-		}
-		if p != "" {
+			ports = append(ports, p)
+		} else if p != "" {
 			ports = append(ports, p)
 		}
 	}
 	if len(hosts) > 0 {
 		settings["host"] = strings.Join(hosts, ",")
 	}
-	if len(ports) > 0 {
+	// Only record the port when at least one host specified one. If no host did,
+	// leaving it unset lets the default port apply and keeps the connection
+	// string from being treated as having specified a port.
+	if anyPort {
 		settings["port"] = strings.Join(ports, ",")
 	}
 

--- a/pgconn/config_test.go
+++ b/pgconn/config_test.go
@@ -484,6 +484,55 @@ func TestParseConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			// A leading host that omits its port must use the default port, not
+			// the port of a later host in the list.
+			name:       "URL multiple hosts with a missing leading port",
+			connString: "postgres://jack:secret@foo,bar:5433/mydb?sslmode=disable",
+			config: &pgconn.Config{
+				User:          "jack",
+				Password:      "secret",
+				Host:          "foo",
+				Port:          defaultPort,
+				Database:      "mydb",
+				TLSConfig:     nil,
+				RuntimeParams: map[string]string{},
+				Fallbacks: []*pgconn.FallbackConfig{
+					{
+						Host:      "bar",
+						Port:      5433,
+						TLSConfig: nil,
+					},
+				},
+			},
+		},
+		{
+			// An omitted middle port must not shift the remaining ports onto the
+			// wrong hosts; each explicit port stays with its own host.
+			name:       "URL multiple hosts with a missing middle port",
+			connString: "postgres://jack:secret@foo:1,bar,baz:3/mydb?sslmode=disable",
+			config: &pgconn.Config{
+				User:          "jack",
+				Password:      "secret",
+				Host:          "foo",
+				Port:          1,
+				Database:      "mydb",
+				TLSConfig:     nil,
+				RuntimeParams: map[string]string{},
+				Fallbacks: []*pgconn.FallbackConfig{
+					{
+						Host:      "bar",
+						Port:      defaultPort,
+						TLSConfig: nil,
+					},
+					{
+						Host:      "baz",
+						Port:      3,
+						TLSConfig: nil,
+					},
+				},
+			},
+		},
 		// https://github.com/jackc/pgconn/issues/72
 		{
 			name:       "URL without host but with port still uses default host",


### PR DESCRIPTION
`ParseConfig` pairs the wrong port with a host in a multi-host connection URL when one of the hosts omits its port.

`parseURLSettings` splits `url.Host` on commas but only appends to its `ports` slice when a host carries an explicit port. As soon as an earlier host omits its port, that slice is no longer aligned with the host list, and the fallback builder in `ParseConfigWithOptions` then reads the wrong element for each host (falling back to `ports[0]` once it runs off the end).

So for `postgres://foo,bar:5433/mydb` pgx connects `foo` on 5433 instead of the default 5432, and for `postgres://foo:1,bar,baz:3/mydb` the explicit ports shift onto the wrong hosts. libpq keeps the two lists aligned and resolves an omitted per-host port to the default:

```
$ PGCONNECT_TIMEOUT=1 psql "postgresql://192.0.2.1,192.0.2.2:5433,192.0.2.3:9999/db"
psql: error: connection to server at "192.0.2.1", port 5432 failed: timeout expired
connection to server at "192.0.2.2", port 5433 failed: timeout expired
connection to server at "192.0.2.3", port 9999 failed: timeout expired
```

pgx before this change resolves that URL to `192.0.2.1:5433, 192.0.2.2:9999, 192.0.2.3:5433`. This bites HA connection strings that list, say, a primary and a replica on different ports — the primary silently ends up on the replica's port.

The fix keeps `ports` positionally aligned with `hosts` (a host that omits its port contributes an empty element) and resolves an empty element to the default port (PGPORT or the built-in default) when the fallbacks are built. That matches the documented libpq rule: "An empty string, or an empty item in a comma-separated list, specifies the default port number." A URL where no host specifies a port is unchanged, since the port is only recorded when at least one host set it.

Added two `TestParseConfig` cases (a leading and a middle omitted port); both fail before and pass after. `go test ./pgconn/` passes.
