### PR TITLE
pgtype: preserve precision in Numeric.ScanScientific

### DIFF
--- a/pgtype/numeric.go
+++ b/pgtype/numeric.go
@@ -132,12 +132,7 @@ func (n *Numeric) ScanScientific(src string) error {
 		return scanPlanTextAnyToNumericScanner{}.Scan([]byte(src), n)
 	}
 
-	if bigF, ok := new(big.Float).SetString(src); ok {
-		smallF, _ := bigF.Float64()
-		src = strconv.FormatFloat(smallF, 'f', -1, 64)
-	}
-
-	num, exp, err := parseNumericString(src)
+	num, exp, err := parseScientificNumericString(src)
 	if err != nil {
 		return err
 	}
@@ -145,6 +140,31 @@ func (n *Numeric) ScanScientific(src string) error {
 	*n = Numeric{Int: num, Exp: exp, Valid: true}
 
 	return nil
+}
+
+func parseScientificNumericString(str string) (n *big.Int, exp int32, err error) {
+	idx := strings.IndexAny(str, "eE")
+	if idx == -1 {
+		return parseNumericString(str)
+	}
+
+	mantissa := str[:idx]
+	scientificExp, err := strconv.ParseInt(str[idx+1:], 10, 32)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	num, mantissaExp, err := parseNumericString(mantissa)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	combinedExp := int64(mantissaExp) + scientificExp
+	if combinedExp < -1<<31 || combinedExp > 1<<31-1 {
+		return nil, 0, fmt.Errorf("%s exponent out of range", str)
+	}
+
+	return num, int32(combinedExp), nil
 }
 
 func (n *Numeric) toBigInt() (*big.Int, error) {

--- a/pgtype/numeric_test.go
+++ b/pgtype/numeric_test.go
@@ -74,6 +74,30 @@ func mustParseNumeric(t *testing.T, src string) pgtype.Numeric {
 	return n
 }
 
+func TestNumericScanScientificPreservesPrecision(t *testing.T) {
+	tests := []struct {
+		src  string
+		want pgtype.Numeric
+	}{
+		{
+			src:  "1234567890123456789e0",
+			want: pgtype.Numeric{Int: mustParseBigInt(t, "1234567890123456789"), Valid: true},
+		},
+		{
+			src:  "1.234567890123456789e5",
+			want: pgtype.Numeric{Int: mustParseBigInt(t, "1234567890123456789"), Exp: -13, Valid: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.src, func(t *testing.T) {
+			var got pgtype.Numeric
+			require.NoError(t, got.ScanScientific(tt.src))
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestNumericCodec(t *testing.T) {
 	skipCockroachDB(t, "server formats numeric text format differently")
 


### PR DESCRIPTION
## What changed

`Numeric.ScanScientific` was converting scientific notation through `float64` before parsing it as a PostgreSQL numeric. That loses precision for values with more significant digits than a `float64` can represent.

For example, `1234567890123456789e0` was stored as `12345678901234568 * 10^2`, and `1.234567890123456789e5` was stored as `12345678901234567 * 10^-11`.

This keeps the existing decimal parser for the mantissa and adds the scientific exponent directly to the resulting decimal exponent, so there is no float64 round trip.

## Tests

- `go test ./pgtype -run TestNumericScanScientificPreservesPrecision -count=1`
- `go test ./pgtype -count=1`
- `go test ./pgproto3 -count=1`
- `go test -p 1 $(go list ./... | grep -v "github.com/jackc/pgx/v5/pgproto3$") -count=1`
- `go test -race ./pgtype -run TestNumericScanScientificPreservesPrecision -count=1`
- `golangci-lint run ./...`
