### PR TITLE
Backport CVE-2026-33816 fix to v5.6.0

### DIFF
--- a/pgproto3/backend.go
+++ b/pgproto3/backend.go
@@ -123,7 +123,7 @@ func (b *Backend) ReceiveStartupMessage() (FrontendMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	msgSize := int(binary.BigEndian.Uint32(buf) - 4)
+	msgSize := int(int32(binary.BigEndian.Uint32(buf)) - 4)
 
 	if msgSize < minStartupPacketLen || msgSize > maxStartupPacketLen {
 		return nil, fmt.Errorf("invalid length of startup packet: %d", msgSize)
@@ -175,7 +175,13 @@ func (b *Backend) Receive() (FrontendMessage, error) {
 		}
 
 		b.msgType = header[0]
-		b.bodyLen = int(binary.BigEndian.Uint32(header[1:])) - 4
+
+		msgLength := int(int32(binary.BigEndian.Uint32(header[1:])))
+		if msgLength < 4 {
+			return nil, fmt.Errorf("invalid message length: %d", msgLength)
+		}
+
+		b.bodyLen = msgLength - 4
 		if b.maxBodyLen > 0 && b.bodyLen > b.maxBodyLen {
 			return nil, &ExceededMaxBodyLenErr{b.maxBodyLen, b.bodyLen}
 		}

--- a/pgproto3/frontend.go
+++ b/pgproto3/frontend.go
@@ -311,7 +311,7 @@ func (f *Frontend) Receive() (BackendMessage, error) {
 
 		f.msgType = header[0]
 
-		msgLength := int(binary.BigEndian.Uint32(header[1:]))
+		msgLength := int(int32(binary.BigEndian.Uint32(header[1:])))
 		if msgLength < 4 {
 			return nil, fmt.Errorf("invalid message length: %d", msgLength)
 		}

--- a/pgproto3/function_call.go
+++ b/pgproto3/function_call.go
@@ -23,6 +23,11 @@ func (*FunctionCall) Frontend() {}
 func (dst *FunctionCall) Decode(src []byte) error {
 	*dst = FunctionCall{}
 	rp := 0
+
+	if len(src) < 8 {
+		return &invalidMessageFormatErr{messageType: "FunctionCall"}
+	}
+
 	// Specifies the object ID of the function to call.
 	dst.Function = binary.BigEndian.Uint32(src[rp:])
 	rp += 4
@@ -32,6 +37,11 @@ func (dst *FunctionCall) Decode(src []byte) error {
 	// or it can equal the actual number of arguments.
 	nArgumentCodes := int(binary.BigEndian.Uint16(src[rp:]))
 	rp += 2
+
+	if len(src[rp:]) < nArgumentCodes*2+2 {
+		return &invalidMessageFormatErr{messageType: "FunctionCall"}
+	}
+
 	argumentCodes := make([]uint16, nArgumentCodes)
 	for i := 0; i < nArgumentCodes; i++ {
 		// The argument format codes. Each must presently be zero (text) or one (binary).
@@ -49,13 +59,21 @@ func (dst *FunctionCall) Decode(src []byte) error {
 	rp += 2
 	arguments := make([][]byte, nArguments)
 	for i := 0; i < nArguments; i++ {
+		if len(src[rp:]) < 4 {
+			return &invalidMessageFormatErr{messageType: "FunctionCall"}
+		}
 		// The length of the argument value, in bytes (this count does not include itself). Can be zero.
 		// As a special case, -1 indicates a NULL argument value. No value bytes follow in the NULL case.
-		argumentLength := int(binary.BigEndian.Uint32(src[rp:]))
+		argumentLength := int(int32(binary.BigEndian.Uint32(src[rp:])))
 		rp += 4
 		if argumentLength == -1 {
 			arguments[i] = nil
+		} else if argumentLength < 0 {
+			return &invalidMessageFormatErr{messageType: "FunctionCall"}
 		} else {
+			if len(src[rp:]) < argumentLength {
+				return &invalidMessageFormatErr{messageType: "FunctionCall"}
+			}
 			// The value of the argument, in the format indicated by the associated format code. n is the above length.
 			argumentValue := src[rp : rp+argumentLength]
 			rp += argumentLength
@@ -64,6 +82,9 @@ func (dst *FunctionCall) Decode(src []byte) error {
 	}
 	dst.Arguments = arguments
 	// The format code for the function result. Must presently be zero (text) or one (binary).
+	if len(src[rp:]) < 2 {
+		return &invalidMessageFormatErr{messageType: "FunctionCall"}
+	}
 	resultFormatCode := binary.BigEndian.Uint16(src[rp:])
 	if resultFormatCode != 0 && resultFormatCode != 1 {
 		return &invalidMessageFormatErr{messageType: "FunctionCall"}

--- a/pgproto3/function_call_response.go
+++ b/pgproto3/function_call_response.go
@@ -22,7 +22,7 @@ func (dst *FunctionCallResponse) Decode(src []byte) error {
 		return &invalidMessageFormatErr{messageType: "FunctionCallResponse"}
 	}
 	rp := 0
-	resultSize := int(binary.BigEndian.Uint32(src[rp:]))
+	resultSize := int(int32(binary.BigEndian.Uint32(src[rp:])))
 	rp += 4
 
 	if resultSize == -1 {
@@ -30,7 +30,7 @@ func (dst *FunctionCallResponse) Decode(src []byte) error {
 		return nil
 	}
 
-	if len(src[rp:]) != resultSize {
+	if resultSize < 0 || len(src[rp:]) != resultSize {
 		return &invalidMessageFormatErr{messageType: "FunctionCallResponse"}
 	}
 


### PR DESCRIPTION
## Summary

This PR backports the fix for **CVE-2026-33816** to the `v5.6.x` release line.

The target version is:

`v5.6.0`

The proposed maintenance release tag is:

`v5.6.1`

## Motivation

CVE-2026-33816 is a memory-safety vulnerability affecting `github.com/jackc/pgx/v5`.

The vulnerability is fixed upstream starting from `v5.9.0`, but applications that need to remain on the `v5.6.x` release line cannot consume the fix without upgrading to a newer pgx version.

This PR applies the upstream security fix to the `v5.6.0` codebase while preserving the existing `v5.6.x` API and behavior.

## Proposed release

If the backport is acceptable, I suggest publishing:

`v5.6.1`

as a security/maintenance release for the `v5.6.x` line.

## Notes

There does not appear to be a dedicated `v5.6.x` maintenance branch in the repository. This change is therefore based on `v5.6.0`.

If the project has a preferred maintenance branch or a different process for security backports, please let me know and I will retarget the change accordingly.

## Security reference

* CVE-2026-33816
* Fixed upstream in pgx `v5.9.0`

## Validation

The backported changes have been tested against the `v5.6.0` codebase.
