### PR TITLE
pgtype: support non-comma text array delimiters

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1309,7 +1309,7 @@ func (c *Conn) LoadType(ctx context.Context, typeName string) (*pgtype.Type, err
 
 	switch typtype {
 	case "b": // array
-		elementOID, err := c.getArrayElementOID(ctx, oid)
+		elementOID, delimiter, err := c.getArrayElementOIDAndDelimiter(ctx, oid)
 		if err != nil {
 			return nil, err
 		}
@@ -1319,7 +1319,7 @@ func (c *Conn) LoadType(ctx context.Context, typeName string) (*pgtype.Type, err
 			return nil, errors.New("array element OID not registered")
 		}
 
-		return &pgtype.Type{Name: typeName, OID: oid, Codec: &pgtype.ArrayCodec{ElementType: dt}}, nil
+		return &pgtype.Type{Name: typeName, OID: oid, Codec: &pgtype.ArrayCodec{ElementType: dt, Delimiter: delimiter}}, nil
 	case "c": // composite
 		fields, err := c.getCompositeFields(ctx, oid)
 		if err != nil {
@@ -1365,15 +1365,16 @@ func (c *Conn) LoadType(ctx context.Context, typeName string) (*pgtype.Type, err
 	}
 }
 
-func (c *Conn) getArrayElementOID(ctx context.Context, oid uint32) (uint32, error) {
+func (c *Conn) getArrayElementOIDAndDelimiter(ctx context.Context, oid uint32) (uint32, byte, error) {
 	var typelem uint32
+	var typdelim string
 
-	err := c.QueryRow(ctx, "select typelem from pg_type where oid=$1", oid).Scan(&typelem)
+	err := c.QueryRow(ctx, "select typelem, typdelim::text from pg_type where oid=$1", oid).Scan(&typelem, &typdelim)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
-	return typelem, nil
+	return typelem, parseTypeDelimiter(typdelim), nil
 }
 
 func (c *Conn) getRangeElementOID(ctx context.Context, oid uint32) (uint32, error) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1110,6 +1110,19 @@ create type pgx_b.point as (c text);
 	})
 }
 
+func TestLoadTypeLoadsArrayDelimiter(t *testing.T) {
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		pgxtest.SkipCockroachDB(t, conn, "Server does not support box type")
+
+		dt, err := conn.LoadType(ctx, "_box")
+		require.NoError(t, err)
+
+		codec, ok := dt.Codec.(*pgtype.ArrayCodec)
+		require.True(t, ok)
+		require.Equal(t, byte(';'), codec.Delimiter)
+	})
+}
+
 func TestLoadCompositeType(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()

--- a/derived_types.go
+++ b/derived_types.go
@@ -116,6 +116,7 @@ SELECT typname,
        typtype,
        typbasetype,
        typelem,
+       typdelim,
        pg_type.oid,`)
 	if supportsMultirange {
 		parts = append(parts, `
@@ -144,7 +145,7 @@ SELECT typname,
     -- or LoadTypes will overwrite their correct codec with a bogus ArrayCodec.
     WHERE NOT (typtype = 'b' AND NOT (typelem != 0 AND typcategory = 'A'))`)
 	parts = append(parts, `
-    GROUP BY typname, pg_namespace.nspname, typtype, typbasetype, typelem, pg_type.oid, pg_range.rngsubtype,`)
+    GROUP BY typname, pg_namespace.nspname, typtype, typbasetype, typelem, typdelim, pg_type.oid, pg_range.rngsubtype,`)
 	if supportsMultirange {
 		parts = append(parts, `
         multirange.rngtypid,`)
@@ -157,9 +158,16 @@ SELECT typname,
 
 type derivedTypeInfo struct {
 	Oid, Typbasetype, Typelem, Rngsubtype, Rngtypid uint32
-	TypeName, Typtype, NspName                      string
+	TypeName, Typtype, NspName, Typdelim            string
 	Attnames                                        []string
 	Atttypids                                       []uint32
+}
+
+func parseTypeDelimiter(typdelim string) byte {
+	if typdelim == "" {
+		return 0
+	}
+	return typdelim[0]
 }
 
 // LoadTypes performs a single (complex) query, returning all the required
@@ -184,7 +192,7 @@ func (c *Conn) LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Typ
 	result := make([]*pgtype.Type, 0, 100)
 	for rows.Next() {
 		ti := derivedTypeInfo{}
-		err = rows.Scan(&ti.TypeName, &ti.NspName, &ti.Typtype, &ti.Typbasetype, &ti.Typelem, &ti.Oid, &ti.Rngtypid, &ti.Rngsubtype, &ti.Attnames, &ti.Atttypids)
+		err = rows.Scan(&ti.TypeName, &ti.NspName, &ti.Typtype, &ti.Typbasetype, &ti.Typelem, &ti.Typdelim, &ti.Oid, &ti.Rngtypid, &ti.Rngsubtype, &ti.Attnames, &ti.Atttypids)
 		if err != nil {
 			return nil, fmt.Errorf("While scanning type information: %w", err)
 		}
@@ -195,7 +203,7 @@ func (c *Conn) LoadTypes(ctx context.Context, typeNames []string) ([]*pgtype.Typ
 			if !ok {
 				return nil, fmt.Errorf("Array element OID %v not registered while loading pgtype %q", ti.Typelem, ti.TypeName)
 			}
-			type_ = &pgtype.Type{Name: ti.TypeName, OID: ti.Oid, Codec: &pgtype.ArrayCodec{ElementType: dt}}
+			type_ = &pgtype.Type{Name: ti.TypeName, OID: ti.Oid, Codec: &pgtype.ArrayCodec{ElementType: dt, Delimiter: parseTypeDelimiter(ti.Typdelim)}}
 		case "c": // composite
 			var fields []pgtype.CompositeCodecField
 			for i, fieldName := range ti.Attnames {

--- a/derived_types_test.go
+++ b/derived_types_test.go
@@ -81,3 +81,26 @@ create type dtype_geometric_test as (
 		require.True(t, area.Valid)
 	})
 }
+
+func TestLoadTypesLoadsArrayDelimiter(t *testing.T) {
+	skipCockroachDB(t, "Server does not support box type")
+
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		types, err := conn.LoadTypes(ctx, []string{"_box"})
+		require.NoError(t, err)
+
+		var found bool
+		for _, dt := range types {
+			if dt.Name != "_box" && dt.Name != "pg_catalog._box" {
+				continue
+			}
+
+			codec, ok := dt.Codec.(*pgtype.ArrayCodec)
+			require.True(t, ok)
+			require.Equal(t, byte(';'), codec.Delimiter)
+			found = true
+		}
+
+		require.True(t, found)
+	})
+}

--- a/pgtype/array.go
+++ b/pgtype/array.go
@@ -95,7 +95,11 @@ type untypedTextArray struct {
 	Dimensions []ArrayDimension
 }
 
-func parseUntypedTextArray(src string) (*untypedTextArray, error) {
+func parseUntypedTextArray(src string, delimiter byte) (*untypedTextArray, error) {
+	if delimiter == 0 {
+		delimiter = ','
+	}
+
 	dst := &untypedTextArray{
 		Elements:   []string{},
 		Quoted:     []bool{},
@@ -202,7 +206,7 @@ func parseUntypedTextArray(src string) (*untypedTextArray, error) {
 				implicitDimensions[currentDim].Length++
 			}
 			currentDim++
-		case ',':
+		case rune(delimiter):
 		case '}':
 			currentDim--
 			if currentDim < counterDim {
@@ -210,7 +214,7 @@ func parseUntypedTextArray(src string) (*untypedTextArray, error) {
 			}
 		default:
 			buf.UnreadRune()
-			value, quoted, err := arrayParseValue(buf)
+			value, quoted, err := arrayParseValue(buf, delimiter)
 			if err != nil {
 				return nil, fmt.Errorf("invalid array value: %w", err)
 			}
@@ -254,7 +258,7 @@ func skipWhitespace(buf *bytes.Buffer) {
 	}
 }
 
-func arrayParseValue(buf *bytes.Buffer) (string, bool, error) {
+func arrayParseValue(buf *bytes.Buffer, delimiter byte) (string, bool, error) {
 	r, _, err := buf.ReadRune()
 	if err != nil {
 		return "", false, err
@@ -273,7 +277,7 @@ func arrayParseValue(buf *bytes.Buffer) (string, bool, error) {
 		}
 
 		switch r {
-		case ',', '}':
+		case rune(delimiter), '}':
 			buf.UnreadRune()
 			return s.String(), false, nil
 		}
@@ -360,8 +364,12 @@ func quoteArrayElement(src string) string {
 	return `"` + quoteArrayReplacer.Replace(src) + `"`
 }
 
-func quoteArrayElementIfNeeded(src string) string {
-	if src == "" || (len(src) == 4 && strings.EqualFold(src, "null")) || strings.ContainsAny(src, " \t\n\r\v\f") || strings.ContainsAny(src, `{},"\`) {
+func quoteArrayElementIfNeeded(src string, delimiter byte) string {
+	if delimiter == 0 {
+		delimiter = ','
+	}
+
+	if src == "" || (len(src) == 4 && strings.EqualFold(src, "null")) || strings.ContainsAny(src, " \t\n\r\v\f") || strings.ContainsAny(src, `{},"\`) || strings.ContainsRune(src, rune(delimiter)) {
 		return quoteArrayElement(src)
 	}
 	return src

--- a/pgtype/array_codec.go
+++ b/pgtype/array_codec.go
@@ -38,6 +38,16 @@ type ArraySetter interface {
 // ArrayCodec is a codec for any array type.
 type ArrayCodec struct {
 	ElementType *Type
+	// Delimiter is the character PostgreSQL uses to separate array elements for this type.
+	// If unset, "," is used.
+	Delimiter byte
+}
+
+func (c *ArrayCodec) delimiter() byte {
+	if c.Delimiter == 0 {
+		return ','
+	}
+	return c.Delimiter
 }
 
 func (c *ArrayCodec) FormatSupported(format int16) bool {
@@ -117,9 +127,10 @@ func (p *encodePlanArrayCodecText) Encode(value any, buf []byte) (newBuf []byte,
 	var encodePlan EncodePlan
 	var lastElemType reflect.Type
 	inElemBuf := make([]byte, 0, 32)
+	delimiter := p.ac.delimiter()
 	for i := range elementCount {
 		if i > 0 {
-			buf = append(buf, ',')
+			buf = append(buf, delimiter)
 		}
 
 		for _, dec := range dimElemCounts {
@@ -154,7 +165,7 @@ func (p *encodePlanArrayCodecText) Encode(value any, buf []byte) (newBuf []byte,
 		if elemBuf == nil {
 			buf = append(buf, `NULL`...)
 		} else {
-			buf = append(buf, quoteArrayElementIfNeeded(string(elemBuf))...)
+			buf = append(buf, quoteArrayElementIfNeeded(string(elemBuf), delimiter)...)
 		}
 
 		for _, dec := range dimElemCounts {
@@ -305,7 +316,7 @@ func (c *ArrayCodec) decodeBinary(m *Map, arrayOID uint32, src []byte, array Arr
 }
 
 func (c *ArrayCodec) decodeText(m *Map, arrayOID uint32, src []byte, array ArraySetter) error {
-	uta, err := parseUntypedTextArray(string(src))
+	uta, err := parseUntypedTextArray(string(src), c.delimiter())
 	if err != nil {
 		return err
 	}

--- a/pgtype/array_codec_test.go
+++ b/pgtype/array_codec_test.go
@@ -92,6 +92,25 @@ func TestArrayCodecEncodeTextArrayQuotesInternalWhitespace(t *testing.T) {
 	require.Equal(t, `{"has space","two words",nospaces}`, string(buf))
 }
 
+func TestArrayCodecDecodeTextBoxArrayUsesBoxDelimiter(t *testing.T) {
+	var boxes []pgtype.Box
+	err := pgtype.NewMap().Scan(pgtype.BoxArrayOID, pgtype.TextFormatCode, []byte(`{(2,2),(1,1);(4,4),(3,3)}`), &boxes)
+	require.NoError(t, err)
+	require.Equal(t, []pgtype.Box{
+		{P: [2]pgtype.Vec2{{X: 2, Y: 2}, {X: 1, Y: 1}}, Valid: true},
+		{P: [2]pgtype.Vec2{{X: 4, Y: 4}, {X: 3, Y: 3}}, Valid: true},
+	}, boxes)
+}
+
+func TestArrayCodecEncodeTextBoxArrayUsesBoxDelimiter(t *testing.T) {
+	buf, err := pgtype.NewMap().Encode(pgtype.BoxArrayOID, pgtype.TextFormatCode, []pgtype.Box{
+		{P: [2]pgtype.Vec2{{X: 2, Y: 2}, {X: 1, Y: 1}}, Valid: true},
+		{P: [2]pgtype.Vec2{{X: 4, Y: 4}, {X: 3, Y: 3}}, Valid: true},
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, `{"(2,2),(1,1)";"(4,4),(3,3)"}`, string(buf))
+}
+
 func TestArrayCodecArray(t *testing.T) {
 	ctr := defaultConnTestRunner
 	ctr.AfterConnect = func(ctx context.Context, t testing.TB, conn *pgx.Conn) {

--- a/pgtype/array_test.go
+++ b/pgtype/array_test.go
@@ -108,7 +108,7 @@ func TestParseUntypedTextArray(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		r, err := parseUntypedTextArray(tt.source)
+		r, err := parseUntypedTextArray(tt.source, ',')
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue
@@ -117,5 +117,22 @@ func TestParseUntypedTextArray(t *testing.T) {
 		if !reflect.DeepEqual(*r, tt.result) {
 			t.Errorf("%d: expected %+v to be parsed to %+v, but it was %+v", i, tt.source, tt.result, *r)
 		}
+	}
+}
+
+func TestParseUntypedTextArrayWithCustomDelimiter(t *testing.T) {
+	r, err := parseUntypedTextArray(`{(2,2),(1,1);(4,4),(3,3)}`, ';')
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := untypedTextArray{
+		Elements:   []string{"(2,2),(1,1)", "(4,4),(3,3)"},
+		Quoted:     []bool{false, false},
+		Dimensions: []ArrayDimension{{Length: 2, LowerBound: 1}},
+	}
+
+	if !reflect.DeepEqual(*r, expected) {
+		t.Errorf("expected %+v, got %+v", expected, *r)
 	}
 }

--- a/pgtype/pgtype_default.go
+++ b/pgtype/pgtype_default.go
@@ -131,7 +131,7 @@ func initDefaultMap() {
 	defaultMap.RegisterType(&Type{Name: "_aclitem", OID: ACLItemArrayOID, Codec: &ArrayCodec{ElementType: defaultMap.oidToType[ACLItemOID]}})
 	defaultMap.RegisterType(&Type{Name: "_bit", OID: BitArrayOID, Codec: &ArrayCodec{ElementType: defaultMap.oidToType[BitOID]}})
 	defaultMap.RegisterType(&Type{Name: "_bool", OID: BoolArrayOID, Codec: &ArrayCodec{ElementType: defaultMap.oidToType[BoolOID]}})
-	defaultMap.RegisterType(&Type{Name: "_box", OID: BoxArrayOID, Codec: &ArrayCodec{ElementType: defaultMap.oidToType[BoxOID]}})
+	defaultMap.RegisterType(&Type{Name: "_box", OID: BoxArrayOID, Codec: &ArrayCodec{ElementType: defaultMap.oidToType[BoxOID], Delimiter: ';'}})
 	defaultMap.RegisterType(&Type{Name: "_bpchar", OID: BPCharArrayOID, Codec: &ArrayCodec{ElementType: defaultMap.oidToType[BPCharOID]}})
 	defaultMap.RegisterType(&Type{Name: "_bytea", OID: ByteaArrayOID, Codec: &ArrayCodec{ElementType: defaultMap.oidToType[ByteaOID]}})
 	defaultMap.RegisterType(&Type{Name: "_char", OID: QCharArrayOID, Codec: &ArrayCodec{ElementType: defaultMap.oidToType[QCharOID]}})


### PR DESCRIPTION
`ArrayCodec` always used `,` when it encoded or decoded text arrays. PostgreSQL does not use comma for every array type: the delimiter is `pg_type.typdelim`, and the built-in `box[]` type uses `;`.

That means text `box[]` values like `{(2,2),(1,1);(4,4),(3,3)}` were split on the commas inside each box element before the box codec saw them. The new regression test failed before the fix with `invalid length for Box: 2`.

This adds a delimiter field to `ArrayCodec`, keeps comma as the default, registers `_box` with `;`, and uses that delimiter in text array encode/decode. `Conn.LoadType` and `Conn.LoadTypes` now also read `pg_type.typdelim`, matching the direction discussed in #2086.

I checked the PostgreSQL side with a PostgreSQL 18 container:

```sql
select typdelim from pg_type where typname = '_box'; -- ;
select array['((2,2),(1,1))'::box,'((4,4),(3,3))'::box]::text;
-- {(2,2),(1,1);(4,4),(3,3)}
```

Fixes #2086.

Tests:

```sh
go test ./pgtype -run 'Test(ParseUntypedTextArray|ParseUntypedTextArrayWithCustomDelimiter|ArrayCodecEncodeTextArrayQuotesInternalWhitespace|ArrayCodec(Decode|Encode)TextBoxArrayUsesBoxDelimiter)$' -count=20
go test -race ./pgtype -run 'Test(ParseUntypedTextArray|ParseUntypedTextArrayWithCustomDelimiter|ArrayCodecEncodeTextArrayQuotesInternalWhitespace|ArrayCodec(Decode|Encode)TextBoxArrayUsesBoxDelimiter)$' -count=1
PGX_TEST_DATABASE=... go test . -run 'TestLoadTypeLoadsArrayDelimiter|TestLoadTypesLoadsArrayDelimiter' -count=1 -v
PGX_TEST_DATABASE=... go test -race . ./pgtype -run 'Test(LoadTypeLoadsArrayDelimiter|LoadTypesLoadsArrayDelimiter|ParseUntypedTextArray|ParseUntypedTextArrayWithCustomDelimiter|ArrayCodecEncodeTextArrayQuotesInternalWhitespace|ArrayCodec(Decode|Encode)TextBoxArrayUsesBoxDelimiter)$' -count=1
PGX_TEST_DATABASE=... TZ=Asia/Seoul PGTZ=Asia/Seoul go test . ./pgtype -count=1
PGX_TEST_DATABASE=... TZ=Asia/Seoul PGTZ=Asia/Seoul go test -race ./... -count=1
go test ./... -run '^$' -count=1
go build ./...
golangci-lint run ./...
```
