### PR TITLE
Fix panic on unterminated quoted value ending in backslash

### DIFF
--- a/pgconn/config.go
+++ b/pgconn/config.go
@@ -792,6 +792,9 @@ func parseKeywordValueSettings(s string) (map[string]string, error) {
 				}
 				if s[end] == '\\' {
 					end++
+					if end == len(s) {
+						return nil, errors.New("unterminated quoted string in connection info string")
+					}
 				}
 			}
 			if end == len(s) {

--- a/pgconn/config_test.go
+++ b/pgconn/config_test.go
@@ -1022,6 +1022,34 @@ func TestParseConfigKVTrailingBackslash(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid backslash")
 }
 
+// A backslash as the last byte of an unterminated quoted value must be
+// rejected as an unterminated string, not panic with a slice bounds error.
+// The quoted-string loop advances past a backslash without bounds-checking
+// the resulting index, so `='\` (and `0='\`, reached via the pgxpool path)
+// previously panicked with "slice bounds out of range [:2] with length 1".
+func TestParseConfigKVQuotedTrailingBackslashDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name       string
+		connString string
+	}{
+		{name: "bare quoted trailing backslash", connString: `='\`},
+		{name: "quoted trailing backslash with key", connString: `0='\`},
+		{name: "quoted trailing backslash after value", connString: `host='a\`},
+		{name: "quoted trailing backslash after escaped pair", connString: `host='a\\b\`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			assert.NotPanics(t, func() {
+				_, err = pgconn.ParseConfig(tt.connString)
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unterminated quoted string in connection info string")
+		})
+	}
+}
+
 // https://github.com/jackc/pgx/issues/2284
 // Multiple trailing spaces and trailing spaces after quoted values must be
 // accepted as valid keyword/value connection strings.


### PR DESCRIPTION
A backslash as the last byte of a quoted keyword/value value panicked with "slice bounds out of range [:2] with length 1". The quoted-string loop skips the byte after a backslash by incrementing end, and the for loop then increments it again, so `='\` (or `0='\`, reached via pgxpool.ParseConfig) drove end past len(s). The subsequent bounds check compared end == len(s), which no longer matched, and s[:end] sliced past the end of the string.

The unquoted branch has guarded this since be69c1c1 ("Fix parseDSNSettings with bad backslash"), but that fix missed the quoted branch, which has carried the same unguarded increment since the parser was ported from pgx v3 in 99f22ac8. 

Found by go native fuzzing.

The quoted branch now bounds-checks end after the backslash skip, matching the unquoted branch, and returns "unterminated quoted string in connection info string" instead of panicking. Regression test covers both crashing inputs and the value-prefixed variants.