### PR TITLE
Add Conn.TxFromCurrentTransaction and TxOptions.BeginSQL

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -3,6 +3,7 @@ package pgx
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -52,6 +53,14 @@ type TxOptions struct {
 }
 
 var emptyTxOptions TxOptions
+
+// BeginSQL returns the SQL statement that [Conn.BeginTx] would send for
+// txOptions. It is exported so that callers that start a transaction themselves,
+// e.g. by queueing it as the first query of a [Batch] to save a round trip, can
+// use the same statement pgx would.
+func (txOptions TxOptions) BeginSQL() string {
+	return txOptions.beginSQL()
+}
 
 func (txOptions TxOptions) beginSQL() string {
 	if txOptions == emptyTxOptions {
@@ -107,6 +116,31 @@ func (c *Conn) BeginTx(ctx context.Context, txOptions TxOptions) (Tx, error) {
 			c.die()
 		}
 		return nil, err
+	}
+
+	return &dbTx{
+		conn:        c,
+		commitQuery: txOptions.CommitQuery,
+	}, nil
+}
+
+// TxFromCurrentTransaction returns a [Tx] for the transaction c is already in,
+// without sending a begin query. It is for callers that begin the transaction
+// themselves in a way that avoids a dedicated round trip, such as queueing
+// [TxOptions.BeginSQL] as the first query of a [Batch] or of a pgconn pipeline.
+//
+// Only [TxOptions.CommitQuery] is read from txOptions. The isolation level,
+// access mode and deferrable mode must already have been established by the
+// begin query the caller sent.
+//
+// It returns an error if c is not currently in a transaction, which includes the
+// case where the caller's begin query has been sent but its results have not been
+// read yet. The returned Tx is otherwise identical to one from [Conn.BeginTx].
+func (c *Conn) TxFromCurrentTransaction(txOptions TxOptions) (Tx, error) {
+	switch status := c.PgConn().TxStatus(); status {
+	case 'T', 'E':
+	default:
+		return nil, fmt.Errorf("connection is not in a transaction (transaction status %q)", status)
 	}
 
 	return &dbTx{

--- a/tx_test.go
+++ b/tx_test.go
@@ -717,3 +717,169 @@ func TestBeginTxFatalErrorKillsConn(t *testing.T) {
 
 	require.True(t, conn.IsClosed())
 }
+
+func TestTxOptionsBeginSQL(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		txOptions pgx.TxOptions
+		expected  string
+	}{
+		{
+			name:      "empty",
+			txOptions: pgx.TxOptions{},
+			expected:  "begin",
+		},
+		{
+			name:      "iso level",
+			txOptions: pgx.TxOptions{IsoLevel: pgx.Serializable},
+			expected:  "begin isolation level serializable",
+		},
+		{
+			name:      "access mode",
+			txOptions: pgx.TxOptions{AccessMode: pgx.ReadOnly},
+			expected:  "begin read only",
+		},
+		{
+			name: "all modes",
+			txOptions: pgx.TxOptions{
+				IsoLevel:       pgx.Serializable,
+				AccessMode:     pgx.ReadWrite,
+				DeferrableMode: pgx.NotDeferrable,
+			},
+			expected: "begin isolation level serializable read write not deferrable",
+		},
+		{
+			name:      "begin query overrides modes",
+			txOptions: pgx.TxOptions{IsoLevel: pgx.Serializable, BeginQuery: "begin priority high"},
+			expected:  "begin priority high",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, tt.txOptions.BeginSQL())
+		})
+	}
+}
+
+func TestTxFromCurrentTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	_, err := conn.Exec(ctx, "create temporary table foo(id integer primary key)")
+	require.NoError(t, err)
+
+	txOptions := pgx.TxOptions{IsoLevel: pgx.RepeatableRead}
+
+	batch := &pgx.Batch{}
+	batch.Queue(txOptions.BeginSQL())
+	batch.Queue("insert into foo(id) values (1)")
+	require.NoError(t, conn.SendBatch(ctx, batch).Close())
+
+	tx, err := conn.TxFromCurrentTransaction(txOptions)
+	require.NoError(t, err)
+
+	var isoLevel string
+	err = tx.QueryRow(ctx, "select current_setting('transaction_isolation')").Scan(&isoLevel)
+	require.NoError(t, err)
+	require.Equal(t, string(pgx.RepeatableRead), isoLevel)
+
+	_, err = tx.Exec(ctx, "insert into foo(id) values (2)")
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Commit(ctx))
+
+	var n int64
+	err = conn.QueryRow(ctx, "select count(*) from foo").Scan(&n)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, n)
+}
+
+func TestTxFromCurrentTransactionRollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	_, err := conn.Exec(ctx, "create temporary table foo(id integer primary key)")
+	require.NoError(t, err)
+
+	batch := &pgx.Batch{}
+	batch.Queue(pgx.TxOptions{}.BeginSQL())
+	batch.Queue("insert into foo(id) values (1)")
+	require.NoError(t, conn.SendBatch(ctx, batch).Close())
+
+	tx, err := conn.TxFromCurrentTransaction(pgx.TxOptions{})
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback(ctx))
+
+	var n int64
+	err = conn.QueryRow(ctx, "select count(*) from foo").Scan(&n)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, n)
+}
+
+func TestTxFromCurrentTransactionWhenNotInTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	tx, err := conn.TxFromCurrentTransaction(pgx.TxOptions{})
+	require.Error(t, err)
+	require.Nil(t, tx)
+
+	// The connection is untouched and remains usable.
+	var n int32
+	require.NoError(t, conn.QueryRow(ctx, "select 1").Scan(&n))
+	require.EqualValues(t, 1, n)
+}
+
+func TestTxFromCurrentTransactionWhenTransactionFailed(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	batch := &pgx.Batch{}
+	batch.Queue(pgx.TxOptions{}.BeginSQL())
+	batch.Queue("select 1/0")
+	require.Error(t, conn.SendBatch(ctx, batch).Close())
+
+	// The transaction is in the failed state, but a Tx is still needed to roll it back.
+	tx, err := conn.TxFromCurrentTransaction(pgx.TxOptions{})
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback(ctx))
+
+	var n int32
+	require.NoError(t, conn.QueryRow(ctx, "select 1").Scan(&n))
+	require.EqualValues(t, 1, n)
+}
+
+func TestTxFromCurrentTransactionCommitQuery(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	txOptions := pgx.TxOptions{CommitQuery: "commit /* custom */"}
+
+	batch := &pgx.Batch{}
+	batch.Queue(txOptions.BeginSQL())
+	batch.Queue("select 1")
+	require.NoError(t, conn.SendBatch(ctx, batch).Close())
+
+	tx, err := conn.TxFromCurrentTransaction(txOptions)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+	require.ErrorIs(t, tx.Commit(ctx), pgx.ErrTxClosed)
+}


### PR DESCRIPTION
Implements the primitive suggested in #1667:

> Since you want a `Tx`, maybe a function that constructs one without actually sending the `begin` query.

Design discussion and measurements are in https://github.com/jackc/pgx/issues/1667#issuecomment-5367699222. Opening as a draft because naming and shape are still open.

## What this adds

```go
// BeginSQL returns the SQL statement that Conn.BeginTx would send for txOptions.
func (txOptions TxOptions) BeginSQL() string

// TxFromCurrentTransaction returns a Tx for the transaction c is already in,
// without sending a begin query.
func (c *Conn) TxFromCurrentTransaction(txOptions TxOptions) (Tx, error)
```

A caller can already queue `begin` as the first query of a `Batch` or a pgconn pipeline, which saves the round trip `Conn.BeginTx` spends on its own `Exec`. What is missing is a way to get a `Tx` back afterwards, so the rest of the unit of work keeps pgx's transaction bookkeeping (`ErrTxClosed`, `Rollback` being safe after `Commit`, `ErrTxCommitRollback`, savepoint nesting) instead of reimplementing it outside pgx.

```go
b := &pgx.Batch{}
b.Queue(txOptions.BeginSQL())
b.Queue(fenceCheck, shardID, fenceID).QueryRow(func(row pgx.Row) error { return row.Scan(new(int)) })
batchErr := conn.SendBatch(ctx, b).Close()

tx, err := conn.TxFromCurrentTransaction(txOptions)
```

`BeginSQL` is exported so callers queueing the begin themselves use the statement pgx would produce, rather than hand-rolling one that silently drifts from `beginSQL()`.

## Notes on the implementation

- Only `TxOptions.CommitQuery` is read. The isolation level, access mode and deferrable mode must already have been established by the begin query the caller sent, and this is documented on the method.
- The guard accepts transaction status `'T'` and `'E'`. A batch that failed partway leaves the connection in a failed transaction, and the caller still needs a `Tx` to roll it back.
- The returned value is the same unexported `dbTx` that `Conn.BeginTx` returns, so behavior after construction is identical. No existing code path changes.

## Testing

New tests in `tx_test.go`: table-driven coverage of `BeginSQL`, plus commit, rollback, not-in-a-transaction, failed-transaction and `CommitQuery` cases for `TxFromCurrentTransaction`. The commit test also asserts the isolation level from the batched begin is in effect inside the resulting `Tx`.

Full `go test` for the root package passes against PostgreSQL 17.

## Not addressed

You raised on #1667 that `COMMIT` is the symmetric problem. It is, and this does not solve it: a caller can queue `commit` in the final batch, but nothing can tell the `Tx` it is already closed, so `defer tx.Rollback()` spends the round trip that was just saved. That seems to want its own affordance and I did not want to conflate the two.

## AI disclosure

Per CONTRIBUTING.md: this change was developed with AI assistance (Claude Code, Opus 5), including the prototype, the round-trip measurements and the tests. I have reviewed it and can answer questions about it.
