### PR TITLE
docs(pgxpool): correct the documented pool_max_conns default

### DIFF
--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -343,7 +343,7 @@ func NewWithConfig(ctx context.Context, config *Config) (*Pool, error) {
 // ParseConfig builds a Config from connString. It parses connString with the same behavior as [pgx.ParseConfig] with the
 // addition of the following variables:
 //
-//   - pool_max_conns: integer greater than 0 (default 4)
+//   - pool_max_conns: integer greater than 0 (default is the greater of 4 or runtime.NumCPU())
 //   - pool_min_conns: integer 0 or greater (default 0)
 //   - pool_min_idle_conns: integer 0 or greater (default 0)
 //   - pool_max_conn_lifetime: duration string (default 1 hour)


### PR DESCRIPTION
`ParseConfig`'s doc comment lists:

```
//   - pool_max_conns: integer greater than 0 (default 4)
```

But when `pool_max_conns` is not supplied, the code sets it to the greater of 4 and `runtime.NumCPU()`:

```go
} else {
    config.MaxConns = defaultMaxConns            // 4
    if numCPU := int32(runtime.NumCPU()); numCPU > config.MaxConns {
        config.MaxConns = numCPU
    }
}
```

So on any host with more than 4 CPUs the effective default is `NumCPU`, not 4 — which matters for capacity planning against `max_connections`. The `Config.MaxConns` field doc already states this correctly ("The default is the greater of 4 or runtime.NumCPU()"); this just brings the `ParseConfig` parameter list in line with it.

One-line comment change. No code, no behavior change.