### PR TITLE
Deallocate a failed prepare by the name sent in Parse, and only when Parse completed

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -359,10 +359,12 @@ func (c *Conn) Prepare(ctx context.Context, name, sql string) (sd *pgconn.Statem
 	sd, err = c.pgConn.Prepare(ctx, psName, sql, nil)
 	if err != nil {
 		var pErr *pgconn.PrepareError
-		if errors.As(err, &pErr) {
+		if errors.As(err, &pErr) && pErr.ParseComplete {
 			// The server-side statement was created under psName — the name sent in
 			// Parse. In the name == sql case psKey is the SQL text, and deallocating
 			// by it would close a nonexistent statement while leaking the real one.
+			// When Parse never completed no statement was created at all, so there
+			// is nothing to clean up.
 			c.failedDescribeStatement = psName
 		}
 		return nil, err

--- a/conn.go
+++ b/conn.go
@@ -360,7 +360,10 @@ func (c *Conn) Prepare(ctx context.Context, name, sql string) (sd *pgconn.Statem
 	if err != nil {
 		var pErr *pgconn.PrepareError
 		if errors.As(err, &pErr) {
-			c.failedDescribeStatement = psKey
+			// The server-side statement was created under psName — the name sent in
+			// Parse. In the name == sql case psKey is the SQL text, and deallocating
+			// by it would close a nonexistent statement while leaking the real one.
+			c.failedDescribeStatement = psName
 		}
 		return nil, err
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -608,6 +608,55 @@ func TestPrepareWithDigestedNameHandlesTimeoutBetweenParseAndDescribe(t *testing
 	require.NotNil(t, psd)
 }
 
+// https://github.com/jackc/pgx/issues/2640
+func TestPrepareFailedParseSchedulesNoCleanup(t *testing.T) {
+	t.Parallel()
+
+	// A Prepare that fails before Parse completes leaves no statement on the server, so the next Prepare must not
+	// spend a round trip deallocating anything.
+
+	config, err := pgx.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+
+	var faultyConn *faultyconn.Conn
+	config.AfterNetConnect = func(ctx context.Context, config *pgconn.Config, conn net.Conn) (net.Conn, error) {
+		faultyConn = faultyconn.New(conn)
+		return faultyConn, nil
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.ConnectConfig(ctx, config)
+	require.NoError(t, err)
+	defer closeConn(t, conn)
+	require.NotNil(t, faultyConn)
+
+	sql := "select foo"
+	psd, err := conn.Prepare(ctx, sql, sql)
+	require.Error(t, err)
+	require.Nil(t, psd)
+	var pErr *pgconn.PrepareError
+	require.ErrorAs(t, err, &pErr)
+	require.False(t, pErr.ParseComplete)
+
+	var sentClose bool
+	faultyConn.HandleFrontendMessage = func(backendWriter io.Writer, msg pgproto3.FrontendMessage) error {
+		if _, ok := msg.(*pgproto3.Close); ok {
+			sentClose = true
+		}
+		buf, err := msg.Encode(nil)
+		if err != nil {
+			return err
+		}
+		_, err = backendWriter.Write(buf)
+		return err
+	}
+
+	psd, err = conn.Prepare(ctx, "select 1", "select 1")
+	require.NoError(t, err)
+	require.NotNil(t, psd)
+	require.False(t, sentClose)
+}
+
 func TestPrepareBadSQLFailure(t *testing.T) {
 	t.Parallel()
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -3,7 +3,9 @@ package pgx_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"io"
 	"net"
 	"os"
@@ -528,6 +530,80 @@ func TestPrepareHandlesTimeoutBetweenParseAndDescribe(t *testing.T) {
 	require.True(t, existsOnServer)
 
 	psd, err = conn.Prepare(ctx, "test", "select $1::varchar")
+	require.NoError(t, err)
+	require.NotNil(t, psd)
+}
+
+// https://github.com/jackc/pgx/issues/2640
+func TestPrepareWithDigestedNameHandlesTimeoutBetweenParseAndDescribe(t *testing.T) {
+	// Not parallel because it is a timing sensitive test.
+	//
+	// stdlib (and therefore database/sql) calls Prepare(ctx, sql, sql). In that case the statement is prepared on the
+	// server under stmt_<digest> while the client keys it by the SQL text. Cleanup after a Describe phase failure must
+	// deallocate the digest name — deallocating by the SQL text closes a nonexistent statement, so the leaked
+	// statement stays on the server and re-preparing the same SQL fails with 42P05 for the rest of the connection's
+	// life.
+
+	config, err := pgx.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+
+	var faultyConn *faultyconn.Conn
+	config.AfterNetConnect = func(ctx context.Context, config *pgconn.Config, conn net.Conn) (net.Conn, error) {
+		faultyConn = faultyconn.New(conn)
+		return faultyConn, nil
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.ConnectConfig(ctx, config)
+	require.NoError(t, err)
+	defer closeConn(t, conn)
+	require.NotNil(t, faultyConn)
+
+	pgxtest.SkipCockroachDB(t, conn, "Induced error does not occur on CockroachDB")
+
+	_, err = conn.Exec(ctx, "set statement_timeout = '100ms'")
+	require.NoError(t, err)
+
+	faultyConn.HandleFrontendMessage = func(backendWriter io.Writer, msg pgproto3.FrontendMessage) error {
+		if _, ok := msg.(*pgproto3.Describe); ok {
+			time.Sleep(200 * time.Millisecond)
+		}
+		buf, err := msg.Encode(nil)
+		if err != nil {
+			return err
+		}
+		_, err = backendWriter.Write(buf)
+		return err
+	}
+
+	sql := "select $1::varchar"
+	digest := sha256.Sum256([]byte(sql))
+	psName := "stmt_" + hex.EncodeToString(digest[0:24])
+
+	psd, err := conn.Prepare(ctx, sql, sql)
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	require.Equal(t, "57014", pgErr.Code)
+	require.Nil(t, psd)
+
+	faultyConn.HandleFrontendMessage = nil
+
+	_, err = conn.Exec(ctx, "set statement_timeout = default")
+	require.NoError(t, err)
+
+	var existsOnServer bool
+	err = conn.QueryRow(
+		ctx,
+		"select exists(select 1 from pg_prepared_statements where name = $1)",
+		// Avoid using the prepared statement cache or it will clear the broken statement before we can check for its
+		// existence.
+		pgx.QueryExecModeExec,
+		psName,
+	).Scan(&existsOnServer)
+	require.NoError(t, err)
+	require.True(t, existsOnServer)
+
+	psd, err = conn.Prepare(ctx, sql, sql)
 	require.NoError(t, err)
 	require.NotNil(t, psd)
 }


### PR DESCRIPTION
Fixes #2640

database/sql (and GORM with `PrepareStmt: true`) end up calling `Prepare(ctx, sql, sql)`. In that path the server-side statement is named `stmt_<digest>` but the client keys it by the SQL text. When a prepare failed during Describe, the cleanup remembered the client key and later deallocated by it, i.e. it sent Close for a name that never existed. So the real `stmt_<digest>` stayed on the server, retrying the same SQL on that connection hit 42P05 for the rest of its life, and the cleanup error could pop up on whatever query happened to prepare next on that pooled connection.

The first commit stores `psName` (what was actually sent in Parse) instead, so the Close hits the real statement. Named prepares are unaffected since `psName == psKey` there. The test is the digested-name variant of `TestPrepareHandlesTimeoutBetweenParseAndDescribe`, and like that test it checks `pg_prepared_statements` directly for the leaked statement.

While writing the test I noticed `PrepareError.ParseComplete` is never checked. If Parse itself failed (any syntax error, say) there is no statement on the server, but we would still schedule a deallocation: a wasted round trip at the start of the next Prepare, which can also fail and surface its error on an unrelated query. The second commit only schedules the cleanup when ParseComplete is true, with a test that verifies no Close message goes out in that case.

I saw #2642 already has the rename half of this. Since I filed the issue I wanted to put up the complete fix, with the ParseComplete part and the leak assertion included.

Tested against PostgreSQL 17: both new tests fail before their respective commit and pass after, and the full package and stdlib suites pass.

I also reproduced the incident that led to the issue through the same application stack where we hit it in production — GORM with `PrepareStmt: true` over stdlib, single pooled connection, prepare killed by `statement_timeout` between Parse and Describe. On v5.10.0 the connection is poisoned: every retry of that query returns 42P05 for the connection's remaining life. On this branch the first retry succeeds and the connection recovers.
