### PR TITLE
fix: deallocate failed prepare by server-side statement name

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -360,7 +360,11 @@ func (c *Conn) Prepare(ctx context.Context, name, sql string) (sd *pgconn.Statem
 	if err != nil {
 		var pErr *pgconn.PrepareError
 		if errors.As(err, &pErr) {
-			c.failedDescribeStatement = psKey
+			// The statement may have been created on the server under psName. Store psName (not psKey) so the
+			// deferred Deallocate sends the Close for the name the server actually knows. With psKey, the digest
+			// name==sql path would deallocate the SQL text, leak the statement, and permanently poison this
+			// connection with 42P05 on any retry of the same sql. See https://github.com/jackc/pgx/issues/2640.
+			c.failedDescribeStatement = psName
 		}
 		return nil, err
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -3,7 +3,9 @@ package pgx_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"io"
 	"net"
 	"os"
@@ -528,6 +530,76 @@ func TestPrepareHandlesTimeoutBetweenParseAndDescribe(t *testing.T) {
 	require.True(t, existsOnServer)
 
 	psd, err = conn.Prepare(ctx, "test", "select $1::varchar")
+	require.NoError(t, err)
+	require.NotNil(t, psd)
+}
+
+// https://github.com/jackc/pgx/issues/2640
+// When name == sql the statement is created on the server under a digest name (stmt_<sha256>). The deferred cleanup of
+// a failed prepare must deallocate that server-side name; dealing the SQL text instead leaks the statement and every
+// retry of the same sql on this connection fails with 42P05 duplicate_prepared_statement.
+func TestPrepareHandlesTimeoutBetweenParseAndDescribeWhenNameEqualsSQL(t *testing.T) {
+	// Not parallel because it is a timing sensitive test.
+
+	config, err := pgx.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+
+	var faultyConn *faultyconn.Conn
+	config.AfterNetConnect = func(ctx context.Context, config *pgconn.Config, conn net.Conn) (net.Conn, error) {
+		faultyConn = faultyconn.New(conn)
+		return faultyConn, nil
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.ConnectConfig(ctx, config)
+	require.NoError(t, err)
+	defer closeConn(t, conn)
+	require.NotNil(t, faultyConn)
+
+	pgxtest.SkipCockroachDB(t, conn, "Induced error does not occur on CockroachDB")
+
+	_, err = conn.Exec(ctx, "set statement_timeout = '100ms'")
+	require.NoError(t, err)
+
+	faultyConn.HandleFrontendMessage = func(backendWriter io.Writer, msg pgproto3.FrontendMessage) error {
+		if _, ok := msg.(*pgproto3.Describe); ok {
+			time.Sleep(200 * time.Millisecond)
+		}
+		buf, err := msg.Encode(nil)
+		if err != nil {
+			return err
+		}
+		_, err = backendWriter.Write(buf)
+		return err
+	}
+
+	sql := "select $1::varchar"
+	digest := sha256.Sum256([]byte(sql))
+	psName := "stmt_" + hex.EncodeToString(digest[0:24])
+
+	psd, err := conn.Prepare(ctx, sql, sql)
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	require.Equal(t, "57014", pgErr.Code)
+	require.Nil(t, psd)
+
+	faultyConn.HandleFrontendMessage = nil
+
+	_, err = conn.Exec(ctx, "set statement_timeout = default")
+	require.NoError(t, err)
+
+	var existsOnServer bool
+	err = conn.QueryRow(
+		ctx,
+		"select exists(select 1 from pg_prepared_statements where name = '"+psName+"')",
+		// Avoid using the prepared statement cache or it will clear the broken statement before we can check for its
+		// existence.
+		pgx.QueryExecModeExec,
+	).Scan(&existsOnServer)
+	require.NoError(t, err)
+	require.True(t, existsOnServer)
+
+	psd, err = conn.Prepare(ctx, sql, sql)
 	require.NoError(t, err)
 	require.NotNil(t, psd)
 }


### PR DESCRIPTION
## Problem

When a prepare fails after `ParseComplete` (e.g. a `statement_timeout` or `pg_cancel_backend` landing between Parse and Describe), the statement has already been created on the server under the digest name `stmt_<sha256>`. The deferred cleanup introduced in 5.8.0 for #2223 stores `psKey` — the SQL text — instead of `psName`, so `Conn.Deallocate` looks it up in `c.preparedStatements`, finds nothing (a failed prepare was never stored there), and falls through to sending the `Close` protocol message with **the full SQL text as the statement name**. No statement by that name exists, closing one is not an error, so the cleanup "succeeds" while deallocating nothing.

This is invisible through the `pgx.Conn` API (callers pass `name != sql` there), but it is the default path for `stdlib.Conn.PrepareContext`, which calls `c.conn.Prepare(ctx, query, query)` — as used by GORM with `PrepareStmt: true`. On such a connection the server-side `stmt_<digest>` leaks, and every retry of the same SQL fails with `42P05 duplicate_prepared_statement` — which is itself a `PrepareError`, so `failedDescribeStatement` gets set again and the next cleanup no-ops again, poisoning the connection for its remaining lifetime. That is precisely the failure class the #2223 fix was meant to close, still reachable through the digest path.

## Fix

Store `psName` (the name the server actually knows) instead of `psKey`:

```go
if errors.As(err, &pErr) {
    c.failedDescribeStatement = psName
}
```

For the named path (`name != sql`), `psName == psKey`, so behavior there is unchanged. For the digest path, the deferred `Deallocate` now sends `Close` for `stmt_<digest>`, which removes the leaked statement and lets the retry succeed. If the failure happened before `ParseComplete`, no statement exists and the `Close` is a harmless no-op, as before.

## Test

`TestPrepareHandlesTimeoutBetweenParseAndDescribeWhenNameEqualsSQL` mirrors the existing #2223 test but goes through the digest path (`Prepare(ctx, sql, sql)`), using the `faultyconn` hook to induce the same deterministic timeout between Parse and Describe. It verifies the statement exists on the server under its digest name after the failed prepare, and that a retry of the same SQL succeeds.

On the previous code the test fails exactly as reported:

```
ERROR: prepared statement "stmt_91c32deb..." already exists (SQLSTATE 42P05)
```

With the fix it passes. Full `pgx` root package and `stdlib` test suites pass against PostgreSQL 17.

Fixes #2640
