### PR TITLE
Add Batch.BeginTx and BatchResults.Tx

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -62,6 +62,21 @@ func (qq *QueuedQuery) Exec(fn func(ct pgconn.CommandTag) error) {
 // unnecessary network round trips. A Batch must only be sent once.
 type Batch struct {
 	QueuedQueries []*QueuedQuery
+
+	txOptions *TxOptions
+}
+
+// BeginTx queues the query that begins a transaction with txOptions as the first query of b, saving the round trip that
+// [Conn.BeginTx] spends on it. It must be called before any query is queued and panics otherwise. Like any queued query,
+// the begin query has a result: it is the first result of the batch. The transaction is available from
+// [BatchResults.Tx] once b has been sent.
+func (b *Batch) BeginTx(txOptions TxOptions) {
+	if len(b.QueuedQueries) != 0 {
+		panic("Batch.BeginTx must be called before any query is queued")
+	}
+
+	b.Queue(txOptions.beginSQL())
+	b.txOptions = &txOptions
 }
 
 // Queue queues a query to batch b. query can be an SQL query or the name of a prepared statement. The only pgx option
@@ -113,6 +128,12 @@ type BatchResults interface {
 	// Close is safe to call multiple times. If it returns an error subsequent calls will return the same error. Callback
 	// functions will not be rerun.
 	Close() error
+
+	// Tx returns the transaction begun by [Batch.BeginTx], or nil if the batch did not begin one. It is available before
+	// Close is called so that a Rollback can be deferred as usual, but the transaction must not otherwise be used until
+	// Close has been called. If the batch fails before the transaction is begun, the transaction is closed by the time
+	// Close returns, and its methods return an error where errors.Is(ErrTxClosed) is true.
+	Tx() Tx
 }
 
 type batchResults struct {
@@ -259,6 +280,10 @@ func (br *batchResults) Close() error {
 	}
 
 	return br.err
+}
+
+func (br *batchResults) Tx() Tx {
+	return nil
 }
 
 func (br *batchResults) earlyError() error {
@@ -434,6 +459,10 @@ func (br *pipelineBatchResults) Close() error {
 	return br.err
 }
 
+func (br *pipelineBatchResults) Tx() Tx {
+	return nil
+}
+
 func (br *pipelineBatchResults) earlyError() error {
 	return br.err
 }
@@ -489,6 +518,50 @@ func (br *emptyBatchResults) QueryRow() Row {
 func (br *emptyBatchResults) Close() error {
 	br.closed = true
 	return nil
+}
+
+func (br *emptyBatchResults) Tx() Tx {
+	return nil
+}
+
+// txBatchResults are the results of a batch that begins a transaction with [Batch.BeginTx].
+type txBatchResults struct {
+	BatchResults
+	tx     *dbTx
+	closed bool
+	err    error
+}
+
+func (br *txBatchResults) Tx() Tx {
+	return br.tx
+}
+
+// Close closes the batch and, when that leaves the connection outside a transaction because the begin query failed or
+// the batch was never sent, the transaction as well. Only the first call does this: once the transaction has been
+// committed or rolled back the connection may already be in use elsewhere and must not be touched.
+func (br *txBatchResults) Close() error {
+	if br.closed {
+		return br.err
+	}
+	br.closed = true
+
+	br.err = br.BatchResults.Close()
+	if br.tx.conn.PgConn().TxStatus() == 'I' {
+		br.tx.closed = true
+	}
+	return br.err
+}
+
+// FailedBatchResults returns [BatchResults] for b that report err from every method, as if sending b had failed before
+// anything reached the server. It is for code that wraps [Conn.SendBatch] and can fail before it has a connection to
+// send b on, such as a connection pool. If b began a transaction with [Batch.BeginTx], Tx returns a closed transaction.
+func FailedBatchResults(b *Batch, err error) BatchResults {
+	br := &batchResults{err: err}
+	if b.txOptions == nil {
+		return br
+	}
+
+	return &txBatchResults{BatchResults: br, tx: &dbTx{closed: true}, closed: true, err: err}
 }
 
 // invalidates statement and description caches on batch results error

--- a/batch_tx_test.go
+++ b/batch_tx_test.go
@@ -1,0 +1,305 @@
+package pgx_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnSendBatchBeginTx(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		mustExec(t, conn, "create temporary table batch_tx(id integer primary key)")
+
+		batch := &pgx.Batch{}
+		batch.BeginTx(pgx.TxOptions{})
+		batch.Queue("insert into batch_tx(id) values ($1)", 1)
+
+		br := conn.SendBatch(ctx, batch)
+		tx := br.Tx()
+		require.NotNil(t, tx)
+		defer tx.Rollback(ctx)
+
+		require.NoError(t, br.Close())
+		require.Same(t, tx, br.Tx())
+		require.EqualValues(t, 'T', conn.PgConn().TxStatus())
+
+		_, err := tx.Exec(ctx, "insert into batch_tx(id) values ($1)", 2)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit(ctx))
+		require.ErrorIs(t, tx.Rollback(ctx), pgx.ErrTxClosed)
+
+		var n int64
+		require.NoError(t, conn.QueryRow(ctx, "select count(*) from batch_tx").Scan(&n))
+		require.EqualValues(t, 2, n)
+	})
+}
+
+func TestConnSendBatchBeginTxIsFirstResult(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		batch := &pgx.Batch{}
+		batch.BeginTx(pgx.TxOptions{})
+		batch.Queue("select 1")
+
+		br := conn.SendBatch(ctx, batch)
+		defer br.Tx().Rollback(ctx)
+
+		ct, err := br.Exec()
+		require.NoError(t, err)
+		require.Equal(t, "BEGIN", ct.String())
+
+		var n int32
+		require.NoError(t, br.QueryRow().Scan(&n))
+		require.EqualValues(t, 1, n)
+
+		require.NoError(t, br.Close())
+	})
+}
+
+func TestConnSendBatchBeginTxOptions(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		pgxtest.SkipCockroachDB(t, conn, "Server does not support all transaction modes")
+
+		batch := &pgx.Batch{}
+		batch.BeginTx(pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
+		batch.Queue("select current_setting('transaction_isolation'), current_setting('transaction_read_only')")
+
+		br := conn.SendBatch(ctx, batch)
+		defer br.Tx().Rollback(ctx)
+
+		_, err := br.Exec()
+		require.NoError(t, err)
+
+		var isoLevel, readOnly string
+		require.NoError(t, br.QueryRow().Scan(&isoLevel, &readOnly))
+		require.NoError(t, br.Close())
+		require.Equal(t, string(pgx.RepeatableRead), isoLevel)
+		require.Equal(t, "on", readOnly)
+	})
+}
+
+func TestConnSendBatchBeginTxCommitQuery(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		pgxtest.SkipCockroachDB(t, conn, "Server does not support COMMIT AND CHAIN")
+
+		batch := &pgx.Batch{}
+		batch.BeginTx(pgx.TxOptions{CommitQuery: "commit and chain"})
+		batch.Queue("select 1")
+
+		br := conn.SendBatch(ctx, batch)
+		require.NoError(t, br.Close())
+		require.NoError(t, br.Tx().Commit(ctx))
+
+		// COMMIT AND CHAIN leaves the connection in a new transaction, which proves the configured commit query ran.
+		require.EqualValues(t, 'T', conn.PgConn().TxStatus())
+		mustExec(t, conn, "rollback")
+	})
+}
+
+func TestConnSendBatchBeginTxQueryError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		batch := &pgx.Batch{}
+		batch.BeginTx(pgx.TxOptions{})
+		batch.Queue("select 1/0")
+
+		br := conn.SendBatch(ctx, batch)
+		tx := br.Tx()
+
+		var pgErr *pgconn.PgError
+		require.ErrorAs(t, br.Close(), &pgErr)
+		require.EqualValues(t, 'E', conn.PgConn().TxStatus())
+
+		require.NoError(t, tx.Rollback(ctx))
+		require.EqualValues(t, 'I', conn.PgConn().TxStatus())
+	})
+}
+
+func TestConnSendBatchBeginTxBeginError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		batch := &pgx.Batch{}
+		batch.BeginTx(pgx.TxOptions{BeginQuery: "begin garbage"})
+		batch.Queue("select 1")
+
+		br := conn.SendBatch(ctx, batch)
+		tx := br.Tx()
+		require.NotNil(t, tx)
+
+		var pgErr *pgconn.PgError
+		require.ErrorAs(t, br.Close(), &pgErr)
+		require.EqualValues(t, 'I', conn.PgConn().TxStatus())
+
+		// No transaction was begun, so the Tx is closed instead of sending a rollback that has nothing to roll back.
+		require.ErrorIs(t, tx.Rollback(ctx), pgx.ErrTxClosed)
+		require.ErrorIs(t, tx.Commit(ctx), pgx.ErrTxClosed)
+
+		var n int32
+		require.NoError(t, conn.QueryRow(ctx, "select 1").Scan(&n))
+	})
+}
+
+type errQueryRewriter struct{}
+
+func (errQueryRewriter) RewriteQuery(ctx context.Context, conn *pgx.Conn, sql string, args []any) (string, []any, error) {
+	return "", nil, errors.New("rewrite failed")
+}
+
+func TestConnSendBatchBeginTxNotSent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, defaultConnTestRunner, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		batch := &pgx.Batch{}
+		batch.BeginTx(pgx.TxOptions{})
+		batch.Queue("select 1", errQueryRewriter{})
+
+		br := conn.SendBatch(ctx, batch)
+		tx := br.Tx()
+		require.NotNil(t, tx)
+
+		require.ErrorContains(t, br.Close(), "rewrite failed")
+		require.ErrorIs(t, tx.Rollback(ctx), pgx.ErrTxClosed)
+
+		var n int32
+		require.NoError(t, conn.QueryRow(ctx, "select 1").Scan(&n))
+	})
+}
+
+func TestConnSendBatchTxIsNilWithoutBeginTx(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	batch := &pgx.Batch{}
+	batch.Queue("select 1")
+	br := conn.SendBatch(ctx, batch)
+	require.Nil(t, br.Tx())
+	require.NoError(t, br.Close())
+
+	require.Nil(t, conn.SendBatch(ctx, &pgx.Batch{}).Tx())
+}
+
+func TestBatchBeginTxMustBeFirst(t *testing.T) {
+	t.Parallel()
+
+	batch := &pgx.Batch{}
+	batch.Queue("select 1")
+	require.Panics(t, func() { batch.BeginTx(pgx.TxOptions{}) })
+
+	batch = &pgx.Batch{}
+	batch.BeginTx(pgx.TxOptions{})
+	require.Panics(t, func() { batch.BeginTx(pgx.TxOptions{}) })
+}
+
+func TestTxSendBatchRejectsBeginTx(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	conn := mustConnectString(t, os.Getenv("PGX_TEST_DATABASE"))
+	defer closeConn(t, conn)
+
+	tx, err := conn.Begin(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback(ctx)
+
+	batch := &pgx.Batch{}
+	batch.BeginTx(pgx.TxOptions{})
+	batch.Queue("select 1")
+
+	br := tx.SendBatch(ctx, batch)
+	require.Error(t, br.Close())
+	require.ErrorIs(t, br.Tx().Rollback(ctx), pgx.ErrTxClosed)
+
+	nested, err := tx.Begin(ctx)
+	require.NoError(t, err)
+	br = nested.SendBatch(ctx, batch)
+	require.Error(t, br.Close())
+	require.ErrorIs(t, br.Tx().Rollback(ctx), pgx.ErrTxClosed)
+
+	// The outer transaction is unaffected.
+	var n int32
+	require.NoError(t, tx.QueryRow(ctx, "select 1").Scan(&n))
+	require.EqualValues(t, 'T', conn.PgConn().TxStatus())
+
+	// A batch that begins a transaction is refused on a closed transaction the same way.
+	require.NoError(t, tx.Rollback(ctx))
+	br = tx.SendBatch(ctx, batch)
+	require.ErrorIs(t, br.Close(), pgx.ErrTxClosed)
+	require.ErrorIs(t, br.Tx().Commit(ctx), pgx.ErrTxClosed)
+}
+
+func TestFailedBatchResults(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	failure := errors.New("failure")
+
+	batch := &pgx.Batch{}
+	batch.Queue("select 1")
+	br := pgx.FailedBatchResults(batch, failure)
+	_, err := br.Exec()
+	require.ErrorIs(t, err, failure)
+	_, err = br.Query()
+	require.ErrorIs(t, err, failure)
+	require.ErrorIs(t, br.QueryRow().Scan(new(int32)), failure)
+	require.ErrorIs(t, br.Close(), failure)
+	require.ErrorIs(t, br.Close(), failure)
+	require.Nil(t, br.Tx())
+
+	batch = &pgx.Batch{}
+	batch.BeginTx(pgx.TxOptions{})
+	batch.Queue("select 1")
+	br = pgx.FailedBatchResults(batch, failure)
+	require.ErrorIs(t, br.Close(), failure)
+
+	tx := br.Tx()
+	require.NotNil(t, tx)
+	require.ErrorIs(t, tx.Rollback(ctx), pgx.ErrTxClosed)
+	require.ErrorIs(t, tx.Commit(ctx), pgx.ErrTxClosed)
+	lo := tx.LargeObjects()
+	_, err = lo.Create(ctx, 0)
+	require.ErrorIs(t, err, pgx.ErrTxClosed)
+}

--- a/conn.go
+++ b/conn.go
@@ -943,12 +943,24 @@ func (c *Conn) QueryRow(ctx context.Context, sql string, args ...any) Row {
 }
 
 // SendBatch sends all queued queries to the server at once. All queries are run in an implicit transaction unless
-// explicit transaction control statements are executed. The returned [BatchResults] must be closed before the connection
-// is used again.
+// explicit transaction control statements are executed or the batch begins a transaction with [Batch.BeginTx]. The
+// returned [BatchResults] must be closed before the connection is used again.
 //
 // Depending on the QueryExecMode, all queries may be prepared before any are executed. This means that creating a table
 // and using it in a subsequent query in the same batch can fail.
-func (c *Conn) SendBatch(ctx context.Context, b *Batch) (br BatchResults) {
+func (c *Conn) SendBatch(ctx context.Context, b *Batch) BatchResults {
+	br := c.sendBatch(ctx, b)
+	if b.txOptions == nil {
+		return br
+	}
+
+	return &txBatchResults{
+		BatchResults: br,
+		tx:           &dbTx{conn: c, commitQuery: b.txOptions.CommitQuery},
+	}
+}
+
+func (c *Conn) sendBatch(ctx context.Context, b *Batch) (br BatchResults) {
 	if len(b.QueuedQueries) == 0 {
 		return &emptyBatchResults{conn: c}
 	}

--- a/pgxpool/batch_results.go
+++ b/pgxpool/batch_results.go
@@ -5,29 +5,10 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-type errBatchResults struct {
-	err error
-}
-
-func (br errBatchResults) Exec() (pgconn.CommandTag, error) {
-	return pgconn.CommandTag{}, br.err
-}
-
-func (br errBatchResults) Query() (pgx.Rows, error) {
-	return errRows{err: br.err}, br.err
-}
-
-func (br errBatchResults) QueryRow() pgx.Row {
-	return errRow{err: br.err}
-}
-
-func (br errBatchResults) Close() error {
-	return br.err
-}
-
 type poolBatchResults struct {
 	br pgx.BatchResults
 	c  *Conn
+	tx *Tx // owns c instead when the batch began a transaction
 }
 
 func (br *poolBatchResults) Exec() (pgconn.CommandTag, error) {
@@ -49,4 +30,11 @@ func (br *poolBatchResults) Close() error {
 		br.c = nil
 	}
 	return err
+}
+
+func (br *poolBatchResults) Tx() pgx.Tx {
+	if br.tx == nil {
+		return nil
+	}
+	return br.tx
 }

--- a/pgxpool/batch_results_test.go
+++ b/pgxpool/batch_results_test.go
@@ -1,0 +1,220 @@
+package pgxpool_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolSendBatchBeginTx(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	defer pool.Close()
+
+	batch := &pgx.Batch{}
+	batch.BeginTx(pgx.TxOptions{})
+	batch.Queue("select 1")
+
+	br := pool.SendBatch(ctx, batch)
+	tx := br.Tx()
+	require.NotNil(t, tx)
+	defer tx.Rollback(ctx)
+	require.NoError(t, br.Close())
+
+	// Close leaves the connection acquired for the transaction.
+	require.EqualValues(t, 1, pool.Stat().AcquiredConns())
+
+	var n int32
+	require.NoError(t, tx.QueryRow(ctx, "select 2").Scan(&n))
+	require.EqualValues(t, 2, n)
+
+	require.NoError(t, tx.Commit(ctx))
+	waitForReleaseToComplete()
+	require.EqualValues(t, 0, pool.Stat().AcquiredConns())
+	require.EqualValues(t, 1, pool.Stat().TotalConns())
+}
+
+func TestPoolSendBatchBeginTxRollbackAfterQueryError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	defer pool.Close()
+
+	batch := &pgx.Batch{}
+	batch.BeginTx(pgx.TxOptions{})
+	batch.Queue("select 1/0")
+
+	br := pool.SendBatch(ctx, batch)
+	tx := br.Tx()
+	require.Error(t, br.Close())
+	require.EqualValues(t, 1, pool.Stat().AcquiredConns())
+
+	require.NoError(t, tx.Rollback(ctx))
+	waitForReleaseToComplete()
+	require.EqualValues(t, 0, pool.Stat().AcquiredConns())
+	require.EqualValues(t, 1, pool.Stat().TotalConns())
+}
+
+func TestPoolSendBatchBeginTxReleasesConnWhenBeginFails(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	defer pool.Close()
+
+	batch := &pgx.Batch{}
+	batch.BeginTx(pgx.TxOptions{BeginQuery: "begin garbage"})
+	batch.Queue("select 1")
+
+	br := pool.SendBatch(ctx, batch)
+	tx := br.Tx()
+	require.Error(t, br.Close())
+
+	// The transaction never began, so it is already closed, but rolling it back still releases the connection.
+	require.ErrorIs(t, tx.Rollback(ctx), pgx.ErrTxClosed)
+	waitForReleaseToComplete()
+	require.EqualValues(t, 0, pool.Stat().AcquiredConns())
+	require.EqualValues(t, 1, pool.Stat().TotalConns())
+}
+
+func TestPoolSendBatchTxIsNilWithoutBeginTx(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	defer pool.Close()
+
+	batch := &pgx.Batch{}
+	batch.Queue("select 1")
+
+	br := pool.SendBatch(ctx, batch)
+	require.Nil(t, br.Tx())
+	require.NoError(t, br.Close())
+	waitForReleaseToComplete()
+	require.EqualValues(t, 0, pool.Stat().AcquiredConns())
+
+	pool.Close()
+	require.Nil(t, pool.SendBatch(ctx, batch).Tx())
+}
+
+func TestConnSendBatchBeginTx(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	defer pool.Close()
+
+	c, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	defer c.Release()
+
+	batch := &pgx.Batch{}
+	batch.BeginTx(pgx.TxOptions{})
+	batch.Queue("select 1")
+
+	br := c.SendBatch(ctx, batch)
+	tx := br.Tx()
+	require.NotNil(t, tx)
+	require.NoError(t, br.Close())
+	require.EqualValues(t, 'T', c.Conn().PgConn().TxStatus())
+	require.NoError(t, tx.Commit(ctx))
+
+	// The caller still owns the connection: committing the transaction does not release it.
+	require.EqualValues(t, 1, pool.Stat().AcquiredConns())
+}
+
+func TestPoolSendBatchBeginTxCloseAgainAfterCommit(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	config, err := pgxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	config.MaxConns = 1
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	batch := &pgx.Batch{}
+	batch.BeginTx(pgx.TxOptions{})
+	batch.Queue("select 1")
+
+	br := pool.SendBatch(ctx, batch)
+	require.NoError(t, br.Close())
+	require.NoError(t, br.Tx().Commit(ctx))
+
+	// The only connection is back in the pool and in use by another goroutine. Closing the results again, as a
+	// deferred Close does, must not touch it. The race detector catches a violation.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 50 {
+			_, err := pool.Exec(ctx, "select 1")
+			assert.NoError(t, err)
+		}
+	}()
+	for range 50 {
+		require.NoError(t, br.Close())
+	}
+	<-done
+}
+
+func TestPoolSendBatchBeginTxAcquireError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	config, err := pgxpool.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+	require.NoError(t, err)
+	config.MaxConns = 1
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// Hold the only connection so that SendBatch cannot acquire one.
+	c, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	defer c.Release()
+
+	batch := &pgx.Batch{}
+	batch.BeginTx(pgx.TxOptions{})
+	batch.Queue("select 1")
+
+	acquireCtx, cancelAcquire := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancelAcquire()
+	br := pool.SendBatch(acquireCtx, batch)
+
+	// The transaction handle exists but is closed, so the usual deferred Rollback is safe.
+	tx := br.Tx()
+	require.NotNil(t, tx)
+	require.ErrorIs(t, tx.Rollback(ctx), pgx.ErrTxClosed)
+	require.ErrorIs(t, br.Close(), context.DeadlineExceeded)
+}

--- a/pgxpool/pool.go
+++ b/pgxpool/pool.go
@@ -798,13 +798,20 @@ func (p *Pool) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
 	return c.getPoolRow(row)
 }
 
+// SendBatch acquires a connection from the Pool and sends the batch on it. The connection is released when the returned
+// [pgx.BatchResults] is closed, unless the batch begins a transaction with [pgx.Batch.BeginTx]: then it is released when
+// the transaction returned by [pgx.BatchResults.Tx] is committed or rolled back.
 func (p *Pool) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
 	c, err := p.Acquire(ctx)
 	if err != nil {
-		return errBatchResults{err: err}
+		return pgx.FailedBatchResults(b, err)
 	}
 
 	br := c.SendBatch(ctx, b)
+	if tx := br.Tx(); tx != nil {
+		return &poolBatchResults{br: br, tx: &Tx{t: tx, c: c}}
+	}
+
 	return &poolBatchResults{br: br, c: c}
 }
 

--- a/tx.go
+++ b/tx.go
@@ -280,7 +280,10 @@ func (tx *dbTx) CopyFrom(ctx context.Context, tableName Identifier, columnNames 
 // SendBatch delegates to the underlying *Conn
 func (tx *dbTx) SendBatch(ctx context.Context, b *Batch) BatchResults {
 	if tx.closed {
-		return &batchResults{err: ErrTxClosed}
+		return FailedBatchResults(b, ErrTxClosed)
+	}
+	if b.txOptions != nil {
+		return FailedBatchResults(b, errors.New("Batch.BeginTx cannot be used within a transaction"))
 	}
 
 	return tx.conn.SendBatch(ctx, b)
@@ -382,7 +385,7 @@ func (sp *dbSimulatedNestedTx) CopyFrom(ctx context.Context, tableName Identifie
 // SendBatch delegates to the underlying *Conn
 func (sp *dbSimulatedNestedTx) SendBatch(ctx context.Context, b *Batch) BatchResults {
 	if sp.closed {
-		return &batchResults{err: ErrTxClosed}
+		return FailedBatchResults(b, ErrTxClosed)
 	}
 
 	return sp.tx.SendBatch(ctx, b)


### PR DESCRIPTION
Implements the interface suggested in https://github.com/jackc/pgx/issues/1667#issuecomment-5574730641. Supersedes #2637.

## What this adds

```go
// BeginTx queues the query that begins a transaction with txOptions as the first
// query of b. It must be called before any query is queued.
func (b *Batch) BeginTx(txOptions TxOptions)

// Tx returns the transaction begun by Batch.BeginTx, or nil if the batch did not
// begin one.
func (BatchResults) Tx() Tx
```

```go
b := &pgx.Batch{}
b.BeginTx(pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
b.Queue(fenceCheck, shardID, fenceID).QueryRow(func(row pgx.Row) error { return row.Scan(new(int)) })

br := pool.SendBatch(ctx, b)
tx := br.Tx()
defer tx.Rollback(ctx)
if err := br.Close(); err != nil {
	return err
}
// ... the rest of the unit of work on tx ...
return tx.Commit(ctx)
```

## Design notes

Points that go beyond the sketch in the issue, each covered by a test:

* **`Tx()` is available before `Close`**, so `defer tx.Rollback(ctx)` works exactly as with `Conn.BeginTx`. The transaction must not otherwise be used until `Close` has been called; doing so fails with the usual conn busy error rather than corrupting the connection.
* **A failed begin leaves a closed `Tx`.** After `Close`, if the connection is not in a transaction because the begin query failed or the batch was never sent, the `Tx` is closed and `Rollback`/`Commit` return `ErrTxClosed`. Without this, `Commit` after a failed begin would return nil, since PostgreSQL answers a stray `COMMIT` with a warning and a `COMMIT` tag. A failing later statement leaves the connection in a failed transaction and the `Tx` open, so `Rollback` works as usual.
* **`Pool.SendBatch` hands the connection to the `Tx`.** `poolBatchResults.Close` releases the connection today, and `Conn.Release` destroys a connection that is inside a transaction. For a batch that began a transaction the connection is now released when the `Tx` is committed or rolled back, including when that `Tx` is already closed. `pgxpool.Conn.SendBatch` is unchanged: the caller owns the connection.
* **`Tx.SendBatch` rejects a batch that begins a transaction**, since otherwise two `Tx` values would refer to one server transaction. Easy to drop if you would rather leave this to the server's warning.
* **The begin query is an ordinary queued query.** Its result is the first result of the batch, so positional `br.Exec()`/`br.Query()` callers see it. Callbacks and `Close` are unaffected.
* `Batch.BeginTx` panics when a query is already queued.

`Conn.SendBatch` wraps the existing results in a small `txBatchResults` when the batch began a transaction; none of the per-`QueryExecMode` paths changed.

## Compatibility

`Tx()` is added to the `BatchResults` interface, as anticipated in the issue. Custom implementations, including mocks, must add it. The in-tree implementations in `pgxpool` are updated.

## Not included

The commit side. Queuing `commit` as the last query of a batch sent on the `Tx` already leaves `Tx()` closed after `Close`, so a deferred `Rollback` costs nothing, but `ErrTxCommitRollback` detection and a `Batch` API for it deserve their own change.

## Testing

New tests in `batch_tx_test.go` and `pgxpool/batch_results_test.go` cover commit, rollback, transaction options, a custom commit query, a failing statement after begin, a failing begin, a batch that is never sent, positional results, the panic, the `Tx.SendBatch` guard, and pool connection ownership in the success, failure and failed-begin paths. They run across all `QueryExecMode`s and pass against PostgreSQL 14, 16 and 17 and CockroachDB. The full suite passes against PostgreSQL 17.

## AI disclosure

Per CONTRIBUTING.md: this change was developed with AI assistance (Claude Code, Fable 5.1), including the review of the suggested interface, the implementation and the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
