### PR TITLE
Add ReadStartTime to TraceBatchQueryData for per-query timing

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -137,6 +138,8 @@ func (br *batchResults) Exec() (pgconn.CommandTag, error) {
 
 	query, arguments, _ := br.nextQueryAndArgs()
 
+	readStartTime := time.Now()
+
 	if !br.mrr.NextResult() {
 		err := br.mrr.Close()
 		if err == nil {
@@ -144,9 +147,10 @@ func (br *batchResults) Exec() (pgconn.CommandTag, error) {
 		}
 		if br.conn.batchTracer != nil {
 			br.conn.batchTracer.TraceBatchQuery(br.ctx, br.conn, TraceBatchQueryData{
-				SQL:  query,
-				Args: arguments,
-				Err:  err,
+				SQL:           query,
+				Args:          arguments,
+				Err:           err,
+				ReadStartTime: readStartTime,
 			})
 		}
 		return pgconn.CommandTag{}, err
@@ -160,10 +164,11 @@ func (br *batchResults) Exec() (pgconn.CommandTag, error) {
 
 	if br.conn.batchTracer != nil {
 		br.conn.batchTracer.TraceBatchQuery(br.ctx, br.conn, TraceBatchQueryData{
-			SQL:        query,
-			Args:       arguments,
-			CommandTag: commandTag,
-			Err:        br.err,
+			SQL:           query,
+			Args:          arguments,
+			CommandTag:    commandTag,
+			Err:           br.err,
+			ReadStartTime: readStartTime,
 		})
 	}
 
@@ -198,9 +203,10 @@ func (br *batchResults) Query() (Rows, error) {
 
 		if br.conn.batchTracer != nil {
 			br.conn.batchTracer.TraceBatchQuery(br.ctx, br.conn, TraceBatchQueryData{
-				SQL:  query,
-				Args: arguments,
-				Err:  rows.err,
+				SQL:           query,
+				Args:          arguments,
+				Err:           rows.err,
+				ReadStartTime: rows.startTime,
 			})
 		}
 
@@ -306,9 +312,19 @@ func (br *pipelineBatchResults) Exec() (pgconn.CommandTag, error) {
 		return pgconn.CommandTag{}, err
 	}
 
+	readStartTime := time.Now()
+
 	results, err := br.pipeline.GetResults()
 	if err != nil {
 		br.err = err
+		if br.conn.batchTracer != nil {
+			br.conn.batchTracer.TraceBatchQuery(br.ctx, br.conn, TraceBatchQueryData{
+				SQL:           query,
+				Args:          arguments,
+				Err:           br.err,
+				ReadStartTime: readStartTime,
+			})
+		}
 		return pgconn.CommandTag{}, br.err
 	}
 	var commandTag pgconn.CommandTag
@@ -316,15 +332,25 @@ func (br *pipelineBatchResults) Exec() (pgconn.CommandTag, error) {
 	case *pgconn.ResultReader:
 		commandTag, br.err = results.Close()
 	default:
-		return pgconn.CommandTag{}, fmt.Errorf("unexpected pipeline result: %T", results)
+		err = fmt.Errorf("unexpected pipeline result: %T", results)
+		if br.conn.batchTracer != nil {
+			br.conn.batchTracer.TraceBatchQuery(br.ctx, br.conn, TraceBatchQueryData{
+				SQL:           query,
+				Args:          arguments,
+				Err:           err,
+				ReadStartTime: readStartTime,
+			})
+		}
+		return pgconn.CommandTag{}, err
 	}
 
 	if br.conn.batchTracer != nil {
 		br.conn.batchTracer.TraceBatchQuery(br.ctx, br.conn, TraceBatchQueryData{
-			SQL:        query,
-			Args:       arguments,
-			CommandTag: commandTag,
-			Err:        br.err,
+			SQL:           query,
+			Args:          arguments,
+			CommandTag:    commandTag,
+			Err:           br.err,
+			ReadStartTime: readStartTime,
 		})
 	}
 
@@ -364,9 +390,10 @@ func (br *pipelineBatchResults) Query() (Rows, error) {
 
 		if br.conn.batchTracer != nil {
 			br.conn.batchTracer.TraceBatchQuery(br.ctx, br.conn, TraceBatchQueryData{
-				SQL:  query,
-				Args: arguments,
-				Err:  err,
+				SQL:           query,
+				Args:          arguments,
+				Err:           err,
+				ReadStartTime: rows.startTime,
 			})
 		}
 	} else {
@@ -378,6 +405,15 @@ func (br *pipelineBatchResults) Query() (Rows, error) {
 			br.err = err
 			rows.err = err
 			rows.closed = true
+
+			if br.conn.batchTracer != nil {
+				br.conn.batchTracer.TraceBatchQuery(br.ctx, br.conn, TraceBatchQueryData{
+					SQL:           query,
+					Args:          arguments,
+					Err:           err,
+					ReadStartTime: rows.startTime,
+				})
+			}
 		}
 	}
 

--- a/rows.go
+++ b/rows.go
@@ -203,7 +203,7 @@ func (rows *baseRows) Close() {
 	}
 
 	if rows.batchTracer != nil {
-		rows.batchTracer.TraceBatchQuery(rows.ctx, rows.conn, TraceBatchQueryData{SQL: rows.sql, Args: rows.args, CommandTag: rows.commandTag, Err: rows.err})
+		rows.batchTracer.TraceBatchQuery(rows.ctx, rows.conn, TraceBatchQueryData{SQL: rows.sql, Args: rows.args, CommandTag: rows.commandTag, Err: rows.err, ReadStartTime: rows.startTime})
 	} else if rows.queryTracer != nil {
 		rows.queryTracer.TraceQueryEnd(rows.ctx, rows.conn, TraceQueryEndData{rows.commandTag, rows.err})
 	}

--- a/tracelog/tracelog.go
+++ b/tracelog/tracelog.go
@@ -209,15 +209,24 @@ func (tl *TraceLog) TraceBatchStart(ctx context.Context, conn *pgx.Conn, data pg
 }
 
 func (tl *TraceLog) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchQueryData) {
+	tl.ensureConfig()
+
+	// ReadStartTime is when pgx began reading this query's result, not when SendBatch was called, so this interval
+	// measures this query's own result consumption rather than its position in the batch.
+	var interval time.Duration
+	if !data.ReadStartTime.IsZero() {
+		interval = time.Since(data.ReadStartTime)
+	}
+
 	if data.Err != nil {
 		if tl.shouldLog(LogLevelError) {
-			tl.log(ctx, conn, LogLevelError, "BatchQuery", map[string]any{"sql": data.SQL, "args": logQueryArgs(data.Args), "err": data.Err})
+			tl.log(ctx, conn, LogLevelError, "BatchQuery", map[string]any{"sql": data.SQL, "args": logQueryArgs(data.Args), "err": data.Err, tl.Config.TimeKey: interval})
 		}
 		return
 	}
 
 	if tl.shouldLog(LogLevelInfo) {
-		tl.log(ctx, conn, LogLevelInfo, "BatchQuery", map[string]any{"sql": data.SQL, "args": logQueryArgs(data.Args), "commandTag": data.CommandTag.String()})
+		tl.log(ctx, conn, LogLevelInfo, "BatchQuery", map[string]any{"sql": data.SQL, "args": logQueryArgs(data.Args), tl.Config.TimeKey: interval, "commandTag": data.CommandTag.String()})
 	}
 }
 

--- a/tracer.go
+++ b/tracer.go
@@ -2,6 +2,7 @@ package pgx
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -44,6 +45,16 @@ type TraceBatchQueryData struct {
 	Args       []any
 	CommandTag pgconn.CommandTag
 	Err        error
+
+	// ReadStartTime is when pgx began reading this query's result from the server -- i.e. when it requested the next
+	// result in the batch, not when SendBatch was called or when this query's turn in the batch started.
+	//
+	// The interval from ReadStartTime to when TraceBatchQuery is called is not a pure network or server measurement.
+	// It excludes any time the query spent waiting for earlier queries in the batch to be consumed, but it does
+	// include network waits, server-side buffering, and -- for a query consumed via [QueuedQuery.Query] or
+	// [BatchResults.Query] -- however long the calling application takes to read and close the returned Rows, since
+	// TraceBatchQuery for that query is not called until Rows is closed.
+	ReadStartTime time.Time
 }
 
 type TraceBatchEndData struct {

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -422,10 +422,8 @@ func TestTraceBatchErrorWhileReadingResultsWhileClosing(t *testing.T) {
 	})
 }
 
-// TestTraceBatchQueryReadStartTime asserts that TraceBatchQueryData.ReadStartTime is populated for every execution
-// mode and consumption path (Exec, QueryRow, and Query followed by a deferred Rows.Close), and that it advances
-// monotonically across a batch. It also asserts that, for Query, TraceBatchQuery is not emitted until the returned
-// Rows is closed -- a pause while the application holds Rows open must not be excluded from the traced interval.
+// TestTraceBatchQueryReadStartTime checks that each result's timestamp excludes pauses before requesting it and
+// includes pauses while its Rows remains open, across all execution modes and consumption paths.
 func TestTraceBatchQueryReadStartTime(t *testing.T) {
 	t.Parallel()
 
@@ -442,42 +440,61 @@ func TestTraceBatchQueryReadStartTime(t *testing.T) {
 	defer cancel()
 
 	pgxtest.RunWithQueryExecModes(ctx, t, ctr, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
-		beforeSendBatch := time.Now()
-
 		var readStartTimes []time.Time
 		tracer.traceBatchQuery = func(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchQueryData) {
 			require.NoError(t, data.Err)
 			require.Falsef(t, data.ReadStartTime.IsZero(), "ReadStartTime must be populated")
-			require.Falsef(t, data.ReadStartTime.Before(beforeSendBatch), "ReadStartTime must not predate SendBatch")
 			readStartTimes = append(readStartTimes, data.ReadStartTime)
+		}
+		assertReadStartTime := func(index int, beforeRead, afterRead time.Time) {
+			t.Helper()
+			require.Falsef(t, readStartTimes[index].Before(beforeRead),
+				"query %d: ReadStartTime must exclude the pause before requesting the result", index)
+			require.Falsef(t, readStartTimes[index].After(afterRead),
+				"query %d: ReadStartTime must be captured before the result request returns", index)
 		}
 
 		batch := &pgx.Batch{}
 		batch.Queue(`select 1`)
 		batch.Queue(`select 2`)
 		batch.Queue(`select 3`)
+		batch.Queue(`select 4`)
 
-		br := conn.SendBatch(context.Background(), batch)
-
-		// Exec consumes the first query immediately; TraceBatchQuery fires before Exec returns.
-		_, err := br.Exec()
-		require.NoError(t, err)
-		require.Len(t, readStartTimes, 1)
+		br := conn.SendBatch(ctx, batch)
+		defer br.Close()
 
 		time.Sleep(5 * time.Millisecond)
 
-		// QueryRow consumes the second query immediately too.
+		// Exec consumes the first query immediately; TraceBatchQuery fires before Exec returns.
+		beforeRead := time.Now()
+		_, err := br.Exec()
+		afterRead := time.Now()
+		require.NoError(t, err)
+		require.Len(t, readStartTimes, 1)
+		assertReadStartTime(0, beforeRead, afterRead)
+
+		time.Sleep(5 * time.Millisecond)
+
+		// QueryRow starts reading before Scan; the interval must include a pause before Scan closes the Rows.
+		beforeRead = time.Now()
+		row := br.QueryRow()
+		afterRead = time.Now()
+		require.Len(t, readStartTimes, 1)
+		time.Sleep(5 * time.Millisecond)
 		var n int32
-		err = br.QueryRow().Scan(&n)
+		err = row.Scan(&n)
 		require.NoError(t, err)
 		require.EqualValues(t, 2, n)
 		require.Len(t, readStartTimes, 2)
+		assertReadStartTime(1, beforeRead, afterRead)
 
 		time.Sleep(5 * time.Millisecond)
 
 		// Query defers TraceBatchQuery until the returned Rows is closed: reading the row and pausing before Close
 		// must not produce a trace yet, even though pgx already began reading the third query's result.
+		beforeRead = time.Now()
 		rows, err := br.Query()
+		afterRead = time.Now()
 		require.NoError(t, err)
 		require.True(t, rows.Next())
 		require.NoError(t, rows.Scan(&n))
@@ -490,20 +507,16 @@ func TestTraceBatchQueryReadStartTime(t *testing.T) {
 		rows.Close()
 		require.NoError(t, rows.Err())
 		require.Len(t, readStartTimes, 3)
+		assertReadStartTime(2, beforeRead, afterRead)
 
+		// Close requests and drains the remaining result, excluding the pause before Close.
+		time.Sleep(5 * time.Millisecond)
+		beforeRead = time.Now()
 		err = br.Close()
+		afterRead = time.Now()
 		require.NoError(t, err)
-		afterClose := time.Now()
-
-		require.Len(t, readStartTimes, 3)
-		for _, readStartTime := range readStartTimes {
-			require.Falsef(t, readStartTime.After(afterClose), "ReadStartTime must not postdate the batch close")
-		}
-		for i := 1; i < len(readStartTimes); i++ {
-			require.Falsef(t, readStartTimes[i].Before(readStartTimes[i-1]),
-				"ReadStartTime must be monotonic across a batch: query %d (%v) is before query %d (%v)",
-				i, readStartTimes[i], i-1, readStartTimes[i-1])
-		}
+		require.Len(t, readStartTimes, 4)
+		assertReadStartTime(3, beforeRead, afterRead)
 	})
 }
 

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -2,10 +2,14 @@ package pgx_test
 
 import (
 	"context"
+	"net"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/internal/faultyconn"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxtest"
 	"github.com/stretchr/testify/require"
 )
@@ -415,6 +419,155 @@ func TestTraceBatchErrorWhileReadingResultsWhileClosing(t *testing.T) {
 		require.Error(t, err)
 		require.EqualValues(t, 2, traceBatchQueryCalledCount)
 		require.True(t, traceBatchEndCalled)
+	})
+}
+
+// TestTraceBatchQueryReadStartTime asserts that TraceBatchQueryData.ReadStartTime is populated for every execution
+// mode and consumption path (Exec, QueryRow, and Query followed by a deferred Rows.Close), and that it advances
+// monotonically across a batch. It also asserts that, for Query, TraceBatchQuery is not emitted until the returned
+// Rows is closed -- a pause while the application holds Rows open must not be excluded from the traced interval.
+func TestTraceBatchQueryReadStartTime(t *testing.T) {
+	t.Parallel()
+
+	tracer := &testTracer{}
+
+	ctr := defaultConnTestRunner
+	ctr.CreateConfig = func(ctx context.Context, t testing.TB) *pgx.ConnConfig {
+		config := defaultConnTestRunner.CreateConfig(ctx, t)
+		config.Tracer = tracer
+		return config
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	pgxtest.RunWithQueryExecModes(ctx, t, ctr, nil, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		beforeSendBatch := time.Now()
+
+		var readStartTimes []time.Time
+		tracer.traceBatchQuery = func(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchQueryData) {
+			require.NoError(t, data.Err)
+			require.Falsef(t, data.ReadStartTime.IsZero(), "ReadStartTime must be populated")
+			require.Falsef(t, data.ReadStartTime.Before(beforeSendBatch), "ReadStartTime must not predate SendBatch")
+			readStartTimes = append(readStartTimes, data.ReadStartTime)
+		}
+
+		batch := &pgx.Batch{}
+		batch.Queue(`select 1`)
+		batch.Queue(`select 2`)
+		batch.Queue(`select 3`)
+
+		br := conn.SendBatch(context.Background(), batch)
+
+		// Exec consumes the first query immediately; TraceBatchQuery fires before Exec returns.
+		_, err := br.Exec()
+		require.NoError(t, err)
+		require.Len(t, readStartTimes, 1)
+
+		time.Sleep(5 * time.Millisecond)
+
+		// QueryRow consumes the second query immediately too.
+		var n int32
+		err = br.QueryRow().Scan(&n)
+		require.NoError(t, err)
+		require.EqualValues(t, 2, n)
+		require.Len(t, readStartTimes, 2)
+
+		time.Sleep(5 * time.Millisecond)
+
+		// Query defers TraceBatchQuery until the returned Rows is closed: reading the row and pausing before Close
+		// must not produce a trace yet, even though pgx already began reading the third query's result.
+		rows, err := br.Query()
+		require.NoError(t, err)
+		require.True(t, rows.Next())
+		require.NoError(t, rows.Scan(&n))
+		require.EqualValues(t, 3, n)
+		// Deliberately do not drain to exhaustion (which would auto-close Rows); leave Rows open and pause, as an
+		// application processing a row would, then close explicitly.
+		require.Len(t, readStartTimes, 2, "TraceBatchQuery must not fire until Rows is closed")
+
+		time.Sleep(5 * time.Millisecond)
+		rows.Close()
+		require.NoError(t, rows.Err())
+		require.Len(t, readStartTimes, 3)
+
+		err = br.Close()
+		require.NoError(t, err)
+		afterClose := time.Now()
+
+		require.Len(t, readStartTimes, 3)
+		for _, readStartTime := range readStartTimes {
+			require.Falsef(t, readStartTime.After(afterClose), "ReadStartTime must not postdate the batch close")
+		}
+		for i := 1; i < len(readStartTimes); i++ {
+			require.Falsef(t, readStartTimes[i].Before(readStartTimes[i-1]),
+				"ReadStartTime must be monotonic across a batch: query %d (%v) is before query %d (%v)",
+				i, readStartTimes[i], i-1, readStartTimes[i-1])
+		}
+	})
+}
+
+// TestTraceBatchQueryTracesPipelineGetResultsError asserts that pipelineBatchResults.Exec emits TraceBatchQuery even
+// when the underlying pipeline.GetResults call itself fails -- e.g. because the context was canceled -- rather than
+// only when the query completes and returns a normal query error. Before this fix, that path returned silently
+// without ever calling TraceBatchQuery, leaving the query untraced.
+func TestTraceBatchQueryTracesPipelineGetResultsError(t *testing.T) {
+	// Not parallel because it deterministically kills the underlying connection.
+
+	tracer := &testTracer{}
+
+	var faultyConn *faultyconn.Conn
+	ctr := pgxtest.DefaultConnTestRunner()
+	ctr.CreateConfig = func(ctx context.Context, t testing.TB) *pgx.ConnConfig {
+		config, err := pgx.ParseConfig(os.Getenv("PGX_TEST_DATABASE"))
+		require.NoError(t, err)
+		config.Tracer = tracer
+		config.AfterNetConnect = func(ctx context.Context, config *pgconn.Config, conn net.Conn) (net.Conn, error) {
+			faultyConn = faultyconn.New(conn)
+			return faultyConn, nil
+		}
+		return config
+	}
+	// The test kills the connection deliberately, so a clean Close is not expected.
+	ctr.CloseConn = func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		_ = conn.Close(ctx)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Only extended-protocol modes route through pipelineBatchResults; QueryExecModeExec and
+	// QueryExecModeSimpleProtocol use batchResults instead, which already traced this error before this fix.
+	pipelineModes := []pgx.QueryExecMode{
+		pgx.QueryExecModeCacheStatement,
+		pgx.QueryExecModeCacheDescribe,
+		pgx.QueryExecModeDescribeExec,
+	}
+
+	pgxtest.RunWithQueryExecModes(ctx, t, ctr, pipelineModes, func(ctx context.Context, t testing.TB, conn *pgx.Conn) {
+		traceBatchQueryCalledCount := 0
+		var lastErr error
+		tracer.traceBatchQuery = func(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchQueryData) {
+			traceBatchQueryCalledCount++
+			lastErr = data.Err
+		}
+
+		batch := &pgx.Batch{}
+		batch.Queue(`select 1`)
+
+		br := conn.SendBatch(context.Background(), batch)
+
+		// Kill the connection before GetResults is called, so it fails at the client level (a read/protocol error),
+		// not with a normal PgError -- deterministically reproducing the path pipelineBatchResults.Exec used to
+		// return from without ever calling TraceBatchQuery.
+		require.NoError(t, faultyConn.Close())
+
+		_, err := br.Exec()
+		require.Error(t, err)
+		require.EqualValues(t, 1, traceBatchQueryCalledCount, "TraceBatchQuery must fire even when GetResults itself fails")
+		require.Error(t, lastErr)
+
+		br.Close()
 	})
 }
 


### PR DESCRIPTION
`TraceBatchQueryData` carries no timestamp, so a `BatchTracer` that wants a per-query duration has to guess from the next hook and ends up attributing a slow streaming query's time to the fast query before it (#2648). This adds `ReadStartTime`, set when pgx begins reading each query's result, which is the first and fourth of the suggestions in that thread.

**Change.**
- `tracer.go`: `TraceBatchQueryData.ReadStartTime time.Time`, documented as the moment pgx requested the next result in the batch, not when `SendBatch` was called; the interval up to the hook therefore includes network waits, buffering and any application processing while `Rows` stays open.
- `batch.go`: `batchResults` and `pipelineBatchResults` capture it right before `NextResult`/`GetResults` in `Exec` and `Query`, and pass it to every `TraceBatchQuery` call. The error returns in `pipelineBatchResults.Exec` (a `GetResults` error and an unexpected result type) and the unexpected-result branch of `pipelineBatchResults.Query` now call `TraceBatchQuery` like the non-pipelined paths already do; that was the third suggestion, checked against the code and found to be a real gap.
- `rows.go`: the deferred `baseRows.Close` trace passes `rows.startTime`, which `getRows` already sets at the same moment. The second suggestion needed no change for that reason.
- `tracelog/tracelog.go`: logs a per-query duration derived from the new field.

**Proof.** `TestTraceBatchQueryReadStartTime` checks the field is set, monotonic across a batch and bounded, for `Exec`, `QueryRow` and `Query` with a deferred close, across every `QueryExecMode`. `TestTraceBatchQueryTracesPipelineGetResultsError` kills the connection through `internal/faultyconn` right after `SendBatch` so `GetResults` fails deterministically, and asserts the trace fires. Both fail with their respective change reverted. `go build ./...`, `go vet`, `gofmt -l` clean; `go test -race -count=2` on the root package, `tracelog` and `multitracer` against PostgreSQL 16.

Per the AI section of CONTRIBUTING: this is an AI proposal. It was produced with an AI coding assistant under my direction from the issue thread and your comment on the four suggestions; the prompts asked for the endorsed first and fourth suggestions, a code check of the second and third, tests across all exec modes with the race detector, and the repo's gates. I have not yet reviewed every line myself, so please treat subtle points with that in mind.

Closes #2648

