### PR TITLE
pgtype: preserve delimiters inside multirange bounds

### DIFF
--- a/pgtype/multirange.go
+++ b/pgtype/multirange.go
@@ -378,21 +378,33 @@ parseValueLoop:
 func parseRange(buf *bytes.Buffer) (string, error) {
 	s := &bytes.Buffer{}
 
-	boundSepRead := false
+	inRange := false
+	inQuotes := false
+	escaped := false
 	for {
 		r, _, err := buf.ReadRune()
 		if err != nil {
 			return "", err
 		}
 
-		switch r {
-		case ',', '}':
-			if r == ',' && !boundSepRead {
-				boundSepRead = true
-				break
+		if escaped {
+			escaped = false
+		} else if r == '\\' {
+			escaped = true
+		} else if r == '"' {
+			inQuotes = !inQuotes
+		} else if !inQuotes {
+			switch r {
+			case '[', '(':
+				inRange = true
+			case ']', ')':
+				inRange = false
+			case ',', '}':
+				if !inRange {
+					buf.UnreadRune()
+					return s.String(), nil
+				}
 			}
-			buf.UnreadRune()
-			return s.String(), nil
 		}
 
 		s.WriteRune(r)

--- a/pgtype/multirange_parser_test.go
+++ b/pgtype/multirange_parser_test.go
@@ -1,0 +1,38 @@
+package pgtype
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseUntypedTextMultirangeBounds(t *testing.T) {
+	for _, tt := range []struct {
+		src  string
+		want []string
+	}{
+		{`{}`, []string{}},
+		{`{empty}`, []string{`empty`}},
+		{`{[a,z)}`, []string{`[a,z)`}},
+		{`{["a,b",z)}`, []string{`["a,b",z)`}},
+		{`{[a}b,z)}`, []string{`[a}b,z)`}},
+		{`{["a)b",z)}`, []string{`["a)b",z)`}},
+		{`{["a""b,c",z)}`, []string{`["a""b,c",z)`}},
+		{`{[a\,b,z)}`, []string{`[a\,b,z)`}},
+		{`{[a\)b,z)}`, []string{`[a\)b,z)`}},
+		{`{["a,b",c),[d,"e,f"]}`, []string{`["a,b",c)`, `[d,"e,f"]`}},
+	} {
+		t.Run(tt.src, func(t *testing.T) {
+			got, err := parseUntypedTextMultirange([]byte(tt.src))
+			if err != nil || !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %q, %v; want %q", got, err, tt.want)
+			}
+		})
+	}
+	for _, src := range []string{`{["a,b",z)`, `{["a,b,z)}`, `{[a,z)\\`, `{[a,z)}trailing`} {
+		t.Run(src, func(t *testing.T) {
+			if _, err := parseUntypedTextMultirange([]byte(src)); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}

--- a/pgtype/multirange_test.go
+++ b/pgtype/multirange_test.go
@@ -111,3 +111,35 @@ func TestMultirangeCodecDecodeValue(t *testing.T) {
 		}
 	})
 }
+
+func TestMultirangeCodecTextBounds(t *testing.T) {
+	skipPostgreSQLVersionLessThan(t, 14)
+	skipCockroachDB(t, "Server does not support range types")
+
+	defaultConnTestRunner.RunTest(context.Background(), t, func(ctx context.Context, _ testing.TB, conn *pgx.Conn) {
+		_, err := conn.Exec(ctx, `create type pg_temp.text_range as range (subtype = text, collation = "C", multirange_type_name = pg_temp.text_multirange)`)
+		require.NoError(t, err)
+		for _, name := range []string{"pg_temp.text_range", "pg_temp.text_multirange"} {
+			dataType, err := conn.LoadType(ctx, name)
+			require.NoError(t, err)
+			conn.TypeMap().RegisterType(dataType)
+		}
+
+		for _, bound := range []string{"abc", "a,b", "a}b", "a{b", "a)b", "a[b", `a"b`, `a\b`, "", "a b", "a,b}c"} {
+			t.Run(bound, func(t *testing.T) {
+				for _, format := range []int16{pgtype.BinaryFormatCode, pgtype.TextFormatCode} {
+					var got pgtype.Multirange[pgtype.Range[string]]
+					err := conn.QueryRow(ctx,
+						`select pg_temp.text_multirange(pg_temp.text_range($1, 'z', '[)'), pg_temp.text_range('zz', 'zzz' || $1, '[)'))`,
+						pgx.QueryResultFormats{format}, bound).Scan(&got)
+					require.NoError(t, err, "format %d", format)
+					require.Equal(t, pgtype.Multirange[pgtype.Range[string]]{{
+						Lower: bound, Upper: "z", LowerType: pgtype.Inclusive, UpperType: pgtype.Exclusive, Valid: true,
+					}, {
+						Lower: "zz", Upper: "zzz" + bound, LowerType: pgtype.Inclusive, UpperType: pgtype.Exclusive, Valid: true,
+					}}, got, "format %d", format)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
Text decoding of a custom text multirange fails when a bound contains a comma or `}`. `parseRange` treats these characters as multirange separators even when they belong to a range bound.

Track range boundaries, quotes and escapes while splitting the elements. The regression uses PostgreSQL to construct two ranges with special characters in both endpoints and checks text and binary decoding. Parser tests also cover escaped delimiters and malformed input.

Tested with Go 1.25.13 and PostgreSQL 18.6 on Linux arm64:

```sh
go test -race ./pgtype -run 'TestMultirangeCodecTextBounds|TestParseUntypedTextMultirangeBounds' -count=20
go test -race ./... -count=1
go build ./...
```

Both regression tests fail on the base commit and pass with this change. Optional authentication, TLS and PgBouncer tests were not configured; the other Go, PostgreSQL and OS matrix combinations were not run locally.

This is an AI proposal produced with Codex. The task was to resume a held multirange parsing defect, reproduce it against PostgreSQL, and prepare a minimal fix with regression and broader tests. It has not had human code review.
