### PR TITLE
Fix NamedArgs truncating queries that contain U+FFFD

### DIFF
--- a/named_args.go
+++ b/named_args.go
@@ -151,6 +151,10 @@ func dbTagKey(sf reflect.StructField) (key string, ok bool, err error) {
 
 type namedArg string
 
+// utf8.RuneError is returned both for a decoding failure and for a literal U+FFFD, which is a valid
+// character in a query. Only the former ends the input.
+const replacementcharacterwidth = 3
+
 type sqlLexer struct {
 	src     string
 	start   int
@@ -244,11 +248,13 @@ func rawState(l *sqlLexer) stateFn {
 				return multilineCommentState
 			}
 		case utf8.RuneError:
-			if l.pos-l.start > 0 {
-				l.parts = append(l.parts, l.src[l.start:l.pos])
-				l.start = l.pos
+			if width != replacementcharacterwidth {
+				if l.pos-l.start > 0 {
+					l.parts = append(l.parts, l.src[l.start:l.pos])
+					l.start = l.pos
+				}
+				return nil
 			}
-			return nil
 		}
 	}
 }
@@ -262,7 +268,7 @@ func namedArgState(l *sqlLexer) stateFn {
 		r, width := utf8.DecodeRuneInString(l.src[l.pos:])
 		l.pos += width
 
-		if r == utf8.RuneError {
+		if r == utf8.RuneError && width != replacementcharacterwidth {
 			if l.pos-l.start > 0 {
 				na := namedArg(l.src[l.start:l.pos])
 				if _, found := l.nameToOrdinal[na]; !found {
@@ -298,11 +304,13 @@ func singleQuoteState(l *sqlLexer) stateFn {
 			}
 			l.pos += width
 		case utf8.RuneError:
-			if l.pos-l.start > 0 {
-				l.parts = append(l.parts, l.src[l.start:l.pos])
-				l.start = l.pos
+			if width != replacementcharacterwidth {
+				if l.pos-l.start > 0 {
+					l.parts = append(l.parts, l.src[l.start:l.pos])
+					l.start = l.pos
+				}
+				return nil
 			}
-			return nil
 		}
 	}
 }
@@ -320,11 +328,13 @@ func doubleQuoteState(l *sqlLexer) stateFn {
 			}
 			l.pos += width
 		case utf8.RuneError:
-			if l.pos-l.start > 0 {
-				l.parts = append(l.parts, l.src[l.start:l.pos])
-				l.start = l.pos
+			if width != replacementcharacterwidth {
+				if l.pos-l.start > 0 {
+					l.parts = append(l.parts, l.src[l.start:l.pos])
+					l.start = l.pos
+				}
+				return nil
 			}
-			return nil
 		}
 	}
 }
@@ -345,11 +355,13 @@ func escapeStringState(l *sqlLexer) stateFn {
 			}
 			l.pos += width
 		case utf8.RuneError:
-			if l.pos-l.start > 0 {
-				l.parts = append(l.parts, l.src[l.start:l.pos])
-				l.start = l.pos
+			if width != replacementcharacterwidth {
+				if l.pos-l.start > 0 {
+					l.parts = append(l.parts, l.src[l.start:l.pos])
+					l.start = l.pos
+				}
+				return nil
 			}
-			return nil
 		}
 	}
 }
@@ -366,11 +378,13 @@ func oneLineCommentState(l *sqlLexer) stateFn {
 		case '\n', '\r':
 			return rawState
 		case utf8.RuneError:
-			if l.pos-l.start > 0 {
-				l.parts = append(l.parts, l.src[l.start:l.pos])
-				l.start = l.pos
+			if width != replacementcharacterwidth {
+				if l.pos-l.start > 0 {
+					l.parts = append(l.parts, l.src[l.start:l.pos])
+					l.start = l.pos
+				}
+				return nil
 			}
-			return nil
 		}
 	}
 }
@@ -400,11 +414,13 @@ func multilineCommentState(l *sqlLexer) stateFn {
 			l.nested--
 
 		case utf8.RuneError:
-			if l.pos-l.start > 0 {
-				l.parts = append(l.parts, l.src[l.start:l.pos])
-				l.start = l.pos
+			if width != replacementcharacterwidth {
+				if l.pos-l.start > 0 {
+					l.parts = append(l.parts, l.src[l.start:l.pos])
+					l.start = l.pos
+				}
+				return nil
 			}
-			return nil
 		}
 	}
 }

--- a/named_args_test.go
+++ b/named_args_test.go
@@ -106,6 +106,51 @@ func TestNamedArgsRewriteQuery(t *testing.T) {
 			expectedArgs: []any{nil},
 		},
 
+		// U+FFFD is a valid character, not the end of the query.
+		{
+			sql:          "select * from t where note = 'a\uFFFDb' and id = @id",
+			namedArgs:    pgx.NamedArgs{"id": int32(42)},
+			expectedSQL:  "select * from t where note = 'a\uFFFDb' and id = $1",
+			expectedArgs: []any{int32(42)},
+		},
+		{
+			sql:          "select * from t where id = @id -- \uFFFD\nand deleted = false",
+			namedArgs:    pgx.NamedArgs{"id": int32(42)},
+			expectedSQL:  "select * from t where id = $1 -- \uFFFD\nand deleted = false",
+			expectedArgs: []any{int32(42)},
+		},
+		{
+			sql:          "select * from t where id = @id /* \uFFFD */ and deleted = false",
+			namedArgs:    pgx.NamedArgs{"id": int32(42)},
+			expectedSQL:  "select * from t where id = $1 /* \uFFFD */ and deleted = false",
+			expectedArgs: []any{int32(42)},
+		},
+		{
+			sql:          "select * from \"a\uFFFDb\" where id = @id",
+			namedArgs:    pgx.NamedArgs{"id": int32(42)},
+			expectedSQL:  "select * from \"a\uFFFDb\" where id = $1",
+			expectedArgs: []any{int32(42)},
+		},
+		{
+			sql:          "select * from t where note = e'a\uFFFDb' and id = @id",
+			namedArgs:    pgx.NamedArgs{"id": int32(42)},
+			expectedSQL:  "select * from t where note = e'a\uFFFDb' and id = $1",
+			expectedArgs: []any{int32(42)},
+		},
+		{
+			sql:          "select @id\uFFFD, @other",
+			namedArgs:    pgx.NamedArgs{"id": int32(42), "other": int32(7)},
+			expectedSQL:  "select $1\uFFFD, $2",
+			expectedArgs: []any{int32(42), int32(7)},
+		},
+		// Invalid UTF-8, unlike U+FFFD, still ends the input.
+		{
+			sql:          "select * from t where id = @id and note = '\xffb'",
+			namedArgs:    pgx.NamedArgs{"id": int32(42)},
+			expectedSQL:  "select * from t where id = $1 and note = '\xff",
+			expectedArgs: []any{int32(42)},
+		},
+
 		// test comments and quotes
 	} {
 		sql, args, err := tt.namedArgs.RewriteQuery(context.Background(), nil, tt.sql, tt.args)


### PR DESCRIPTION
## The bug

`utf8.DecodeRuneInString` returns `utf8.RuneError` for two different things: a decoding failure, and a
successfully decoded literal U+FFFD (width 3), which is a perfectly valid character in a query. Every one of
the seven states of the `NamedArgs` lexer treats any `RuneError` as end of input and returns `nil`, discarding
the rest of the query:

`named_args.go:246-252` (`rawState`), `:265` (`namedArgState`), `:300-306` (`singleQuoteState`),
`:322-328` (`doubleQuoteState`), `:347-353` (`escapeStringState`), `:368-374` (`oneLineCommentState`),
`:402-408` (`multilineCommentState`).

## Why this is the wrong behavior, in this repo's own words

pgx carries two copies of this lexer, and the other one was already fixed. Commit
`ba4bbf92afaf50ce5ca6eddca9a50cd0deab585b` (2022-11-14):

```
Fix query sanitizer

...when query text has contains Unicode replacement character.
uft8.RuneError actually is a valid character.
```

That commit introduced `const replacementcharacterwidth = 3` and guarded all six sites in
`internal/sanitize/sanitize.go` (`:270, :294, :318, :436, :459, :495`). It touched only `sanitize.go` and its
test. `named_args.go` was added on 2022-04-23 in `107196ab0c90528a41a9c2910e158763ac320cd4`, seven months
*before* that fix, and never received it. `git log -S replacementcharacterwidth -- named_args.go` is empty.

Measured side by side on the same input:

```
named_args out= "select * from t where id = $1 and x = '\xff"    <- truncated
sanitize  parts= ["select * from t where id = @id and x = '..."] <- intact
```

## Why it matters to a caller

`NamedArgs.RewriteQuery` returns the wrong SQL to `Conn.Query` / `Conn.Exec`, with `err == nil`. For:

```sql
select id from t
where tenant = @tenant
  -- only live rows: <U+FFFD> marker
  and deleted = false
```

it returns

```
select id from t
where tenant = $1
  -- only live rows: <U+FFFD>
args=[acme] err=<nil>
```

The `and deleted = false` filter is gone, the SQL is still syntactically valid, and the driver happily executes
it and returns deleted rows. Other shapes fail at the server instead (unterminated string, unterminated
`/* */`), which is a confusing error a long way from its cause.

U+FFFD is not exotic. It is what every lossy decoder emits, so it turns up in text that reached the
application through a bad encoding conversion and then got interpolated into a comment, an identifier, or a
literal.

## The change

Add `const replacementcharacterwidth = 3` next to the lexer and guard all seven `RuneError` sites with
`width != replacementcharacterwidth`. This is byte-for-byte the shape `sanitize.go` already uses. Invalid
UTF-8 still ends the input exactly as before; only a valid U+FFFD is now allowed to continue.

`sqlLexer` and all seven state functions are unexported with a single entry point, `rewriteQuery`, reachable
only from `NamedArgs.RewriteQuery` and `StrictNamedArgs.RewriteQuery`. Nothing else in the tree reads them.

## Verification

Test additions: six positive cases (single quote, double quote, `e''` escape string, `--` comment, `/* */`
comment, and U+FFFD directly terminating a named arg) plus one characterization case pinning that *invalid*
UTF-8 still ends the input.

- Green: `go test -run NamedArgs ./` exit 0, `TestNamedArgsRewriteQuery` and `TestStrictNamedArgsRewriteQuery`
  both PASS.
- Red on base (`named_args.go` restored with `git show HEAD:named_args.go`): exit 1, all six U+FFFD
  assertions fail, and the invalid-byte case does not.
- Over-correction mutation (`width == 0`, so invalid bytes would also stop ending input): exit 1, fails
  exactly one assertion, the invalid-byte pin at `named_args_test.go:158`. Disjoint from the revert, so both
  directions of the boundary are held by the tests.
- Full root package against a real PostgreSQL 17 (`PGX_TEST_DATABASE` set, `hstore`/`ltree`/`uint64` created
  per CONTRIBUTING): `ok github.com/jackc/pgx/v5` exit 0, 0 failures, including
  `TestQueryWithQueryRewriter`, `TestExecWithQueryRewriter` and `TestConnSendBatchWithQueryRewriter`.
- `gofmt -l` clean, `gofumpt -extra -l` clean (the formatter and options `.golangci.yml` pins),
  `go build ./...` exit 0, `go vet .` exit 0.

`pgconn` and `pgtype` have some failures in my container for want of the full test fixture (extra roles,
socket and TLS endpoints). Neither package depends on package `pgx` -- `go list -deps ./pgconn | grep -x
github.com/jackc/pgx/v5` is empty, likewise for `./pgtype` -- so `named_args.go` cannot reach them.

## A related case I did not touch

Both lexers let a backslash at the end of a `--` comment swallow the following newline, so `-- C:\path\`
continues the comment onto the next line. `internal/sanitize/sanitize.go:453` has the identical code, so
unlike the case above there is no divergence between the two copies to point at, and it may well be
deliberate. Happy to open a separate issue if it is not.

## Process notes

CONTRIBUTING asks for a discussion before a significant change. I judged this one small enough to send
directly: it is a mechanical application of a fix this repo already made to its other copy of the same lexer,
confined to one file plus its test. Glad to convert it to an issue if you would rather discuss first.

## AI disclosure

Written with AI assistance (Claude Code, claude-opus-5), disclosed here per CONTRIBUTING's AI section. It was
an AI proposal, so treating it as the second bullet there is the fair reading. What that means concretely: I
have read the change and can defend it without going back to the agent, and I will answer review questions
myself rather than relaying them.

The prompts were a standing brief, not a request for this specific fix. The substance of it: find real code
bugs in large Go repositories; screen the repository first for AI policy, CLA, merge cadence and open-queue
saturation; prefer bugs where the repository's own comment, commit message or a sibling call site states the
intent the code violates; before proposing anything, write one sentence naming the API that returns the wrong
answer to a caller; verify with a red-green pair and mutations in both directions, and confirm which file the
test actually loaded before trusting the result. No prompt named pgx, `named_args.go`, or this bug. The
`ba4bbf92` provenance and the sibling guards in `sanitize.go` are what the search turned up, and they are the
whole argument for the change.
